### PR TITLE
fix(ai): pin llmkube controller to GPU node (talos1)

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -19,18 +19,23 @@ spec:
       # Helm crds/ dir), so Flux install.crds/upgrade.crds settings don't apply.
       install: true
       keep: true
-    # Controller runs CPU-only; InferenceService CRs schedule the GPU workloads.
     controllerManager:
       replicaCount: 1
       leaderElection:
         enabled: false
+      # Pin to the GPU node (talos1). The controller mounts the model-cache PVC
+      # that inference pods also share; openebs-zfspv is node-local, so the
+      # controller must live on the same node where GPU inference schedules.
+      nodeSelector:
+        kubernetes.io/hostname: talos1
       resources:
         requests:
           cpu: 10m
           memory: 256Mi
         limits:
           memory: 1Gi
-    # Shared model cache PVC — uses the cluster default storage class (openebs-zfspv).
+    # Shared model cache PVC. openebs-zfspv is node-local, so this binds on the
+    # controller's node (talos1) and is read by inference pods scheduled there.
     modelCache:
       enabled: true
       size: 100Gi


### PR DESCRIPTION
## Problem

After #1009 merged, `qwen3-6-27b-mtp` stayed `Pending` / `WaitingForGPU`:

```
0/2 nodes are available: 1 Insufficient nvidia.com/gpu,
1 node(s) didn't match PersistentVolume's node affinity.
```

The `llmkube-model-cache` PVC (`openebs-zfspv`, **node-local ZFS**) bound to **talos0** because the controller pod mounts it. The inference pod also mounts that same shared cache **and** needs the GPU, which only exists on **talos1**. A node-local RWO volume on talos0 can't be consumed by a pod that must run on talos1.

## Fix

Pin the controller to talos1 via `controllerManager.nodeSelector`, so the model cache provisions on the same node where GPU inference schedules. Controller + inference then co-locate on talos1 and share the ZFS-local cache.

## One-time cluster migration (not GitOps)

The existing PVC is already bound to talos0 and must be recreated on talos1 after merge:
1. Flux applies the nodeSelector (controller rolls; new pod Pending until cache moves).
2. Free the `llmkube-model-cache` PVC of references and delete it so Helm re-provisions it on talos1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)