### PR TITLE
feat(ai): add NVIDIA DCGM Grafana dashboard

### DIFF
--- a/kubernetes/apps/kube-system/nvidia-gpu/operator/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/nvidia-gpu/operator/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nvidia-dcgm
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  allowCrossNamespaceImport: true
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: VictoriaMetrics
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/12239/revisions/2/download

--- a/kubernetes/apps/kube-system/nvidia-gpu/operator/kustomization.yaml
+++ b/kubernetes/apps/kube-system/nvidia-gpu/operator/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## What

Adds the [NVIDIA DCGM Exporter dashboard](https://grafana.com/grafana/dashboards/12239) (grafana.com ID 12239, revision 2) as a `GrafanaDashboard` CR.

## Why

The GPU operator's DCGM exporter exposes GPU/VRAM metrics (`DCGM_FI_DEV_FB_USED/FREE/TOTAL`, `DCGM_FI_DEV_GPU_UTIL`, etc.) but ships no dashboard. This visualizes them. Metrics are already flowing into VictoriaMetrics via the converted ServiceMonitor.

## Notes

- `allowCrossNamespaceImport: true` — app lives in `kube-system`, Grafana runs in `observability` (same pattern as the CNPG dashboard).
- Datasource mapped to `VictoriaMetrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)