### PR TITLE
feat(ai): switch memini embeddings to Qwen3-Embedding-0.6B

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./qwen3-6-27b-mtp.yaml
-  - ./all-minilm-l6-v2.yaml
+  - ./qwen3-embedding-0.6b.yaml
   - ./qwen3-reranker-0.6b.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -2,10 +2,9 @@
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
-  name: all-minilm-l6-v2
+  name: qwen3-embedding-0.6b
 spec:
-  # 384-dim BERT sentence encoder; serves memini's embeddings on CPU.
-  source: https://huggingface.co/second-state/All-MiniLM-L6-v2-Embedding-GGUF/resolve/main/all-MiniLM-L6-v2-Q8_0.gguf
+  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:
@@ -16,25 +15,24 @@ spec:
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: all-minilm-l6-v2
+  name: qwen3-embedding-0.6b
 spec:
-  modelRef: all-minilm-l6-v2
+  modelRef: qwen3-embedding-0.6b
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-b9628@sha256:d0b7bce18e8f1bd9cfa8a455ea184cedae513ddfacded7fa41182fa31d9c4aa9
   replicas: 1
-  contextSize: 32768
+  contextSize: 8192
   uBatchSize: 2048
   parallelSlots: 8
-  # MiniLM is a BERT encoder → mean pooling. --embeddings exposes /v1/embeddings.
   extraArgs:
     - --embeddings
     - --pooling
-    - mean
+    - last
     - --alias
-    - sentence-transformers/all-MiniLM-L6-v2
+    - Qwen/Qwen3-Embedding-0.6B
   resources:
     cpu: "500m"
-    memory: 1Gi
+    memory: 2Gi
   endpoint:
     port: 8080
     type: ClusterIP

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -19,9 +19,9 @@ spec:
             env:
               MEMINI_BACKEND: sqlite
               MEMINI_LOG_FORMAT: json
-              MEMINI_EMBED_BASE_URL: http://all-minilm-l6-v2.ai.svc.cluster.local:8080/v1
-              MEMINI_EMBED_MODEL: sentence-transformers/all-MiniLM-L6-v2
-              MEMINI_EMBED_DIMS: "384"
+              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_MODEL: Qwen/Qwen3-Embedding-0.6B
+              MEMINI_EMBED_DIMS: "1024"
               MEMINI_RERANK: http://qwen3-reranker-0.6b.ai.svc.cluster.local:8080/v1
               MEMINI_RERANK_MODEL: qwen3-reranker-0.6b
               MEMINI_RERANK_TOP_N: "20"


### PR DESCRIPTION
## Summary
- Replace `all-MiniLM-L6-v2` (22M params, 384 dims, mean pooling) with `Qwen3-Embedding-0.6B` (0.6B params, 1024 dims, last-token pooling) as memini's embedding model
- Uses the official Q8_0 GGUF from Qwen, served via llmkube/llama.cpp on CPU
- Reduced context size from 32K to 8K (sufficient for memory snippets, saves RAM)
- Bumped memory limit to 2Gi to accommodate the larger model

## Why
Qwen3-Embedding-0.6B is a 27x parameter upgrade over MiniLM with better retrieval benchmarks, multilingual support (100+ languages), and modern architecture. The 0.6B variant is right-sized for a homelab — 4B/8B would consume significantly more resources for marginal gains on a personal-scale corpus.

## Post-merge
Memini's existing SQLite embeddings will need to be re-indexed since the dimensionality changes from 384 → 1024.

## Test plan
- [ ] Verify `qwen3-embedding-0.6b` InferenceService comes up healthy
- [ ] Verify memini pods restart and connect to new embedding endpoint
- [ ] Test recall/search after re-indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)