### PR TITLE
fix(pocketid): remove null override for pocketid operator dashboard instanceSelector

### DIFF
--- a/kubernetes/apps/security/pocket-id/operator/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/operator/helmrelease.yaml
@@ -24,4 +24,3 @@ spec:
           instanceSelector:
             matchLabels:
               dashboards: grafana
-              grafana.internal/instance: null


### PR DESCRIPTION
this was fixed in aclerici38/pocket-id-operator#385 v0.7.3.

thanks @aclerici38!