### PR TITLE
feat(ai): deploy memini memory service

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ./namespace.yaml
   # - ./llama-cpp/ks.yaml
   - ./llmkube/ks.yaml
+  - ./memini/ks.yaml
   - ./searxng/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/llmkube/models/all-minilm-l6-v2.yaml
+++ b/kubernetes/apps/ai/llmkube/models/all-minilm-l6-v2.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: all-minilm-l6-v2
+spec:
+  # 384-dim BERT sentence encoder; serves memini's embeddings on CPU.
+  source: https://huggingface.co/second-state/All-MiniLM-L6-v2-Embedding-GGUF/resolve/main/all-MiniLM-L6-v2-Q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    accelerator: cpu
+    gpu:
+      enabled: false
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: all-minilm-l6-v2
+spec:
+  modelRef: all-minilm-l6-v2
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-b9628@sha256:d0b7bce18e8f1bd9cfa8a455ea184cedae513ddfacded7fa41182fa31d9c4aa9
+  replicas: 1
+  contextSize: 32768
+  uBatchSize: 2048
+  parallelSlots: 8
+  # MiniLM is a BERT encoder → mean pooling. --embeddings exposes /v1/embeddings.
+  extraArgs:
+    - --embeddings
+    - --pooling
+    - mean
+    - --alias
+    - sentence-transformers/all-MiniLM-L6-v2
+  resources:
+    cpu: "500m"
+    memory: 1Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -3,4 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./qwen3-6-27b-mtp.yaml
+  - ./all-minilm-l6-v2.yaml
+  - ./qwen3-reranker-0.6b.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-reranker-0.6b
+spec:
+  # llama.cpp-packaged reranker build (rank head intact); serves memini's
+  # /v1/rerank on CPU.
+  source: https://huggingface.co/Voodisss/Qwen3-Reranker-0.6B-GGUF-llama_cpp/resolve/main/Qwen3-Reranker-0.6B-Q5_K_M.gguf
+  format: gguf
+  quantization: Q5_K_M
+  hardware:
+    accelerator: cpu
+    gpu:
+      enabled: false
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-reranker-0.6b
+spec:
+  modelRef: qwen3-reranker-0.6b
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-b9628@sha256:d0b7bce18e8f1bd9cfa8a455ea184cedae513ddfacded7fa41182fa31d9c4aa9
+  replicas: 1
+  contextSize: 8192
+  parallelSlots: 4
+  # --reranking + --pooling rank exposes the Cohere-style /v1/rerank endpoint
+  # memini calls.
+  extraArgs:
+    - --reranking
+    - --pooling
+    - rank
+    - --alias
+    - qwen3-reranker-0.6b
+  resources:
+    cpu: "500m"
+    memory: 1Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app memini
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            env:
+              MEMINI_BACKEND: sqlite
+              MEMINI_LOG_FORMAT: json
+              MEMINI_EMBED_BASE_URL: http://all-minilm-l6-v2.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_MODEL: sentence-transformers/all-MiniLM-L6-v2
+              MEMINI_EMBED_DIMS: "384"
+              MEMINI_RERANK: http://qwen3-reranker-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_RERANK_MODEL: qwen3-reranker-0.6b
+              MEMINI_RERANK_TOP_N: "20"
+              MEMINI_RERANK_MAX_DOC_CHARS: "4000"
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_API_KEY
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    persistence:
+      data:
+        existingClaim: *app
+    route:
+      internal:
+        enabled: true
+        hostnames:
+          - "memini.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.3.1
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/apps/ai/memini/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/memini/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: memini-secret
+type: Opaque
+stringData:
+    MEMINI_API_KEY: ENC[AES256_GCM,data:okB4DtwnYUXCdWfLNanHCjCnAP8M3zKcosS1Vn+bIXyuK09vu+uxVntaLkm/VaTu804uycLdDzkxZuJoeuExwg==,iv:jUtbdx1LK/qDzcGb2aieTAxhDP1wak/nbS6A5+/J1xU=,tag:DXy1WZ9yTScutCIUdL+Pkg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJdTlnTXgxQXVQbldMK3dN
+            a0ZrcjlUV0NIdnNZRUwxNmkwaFpNR3RxQXdFClhjQ1B3TzZWNjhvQklsaDN3eTNU
+            ZytpNmRjSWczSG5kKzI3U1ZxMmMvalUKLS0tIENiK09KNUVTbGEwekpnVWphRGZT
+            THd6SXBEUGwxdisvbVdQYWFINWFuYTAKA2NwfI88VQqaBHKSbygU464r2YIzOXK5
+            0NljaT+S/QlvLESS0PDvDIYHncMwDqHaC7y1HMJbW2Mf257COy6wHQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-15T00:59:12Z"
+    mac: ENC[AES256_GCM,data:mQ6BkeBnXFGM3fiLKNSnJwZU8E26+OFzhHwsxCM7faVh6690AIcRO+yK3XX0tGzR94OqIR7itl2+tPIscOW5S/2fpTJugC79V8Yq2Tu7GKWGwJxSVIXlKu48ZhzQVxquqfG65MuFDPrLtwVJEXPvpvaNV41qSGYJ/Nu3sv6gXuo=,iv:O9ijOV+dPGpmA/HJ6W9NPAwPNiOIkBXCtZxq0YBtuM4=,tag:RT3jaYmUpIMYYmxhECa96g==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.1

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memini
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/memini/app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: llmkube-models
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "65532"
+      VOLSYNC_GID: "65532"
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false


### PR DESCRIPTION
## What

Deploys [memini](https://github.com/eleboucher/memini) — a persistent memory service for MCP-capable AI agents (Claude Code, etc.) — to the `ai` namespace, plus the models it needs served via the existing **llmkube** operator.

## How

**memini** (`kubernetes/apps/ai/memini/`)
- Author's own OCI Helm chart `oci://registry.erwanleboucher.dev/eleboucher/charts/memini` `v0.3.1` (same as joryirving uses).
- **SQLite** backend on a **VolSync**-backed PVC mounted at `/data` (CNPG image lacks the VectorChord extension the Postgres backend needs).
- Internal-only `HTTPRoute` at `memini.${SECRET_DOMAIN}` (envoy-internal).
- API key via **SOPS**-encrypted secret.

**Embedding + reranker on llmkube** (CPU, alongside `qwen3-6-27b-mtp`)
- `all-minilm-l6-v2` — 384-dim embeddings (`--embeddings --pooling mean`), required by memini even in SQLite mode.
- `qwen3-reranker-0.6b` — Cohere-style `/v1/rerank` (`--reranking --pooling rank`), mirrors eleboucher's reranker.
- CPU because both NVIDIA GPUs on talos1 are saturated by qwen; both models are tiny.

## Verification

- Rendered the chart with these values: workload is a `StatefulSet` (replicas 1), `MEMINI_SQLITE_PATH=/data/memini.db`, `/data` mounted read-write from PVC `memini` (the VolSync-created claim) — DB path and mount line up.
- `kustomize build` passes for the `ai` aggregator, the memini app, and the llmkube models.
- llama.cpp image pinned by digest (`server-b9628@sha256:d0b7…`); reranker GGUF (`Voodisss/Qwen3-Reranker-0.6B-GGUF-llama_cpp`) confirmed to exist.

Post-merge, follow the plan checklist: embeddings return a 384-vector, reranker scores, memini `/healthz`+`/readyz` green, PVC bound, first backup snapshot completes.

## Follow-ups (not in this PR)
- Optional LLM consolidation (`MEMINI_LLM_BASE_URL` → the existing qwen service).
- Wire memini in as an MCP server via ToolHive once healthy.
- Renovate won't auto-track the author's registry (chart/image) — bump manually or add a datasource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)