### PR TITLE
fix(ai): use default volsync mover uid for memini

### DIFF
--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -16,8 +16,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "65532"
-      VOLSYNC_GID: "65532"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret


### PR DESCRIPTION
## Problem

After #1024 merged, `memini-0` stayed `Pending` and the VolSync restore mover (`volsync-dst-memini-dst-*`) crash-looped:

```
Fatal: create repository at /mnt/repository/memini failed: ... mkdir /mnt/repository/memini: permission denied
```

The `VOLSYNC_UID/GID: "65532"` override (added so the mover would match memini's file ownership) made the restic mover run as uid 65532, which has no permission to create its repo directory on the NFS backup share — that share is owned by the repo-wide default mover uid `4003`.

## Fix

Drop the override. The mover reverts to `4003` (like every other app — none override it), so it can create/read its restic repo on the NFS share. memini's pod `fsGroup: 65532` already makes the restored `/data` volume writable on the app side, so the mover uid is irrelevant to memini.

Once merged, Flux updates the ReplicationDestination's mover securityContext, the restore completes, the `memini` PVC binds, and `memini-0` schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)