### PR TITLE
fix(oidc): make pocket-id operator manage callback URLs

### DIFF
--- a/kubernetes/apps/documents/paperless/ks.yaml
+++ b/kubernetes/apps/documents/paperless/ks.yaml
@@ -22,6 +22,7 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/paperless-ngx.svg"
       OIDC_APP_NAME: Paperless
       OIDC_PKCE_ENABLED: "true"
+      OIDC_CALLBACK_PATH: /accounts/oidc/pocket-id/login/callback/
       VOLSYNC_CAPACITY: 10Gi
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/finance/actual/ks.yaml
+++ b/kubernetes/apps/finance/actual/ks.yaml
@@ -17,6 +17,7 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/actual-budget.svg"
       OIDC_APP_NAME: Actual
+      OIDC_CALLBACK_PATH: /openid/callback
       VOLSYNC_CAPACITY: 1Gi
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -14,6 +14,7 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/jellyfin.svg"
       OIDC_APP_NAME: Jellyfin
+      OIDC_CALLBACK_PATH: /sso/OID/redirect/PocketID
       VOLSYNC_CAPACITY: 5Gi
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -41,6 +41,7 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/grafana.svg"
       OIDC_APP_NAME: Grafana
       OIDC_PKCE_ENABLED: "true"
+      OIDC_CALLBACK_PATH: /login/generic_oauth
       VOLSYNC_CAPACITY: 5Gi
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/components/oidc/variants/base/oidcclient.yaml
+++ b/kubernetes/components/oidc/variants/base/oidcclient.yaml
@@ -8,6 +8,8 @@ spec:
   name: ${OIDC_APP_NAME:=${OIDC_APP:=${APP}}}
   clientID: ${OIDC_APP:=${APP}}
   launchUrl: https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${SECRET_DOMAIN}
+  callbackUrls:
+    - https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${SECRET_DOMAIN}${OIDC_CALLBACK_PATH:=/oauth2/callback}
   pkceEnabled: ${OIDC_PKCE_ENABLED:=false}
   logoUrl: ${APP_ICON_URL}
   secret:


### PR DESCRIPTION
## Problem

After swapping `${SECRET_DOMAIN}` to a new domain, OIDC logins broke because the callback URLs registered in pocket-id still pointed at the old domain.

Root cause: the OIDC client template ([`oidcclient.yaml`](kubernetes/components/oidc/variants/base/oidcclient.yaml)) only set `launchUrl`, leaving `spec.callbackUrls` empty. The operator only reconciles fields it's given, so it **never managed callback URLs** — those were only ever populated by pocket-id's autosave-on-first-login. The DB confirmed the split:

| field | value after domain swap |
| --- | --- |
| `launch_url` (operator-managed) | `*.crayon.club` ✅ |
| `callback_urls` (unmanaged) | `*.spudkingdom.org` ❌ (paperless empty) |

## Fix

Declare `callbackUrls` in the base template so the operator owns and reconciles them, with a default path of `/oauth2/callback` (covers all envoy-proxied apps + flux) and a per-app `OIDC_CALLBACK_PATH` override for native integrations:

- `grafana` → `/login/generic_oauth`
- `actual` → `/openid/callback`
- `jellyfin` → `/sso/OID/redirect/PocketID`
- `paperless` → `/accounts/oidc/pocket-id/login/callback/` (was empty)

`logoutCallbackUrls` intentionally left empty — nothing uses RP-initiated logout through pocket-id today (envoy's `logoutPath` is handled locally).

## Verify after reconcile

```bash
kubectl exec -n database postgres-1 -c postgres -- \
  psql -d pocketid -At -F' | ' -c \
  "select name, callback_urls from oidc_clients order by name;"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)