### PR TITLE
feat(ci): label flate diff comments with resource kind

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -102,6 +102,7 @@ jobs:
           message-id: ${{ github.event.pull_request.number }}/flate/${{ matrix.resource }}
           message-failure: Diff was not successful
           message: |
+            #### Flate diff — `${{ matrix.resource }}`
             ```diff
             ${{ steps.diff.outputs.diff }}
             ```


### PR DESCRIPTION
The diff comments rendered as bare ```diff blocks with no visible heading (only the hidden add-pr-comment marker distinguished helmrelease from kustomization). Add a visible "Flate diff — <kind>" header to the comment body.