### PR TITLE
fix(ai): memini embedding/reranker hostnames + align model aliases

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./qwen3-6-27b-mtp.yaml
-  - ./qwen3-embedding-0.6b.yaml
-  - ./qwen3-reranker-0.6b.yaml
+  - ./qwen3-embedding-0-6b.yaml
+  - ./qwen3-reranker-0-6b.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
@@ -51,6 +51,8 @@ spec:
   # Omitted from the preset: load-on-startup (router-only).
   # --tensor-split 6,1 is emitted by the Model's gpu.sharding (above), not here.
   extraArgs:
+    - --alias
+    - Qwen/Qwen3.6-27B-MTP
     - --verbosity
     - "4"
     - --cache-reuse

--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0-6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0-6b.yaml
@@ -2,13 +2,11 @@
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
-  name: qwen3-reranker-0.6b
+  name: qwen3-embedding-0-6b
 spec:
-  # llama.cpp-packaged reranker build (rank head intact); serves memini's
-  # /v1/rerank on CPU.
-  source: https://huggingface.co/Voodisss/Qwen3-Reranker-0.6B-GGUF-llama_cpp/resolve/main/Qwen3-Reranker-0.6B-Q5_K_M.gguf
+  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
   format: gguf
-  quantization: Q5_K_M
+  quantization: Q8_0
   hardware:
     accelerator: cpu
     gpu:
@@ -17,25 +15,24 @@ spec:
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: qwen3-reranker-0.6b
+  name: qwen3-embedding-0-6b
 spec:
-  modelRef: qwen3-reranker-0.6b
+  modelRef: qwen3-embedding-0-6b
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-b9628@sha256:d0b7bce18e8f1bd9cfa8a455ea184cedae513ddfacded7fa41182fa31d9c4aa9
   replicas: 1
   contextSize: 8192
-  parallelSlots: 4
-  # --reranking + --pooling rank exposes the Cohere-style /v1/rerank endpoint
-  # memini calls.
+  uBatchSize: 2048
+  parallelSlots: 8
   extraArgs:
-    - --reranking
+    - --embeddings
     - --pooling
-    - rank
+    - last
     - --alias
-    - qwen3-reranker-0.6b
+    - Qwen/Qwen3-Embedding-0.6B
   resources:
     cpu: "500m"
-    memory: 1Gi
+    memory: 2Gi
   endpoint:
     port: 8080
     type: ClusterIP

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0-6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0-6b.yaml
@@ -2,11 +2,13 @@
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
-  name: qwen3-embedding-0.6b
+  name: qwen3-reranker-0-6b
 spec:
-  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
+  # llama.cpp-packaged reranker build (rank head intact); serves memini's
+  # /v1/rerank on CPU.
+  source: https://huggingface.co/Voodisss/Qwen3-Reranker-0.6B-GGUF-llama_cpp/resolve/main/Qwen3-Reranker-0.6B-Q5_K_M.gguf
   format: gguf
-  quantization: Q8_0
+  quantization: Q5_K_M
   hardware:
     accelerator: cpu
     gpu:
@@ -15,24 +17,25 @@ spec:
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: qwen3-embedding-0.6b
+  name: qwen3-reranker-0-6b
 spec:
-  modelRef: qwen3-embedding-0.6b
+  modelRef: qwen3-reranker-0-6b
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-b9628@sha256:d0b7bce18e8f1bd9cfa8a455ea184cedae513ddfacded7fa41182fa31d9c4aa9
   replicas: 1
   contextSize: 8192
-  uBatchSize: 2048
-  parallelSlots: 8
+  parallelSlots: 4
+  # --reranking + --pooling rank exposes the Cohere-style /v1/rerank endpoint
+  # memini calls.
   extraArgs:
-    - --embeddings
+    - --reranking
     - --pooling
-    - last
+    - rank
     - --alias
-    - Qwen/Qwen3-Embedding-0.6B
+    - Qwen/Qwen3-Reranker-0.6B
   resources:
     cpu: "500m"
-    memory: 2Gi
+    memory: 1Gi
   endpoint:
     port: 8080
     type: ClusterIP

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -19,11 +19,11 @@ spec:
             env:
               MEMINI_BACKEND: sqlite
               MEMINI_LOG_FORMAT: json
-              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0.6b.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1
               MEMINI_EMBED_MODEL: Qwen/Qwen3-Embedding-0.6B
               MEMINI_EMBED_DIMS: "1024"
-              MEMINI_RERANK: http://qwen3-reranker-0.6b.ai.svc.cluster.local:8080/v1
-              MEMINI_RERANK_MODEL: qwen3-reranker-0.6b
+              MEMINI_RERANK: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080/v1
+              MEMINI_RERANK_MODEL: Qwen/Qwen3-Reranker-0.6B
               MEMINI_RERANK_MAX_DOC_CHARS: "4000"
               MEMINI_API_KEY:
                 valueFrom:


### PR DESCRIPTION
## Summary
- Fixes memini-0 crash loop / non-functional embedding after the Qwen3 switch: configured hostnames used dotted names (`qwen3-embedding-0.6b`) that don't resolve, since k8s Services translate dots to dashes.
- Renames the llmkube `Model`/`InferenceService` resources to dashed form so the resource name matches the generated Service name; points memini at the correct hostnames.
- Aligns all model `--alias` values to canonical `Qwen/Qwen3-*` IDs:
  - `qwen3-embedding-0-6b` → `Qwen/Qwen3-Embedding-0.6B`
  - `qwen3-reranker-0-6b` → `Qwen/Qwen3-Reranker-0.6B`
  - `qwen3-6-27b-mtp` → `Qwen/Qwen3.6-27B-MTP` (previously unaliased)
- Updates `MEMINI_RERANK_MODEL` to match the new reranker alias.

Note: also wiped the incompatible 384-dim memini SQLite store out-of-band so it rebuilds at 1024 dims.

## Validation
- `just test` (flate): 154 passed.
- Will verify a memini remember/recall round-trip after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)