### PR TITLE
fix(ai): fit qwen3.6-27b-mtp on dual-GPU + enable verbose logs

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
@@ -15,6 +15,15 @@ spec:
       count: 2 # 3090 Ti + 3070 on talos1
       vendor: nvidia
       layers: 999 # preset ngl=999 (full offload)
+      # Emit a single --tensor-split 6,1 (preset value). llmkube derives the
+      # ratio from the layerSplit range sizes (6 vs 1), so we must NOT also pass
+      # --tensor-split in extraArgs or llama.cpp gets it twice. The ranges only
+      # express the 6:1 proportion; they need not match the real layer count.
+      sharding:
+        strategy: layer
+        layerSplit:
+          - "0-5" # 3090 Ti — 6 parts
+          - "6-6" # 3070 — 1 part
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -31,15 +40,19 @@ spec:
   contextSize: 262144 # ctx-size
   parallelSlots: 1 # parallel
   batchSize: 2048 # batch-size
-  uBatchSize: 512 # ubatch-size
+  uBatchSize: 256 # ubatch-size — halved from 512 to shrink the per-context
+  # compute buffer on the 3070. The 3070 holds TWO compute buffers (main +
+  # MTP draft context), allocated sequentially; at 512 (and even 384) the
+  # second one OOMs. 256 is the ceiling that fits full 262144 ctx + MTP here.
   cacheTypeK: q8_0 # cache-type-k
   cacheTypeV: q8_0 # cache-type-v
 
   # --- preset flags without typed CRD fields (MTP draft, KV reuse, sampling) ---
-  # Omitted from the preset: load-on-startup (router-only) and verbosity=4 (debug).
+  # Omitted from the preset: load-on-startup (router-only).
+  # --tensor-split 6,1 is emitted by the Model's gpu.sharding (above), not here.
   extraArgs:
-    - --tensor-split
-    - "6,1"
+    - --verbosity
+    - "4"
     - --cache-reuse
     - "256"
     - --kv-unified


### PR DESCRIPTION
## Summary
`qwen3-6-27b-mtp` was crashlooping with CUDA OOM on the 3070 (CUDA1) when llama.cpp created the **MTP draft context**. At 262144 context, the 3070 has to hold its weight slice + KV cache + the main context's compute buffer **and** the MTP draft context's own KV + compute buffer — which overflowed the 8 GiB card. Both GPUs end up loaded to within a few hundred MiB of full (3090 Ti ~631 MiB free, 3070 ~189 MiB free).

## Changes
- **Sharding via the Model CRD**: tensor-split now comes from `gpu.sharding.layerSplit` (`0-5` / `6-6` → 6:1) instead of a manual `--tensor-split` in `extraArgs` (which would otherwise be passed twice).
- **`uBatchSize` 512 → 256**: shrinks the per-context compute buffer. The 3070 carries *two* compute buffers (main + MTP draft), allocated sequentially; both 512 and 384 OOM the second one. **256 is the ceiling** that fits full 262144 ctx + MTP on this 24 GB + 8 GB pair.
- **`--verbosity 4`**: verbose llama.cpp logging (this is what surfaced the OOM in the first place).

## Verification
Applied in-cluster:
- Pod `1/1 Running`, `server is listening`, health `ok`.
- Generation confirmed (MTP speculative decoding active).
- Throughput at uBatch=256: **~1283 tok/s** prompt processing, **~67 tok/s** generation.
- Full 262144 context retained.

Note: runs in non-pipeline-parallel mode (the with-pp compute buffer doesn't fit); this is expected given how full both cards are.