### PR TITLE
refactor(network): rename envoy-external gateway to envoy-cloudflare

### DIFF
--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
       app:
         hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
         parentRefs:
-          - name: envoy-external
+          - name: envoy-cloudflare
             namespace: network
             sectionName: https
         rules:

--- a/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   hostnames: ["flux-webhook.${SECRET_DOMAIN}"]
   parentRefs:
-    - name: envoy-external
+    - name: envoy-cloudflare
       namespace: network
       sectionName: https
   rules:

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
       - --cloudflare-proxied
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
-      - --gateway-name=envoy-external
+      - --gateway-name=envoy-cloudflare
     triggerLoopOnEvent: true
     policy: sync
     sources: ["crd", "gateway-httproute"]

--- a/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
@@ -5,6 +5,6 @@ metadata:
   name: cloudflare-tunnel
 spec:
   endpoints:
-    - dnsName: "external.${SECRET_DOMAIN}"
+    - dnsName: "cloudflare.${SECRET_DOMAIN}"
       recordType: CNAME
       targets: ["${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com"]

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -73,8 +73,8 @@ spec:
               - hostname: "*.${SECRET_DOMAIN}"
                 originRequest:
                   http2Origin: true
-                  originServerName: external.${SECRET_DOMAIN}
-                service: https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
+                  originServerName: cloudflare.${SECRET_DOMAIN}
+                service: https://envoy-cloudflare.{{ .Release.Namespace }}.svc.cluster.local:443
               - service: http_status:404
     persistence:
       config-file:

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -44,14 +44,14 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: envoy-external
+  name: envoy-cloudflare
   annotations:
-    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+    external-dns.alpha.kubernetes.io/target: cloudflare.${SECRET_DOMAIN}
 spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: external.${SECRET_DOMAIN}
+      external-dns.alpha.kubernetes.io/hostname: cloudflare.${SECRET_DOMAIN}
       lbipam.cilium.io/ips: "10.0.42.130"
   listeners:
     - name: http
@@ -157,7 +157,7 @@ metadata:
     external-dns.alpha.kubernetes.io/controller: none
 spec:
   parentRefs:
-    - name: envoy-external
+    - name: envoy-cloudflare
       namespace: network
       sectionName: http
     - name: envoy-internal

--- a/kubernetes/apps/security/pocket-id/instance/instance.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/instance.yaml
@@ -43,7 +43,7 @@ spec:
   route:
     enabled: true
     parentRefs:
-      - name: envoy-external
+      - name: envoy-cloudflare
         namespace: network
     hostnames: ["pocket-id.${SECRET_DOMAIN}"]
 


### PR DESCRIPTION
Rename the external Envoy Gateway (and its derived Service) from `envoy-external` to `envoy-cloudflare`, and the Cloudflare tunnel endpoint host from `external.${SECRET_DOMAIN}` to
`cloudflare.${SECRET_DOMAIN}`. This frees the generic "external" name ahead of introducing a second public ingress path (a self-hosted tunnel on its own gateway).

Pure refactor — no behavior change. Updates the gateway definition, the https-redirect route, the cloudflared origin/SNI + DNSEndpoint, the external-dns --gateway-name filter, and all HTTPRoute parentRefs (flux-instance, pocket-id, echo).