### PR TITLE
fix(ci): flate changed-only mode via FLATE_BASE

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Full history so flate can resolve --base (FLATE_BASE, default "main")
+          # for changed-only mode.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Flate
@@ -58,17 +61,12 @@ jobs:
           - kustomization
       fail-fast: false
     steps:
-      - name: Checkout Pull Request Branch
+      - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          path: pull
-          persist-credentials: false
-
-      - name: Checkout Default Branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          path: default
+          # Full history so flate can materialize the base tree (FLATE_BASE,
+          # default "main") and diff the PR against it in changed-only mode.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Flate
@@ -79,9 +77,9 @@ jobs:
         env:
           KIND: ${{ matrix.resource }}
         run: |
+          set -eo pipefail
           flate diff "$KIND" \
-            --path ./pull/kubernetes/flux/cluster \
-            --path-orig ./default/kubernetes/flux/cluster \
+            --path ./kubernetes/flux/cluster \
             --allow-missing-secrets \
             -o github | tee diff.patch
           {


### PR DESCRIPTION
The flate action exports FLATE_BASE=main (its `base` input default), which flate binds to --base for changed-only mode. The previous workflow fought it:

- test ran on a shallow checkout, so --base=main could not resolve ("not found locally or as origin/main") -> hard fail.
- diff passed an explicit --path-orig, which conflicts with --base ("--path-orig and --base are mutually exclusive"); the error was masked by `| tee` under `bash -e` (no pipefail), leaving an empty diff and no comment.

Fix: let FLATE_BASE drive changed-only mode. Use a single checkout with fetch-depth: 0 in both jobs so main resolves, drop the diff dual-checkout and --path-orig, and add `set -eo pipefail` so a real flate error fails loudly.