### PR TITLE
feat(observability): add Intel GPU VRAM exporter

### DIFF
--- a/kubernetes/apps/observability/intel-gpu-exporter/app/daemonset.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/app/daemonset.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-exporter
+  labels:
+    app.kubernetes.io/name: intel-gpu-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: intel-gpu-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: intel-gpu-exporter
+    spec:
+      # Only nodes with an Intel GPU.
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"
+      # Aggregate VRAM from every GPU client's /proc/<pid>/fdinfo on the host.
+      hostPID: true
+      automountServiceAccountToken: false
+      containers:
+        - name: exporter
+          image: python:3.13-alpine@sha256:db66119d6609a3a941a9433b225f4e13d33c459cede097cf3ec2fc4d1bd314b2
+          command: ["python3", "-u", "/app/exporter.py"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: PORT
+              value: "9123"
+          ports:
+            - name: metrics
+              containerPort: 9123
+          securityContext:
+            # Reading other processes' fdinfo requires host-root + ptrace.
+            privileged: true
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: script
+              mountPath: /app
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: intel-gpu-exporter-script

--- a/kubernetes/apps/observability/intel-gpu-exporter/app/dashboards/intel-gpu.json
+++ b/kubernetes/apps/observability/intel-gpu-exporter/app/dashboards/intel-gpu.json
@@ -1,0 +1,109 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["intel", "gpu"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1,
+        "regex": ""
+      },
+      {
+        "name": "pci_dev",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(intel_gpu_vram_total_bytes, pci_dev)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {}
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "title": "Intel GPU",
+  "uid": "intel-gpu",
+  "panels": [
+    {
+      "id": 1,
+      "title": "VRAM Utilization",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "100 * intel_gpu_vram_used_bytes{pci_dev=~\"$pci_dev\"} / intel_gpu_vram_total_bytes{pci_dev=~\"$pci_dev\"}",
+          "legendFormat": "{{node}} {{pci_dev}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "VRAM Used / Total",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "intel_gpu_vram_used_bytes{pci_dev=~\"$pci_dev\"}",
+          "legendFormat": "used {{pci_dev}}"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "intel_gpu_vram_allocated_bytes{pci_dev=~\"$pci_dev\"}",
+          "legendFormat": "allocated {{pci_dev}}"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "intel_gpu_vram_total_bytes{pci_dev=~\"$pci_dev\"}",
+          "legendFormat": "total {{pci_dev}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "DRM Clients",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "intel_gpu_drm_clients{pci_dev=~\"$pci_dev\"}",
+          "legendFormat": "{{node}} {{pci_dev}}"
+        }
+      ]
+    }
+  ]
+}

--- a/kubernetes/apps/observability/intel-gpu-exporter/app/exporter.py
+++ b/kubernetes/apps/observability/intel-gpu-exporter/app/exporter.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Minimal Prometheus exporter for Intel GPU VRAM usage on the xe driver.
+
+xpu-smi / intel_gpu_top do not reliably report VRAM on Arc/Battlemage, but the
+xe kernel driver exposes per-DRM-client memory accounting in
+/proc/<pid>/fdinfo/<fd> (the drm-*-vram0 fields). This exporter aggregates that
+across every GPU client on the node (requires hostPID), and derives total VRAM
+capacity from the GPU's largest PCI memory BAR (resizable BAR == full aperture).
+
+Metrics (labelled by pci_dev and node):
+  intel_gpu_vram_used_bytes        VRAM currently resident on the device
+  intel_gpu_vram_allocated_bytes   VRAM allocated (may be partly evicted to RAM)
+  intel_gpu_vram_total_bytes       VRAM capacity
+  intel_gpu_drm_clients            number of open DRM clients
+"""
+import glob
+import os
+import re
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+NODE = os.environ.get("NODE_NAME", "")
+PORT = int(os.environ.get("PORT", "9123"))
+BDF_RE = re.compile(r"^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$")
+
+VRAM_RE = re.compile(r"^drm-(total|resident)-vram0:\s+(\d+)\s+KiB", re.M)
+PDEV_RE = re.compile(r"^drm-pdev:\s+(\S+)", re.M)
+CLIENT_RE = re.compile(r"^drm-client-id:\s+(\d+)", re.M)
+DRIVER_RE = re.compile(r"^drm-driver:\s+(\S+)", re.M)
+
+
+def discover_pdevs():
+    """All PCI devices currently bound to the xe driver."""
+    pdevs = set()
+    for entry in glob.glob("/sys/bus/pci/drivers/xe/*"):
+        name = os.path.basename(entry)
+        if BDF_RE.match(name):
+            pdevs.add(name)
+    return pdevs
+
+
+def vram_total_bytes(pdev):
+    """Largest PCI memory BAR == VRAM aperture (resizable BAR)."""
+    biggest = 0
+    try:
+        with open(f"/sys/bus/pci/devices/{pdev}/resource") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                start, end, flags = (int(p, 16) for p in parts[:3])
+                if flags & 0x1:  # I/O space, not memory
+                    continue
+                if end > start:
+                    biggest = max(biggest, end - start + 1)
+    except OSError:
+        pass
+    return biggest
+
+
+def collect():
+    pdevs = discover_pdevs()
+    used = {p: 0 for p in pdevs}
+    allocated = {p: 0 for p in pdevs}
+    clients = {p: set() for p in pdevs}
+
+    for fdinfo in glob.glob("/proc/[0-9]*/fdinfo/[0-9]*"):
+        try:
+            with open(fdinfo) as fh:
+                data = fh.read()
+        except OSError:
+            continue
+        if "drm-pdev" not in data:
+            continue
+        drv = DRIVER_RE.search(data)
+        if not drv or drv.group(1) != "xe":
+            continue
+        pm = PDEV_RE.search(data)
+        if not pm:
+            continue
+        pdev = pm.group(1)
+        used.setdefault(pdev, 0)
+        allocated.setdefault(pdev, 0)
+        clients.setdefault(pdev, set())
+        cm = CLIENT_RE.search(data)
+        if cm:
+            clients[pdev].add(cm.group(1))
+        for kind, kib in VRAM_RE.findall(data):
+            byts = int(kib) * 1024
+            if kind == "resident":
+                used[pdev] += byts
+            else:
+                allocated[pdev] += byts
+
+    return used, allocated, clients
+
+
+def render():
+    used, allocated, clients = collect()
+    out = []
+
+    def metric(name, help_text, values):
+        out.append(f"# HELP {name} {help_text}")
+        out.append(f"# TYPE {name} gauge")
+        for pdev, val in sorted(values.items()):
+            out.append(f'{name}{{pci_dev="{pdev}",node="{NODE}"}} {val}')
+
+    metric("intel_gpu_vram_used_bytes",
+           "VRAM currently resident on the device, summed across DRM clients.",
+           used)
+    metric("intel_gpu_vram_allocated_bytes",
+           "VRAM allocated (may be partly evicted to system RAM).",
+           allocated)
+    metric("intel_gpu_vram_total_bytes",
+           "VRAM capacity (largest PCI memory BAR).",
+           {p: vram_total_bytes(p) for p in used})
+    metric("intel_gpu_drm_clients",
+           "Number of open DRM clients holding the device.",
+           {p: len(c) for p, c in clients.items()})
+
+    return ("\n".join(out) + "\n").encode()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        try:
+            body = render()
+        except Exception as exc:  # never crash the scrape
+            body = f"# exporter error: {exc}\n".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # quiet
+        pass
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("", PORT), Handler).serve_forever()

--- a/kubernetes/apps/observability/intel-gpu-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: intel-gpu
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  allowCrossNamespaceImport: true
+  resyncPeriod: 1h
+  configMapRef:
+    name: intel-gpu-exporter-dashboard
+    key: intel-gpu.json

--- a/kubernetes/apps/observability/intel-gpu-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./daemonset.yaml
+  - ./podmonitor.yaml
+  - ./grafanadashboard.yaml
+
+configMapGenerator:
+  - name: intel-gpu-exporter-script
+    files:
+      - exporter.py
+  - name: intel-gpu-exporter-dashboard
+    files:
+      - dashboards/intel-gpu.json
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/observability/intel-gpu-exporter/app/podmonitor.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/app/podmonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: intel-gpu-exporter
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: intel-gpu-exporter
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      honorLabels: true

--- a/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app intel-gpu-exporter
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/observability/intel-gpu-exporter/app
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -7,6 +7,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./grafana/ks.yaml
+  - ./intel-gpu-exporter/ks.yaml
   - ./kepler/ks.yaml
   - ./snmp-exporter/ks.yaml
   - ./victoria/ks.yaml


### PR DESCRIPTION
## What

Adds a lightweight Prometheus exporter for Intel GPU VRAM, deployed to the `observability` namespace and scraped by Victoria Metrics. Surfaces B50 VRAM usage in Grafana — there was previously no Intel GPU telemetry (only NVIDIA gpu-operator/DCGM metrics existed).

## Why this approach

`xpu-smi` / XPU Manager and `intel_gpu_top` have historically **incomplete/unreliable VRAM telemetry on Arc/Battlemage**. The xe kernel driver, however, exposes accurate per-DRM-client VRAM accounting in `/proc/<pid>/fdinfo/<fd>` (`drm-*-vram0`). This exporter aggregates that across every GPU client on the node and derives capacity from the GPU's largest PCI memory BAR (resizable BAR == full aperture).

## How it works

- `hostPID` DaemonSet pinned to the Intel GPU node via `nodeSelector: intel.feature.node.kubernetes.io/gpu=true`
- ~120-line stdlib-only Python exporter (no custom image — runs on `python:3.13-alpine`, script mounted from a ConfigMap)
- Scraped via `PodMonitor` (Victoria's `selectAllByDefault` picks it up)

## Metrics

| Metric | Meaning |
| --- | --- |
| `intel_gpu_vram_used_bytes` | VRAM currently resident on the device |
| `intel_gpu_vram_allocated_bytes` | VRAM allocated (may be partly evicted to RAM) |
| `intel_gpu_vram_total_bytes` | Capacity (largest PCI BAR) |
| `intel_gpu_drm_clients` | Open DRM client count |

Labels: `pci_dev`, `node`. Includes a Grafana dashboard (util gauge, used/allocated/total timeseries, client count).

## Validation

- `kubectl kustomize` builds cleanly (5 objects)
- Python syntax + parsing unit-tested against **real B50 fdinfo and PCI resource data** — capacity computes to exactly 16 GiB
- Server-side dry-run apply against the live cluster succeeds (the `restricted` PodSecurity warning is the cluster-wide audit profile; `observability` enforces `privileged`, same as Kepler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)