### PR TITLE
feat(ai): add llmkube operator + qwen3.6-27b-mtp

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -7,5 +7,6 @@ components:
 resources:
   - ./namespace.yaml
   - ./llama-cpp/ks.yaml
+  - ./llmkube/ks.yaml
   - ./searxng/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app llmkube
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: *app
+      version: 0.8.6
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+      interval: 1h
+  values:
+    crds:
+      # CRDs are rendered as templated resources gated on this value (not the
+      # Helm crds/ dir), so Flux install.crds/upgrade.crds settings don't apply.
+      install: true
+      keep: true
+    # Controller runs CPU-only; InferenceService CRs schedule the GPU workloads.
+    controllerManager:
+      replicaCount: 1
+      leaderElection:
+        enabled: false
+      resources:
+        requests:
+          cpu: 10m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    # Shared model cache PVC — uses the cluster default storage class (openebs-zfspv).
+    modelCache:
+      enabled: true
+      size: 100Gi
+      accessMode: ReadWriteOnce
+    priorityClasses:
+      enabled: true

--- a/kubernetes/apps/ai/llmkube/app/helmrepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrepository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 1h
+  url: https://defilantech.github.io/LLMKube

--- a/kubernetes/apps/ai/llmkube/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app llmkube
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/llmkube/app
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app llmkube-models
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/llmkube/models
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  dependsOn:
+    - name: llmkube
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./qwen3-6-27b-mtp.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   modelRef: qwen3-6-27b-mtp
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server-cuda
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9603@sha256:841b199aed2649a748875b043b32fed2e8c2d4d87e1d563556817fb7fa44b72b
   runtimeClassName: nvidia
   replicas: 1
 

--- a/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-6-27b-mtp
+spec:
+  # HF cache path models--unsloth--Qwen3.6-27B-MTP-GGUF / Qwen3.6-27B-UD-Q4_K_XL.gguf
+  source: https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF/resolve/main/Qwen3.6-27B-UD-Q4_K_XL.gguf
+  format: gguf
+  quantization: UD-Q4_K_XL
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      count: 2 # 3090 Ti + 3070 on talos1
+      vendor: nvidia
+      layers: 999 # preset ngl=999 (full offload)
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-6-27b-mtp
+spec:
+  modelRef: qwen3-6-27b-mtp
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda
+  runtimeClassName: nvidia
+  replicas: 1
+
+  # --- typed preset fields ---
+  contextSize: 262144 # ctx-size
+  parallelSlots: 1 # parallel
+  batchSize: 2048 # batch-size
+  uBatchSize: 512 # ubatch-size
+  cacheTypeK: q8_0 # cache-type-k
+  cacheTypeV: q8_0 # cache-type-v
+
+  # --- preset flags without typed CRD fields (MTP draft, KV reuse, sampling) ---
+  # Omitted from the preset: load-on-startup (router-only) and verbosity=4 (debug).
+  extraArgs:
+    - --tensor-split
+    - "6,1"
+    - --cache-reuse
+    - "256"
+    - --kv-unified
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-n-max
+    - "3"
+    - --spec-draft-ngl
+    - "999"
+    - --spec-draft-type-k
+    - q8_0
+    - --spec-draft-type-v
+    - q8_0
+    - --temp
+    - "0.6"
+    - --top-p
+    - "0.95"
+    - --top-k
+    - "20"
+    - --min-p
+    - "0.0"
+    - --presence-penalty
+    - "0.0"
+    - --repeat-penalty
+    - "1.0"
+    - --chat-template-kwargs
+    - '{"preserve_thinking":true}'
+
+  resources:
+    cpu: "1"
+    memory: 8Gi
+    gpu: 2
+
+  endpoint:
+    port: 8080
+    type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen3-6-27b-mtp
+spec:
+  hostnames:
+    - "qwen.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: qwen3-6-27b-mtp
+          port: 8080


### PR DESCRIPTION
## Summary

Adds the [LLMKube](https://github.com/defilantech/llmkube) operator and a first inference workload to the `ai` namespace.

- **Operator** ([app/](kubernetes/apps/ai/llmkube/app/)) — installs the LLMKube controller + CRDs (`Model`, `InferenceService`, `ModelRouter`) via its gh-pages Helm repo (chart `0.8.6`). First non-OCI `HelmRepository` source in the repo; LLMKube only publishes to gh-pages. Single replica, leader election off, CRDs kept on uninstall.
- **qwen3.6-27b-mtp** ([models/](kubernetes/apps/ai/llmkube/models/)) — `Model` + `InferenceService` + `HTTPRoute`, translated from the llama.cpp `code-mtp` preset. Runs `server-cuda` on the talos1 NVIDIA GPUs (3090 Ti + 3070, `--tensor-split 6,1`, full offload), exposed at `qwen.${SECRET_DOMAIN}` on `envoy-internal`. MTP/speculative + sampling flags ride in `extraArgs`; `load-on-startup`/`verbosity` dropped.

Structure mirrors the toolhive operator (multiple Flux Kustomizations in one `ks.yaml`, models `dependsOn` the operator so CRDs exist first).

## Verify before merge / first reconcile

- [x] **Model source URL** reconstructed from the local HF cache path — confirm `unsloth/Qwen3.6-27B-MTP-GGUF` serves `Qwen3.6-27B-UD-Q4_K_XL.gguf` as a single (non-sharded) file.
- [x] **MTP flags** (`--spec-type draft-mtp`, `--spec-draft-*`) are mapped 1:1 from the preset; confirm the `server-cuda` llama.cpp build supports them.

## Test plan

- `kubectl kustomize kubernetes/apps/ai` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)