### PR TITLE
fix(ai): give memini embeddings enough per-slot context

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0-6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0-6b.yaml
@@ -21,9 +21,16 @@ spec:
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-b9628@sha256:d0b7bce18e8f1bd9cfa8a455ea184cedae513ddfacded7fa41182fa31d9c4aa9
   replicas: 1
+  # llama.cpp splits contextSize across parallelSlots, so per-slot ctx =
+  # contextSize / parallelSlots. Keep per-slot above memini's
+  # MEMINI_EMBED_MAX_ITEM_CHARS cap (6000 chars ≈ 1500-2000 tokens):
+  # 8192 / 2 = 4096 tokens/slot. Total ctx unchanged, so CPU/KV memory is too.
   contextSize: 8192
-  uBatchSize: 2048
-  parallelSlots: 8
+  # Pooled embeddings must fit the whole sequence in one ubatch, so keep this
+  # >= per-slot ctx (4096) — otherwise a long input fits the context but not a
+  # single micro-batch.
+  uBatchSize: 4096
+  parallelSlots: 2
   extraArgs:
     - --embeddings
     - --pooling

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -22,6 +22,10 @@ spec:
               MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1
               MEMINI_EMBED_MODEL: Qwen/Qwen3-Embedding-0.6B
               MEMINI_EMBED_DIMS: "1024"
+              # Bound each embed input so it can't overrun the embedder's
+              # per-slot context (~6000 chars ≈ 1500-2000 tokens).
+              MEMINI_EMBED_MAX_ITEM_CHARS: "6000"
+              MEMINI_EMBED_MAX_CONCURRENCY: "2"
               MEMINI_RERANK: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080/v1
               MEMINI_RERANK_MODEL: Qwen/Qwen3-Reranker-0.6B
               MEMINI_RERANK_MAX_DOC_CHARS: "4000"


### PR DESCRIPTION
## Problem

The `memini` backfill (`memini import --source claude-code`) failed to embed 15 of 123 Claude Code exchanges. The embedding backend returned:

```
request (1641 tokens) exceeds the available context size (1024 tokens)
```

## Root cause

`qwen3-embedding-0-6b` set `contextSize: 8192` with `parallelSlots: 8`. Because the slot count is set **explicitly** (not auto), llama.cpp disables its unified KV cache and partitions the context rigidly: `8192 ÷ 8 = 1024` tokens **per slot**. Full Claude Code exchanges run 1k–1.6k+ tokens, overrunning that 1024 ceiling.

The model itself (Qwen3-Embedding-0.6B) supports 32768 tokens — the limit was purely the slot split.

## Fix

**`llmkube/models/qwen3-embedding-0-6b.yaml`**
- `parallelSlots: 8 → 2` → 4096 tokens/slot. Total context stays 8192, so CPU/KV-cache memory is unchanged (no risk to the 2Gi limit).
- `uBatchSize: 2048 → 4096` → pooled embeddings must fit the whole sequence in one micro-batch; keep ubatch ≥ per-slot ctx.

**`memini/app/helmrelease.yaml`**
- `MEMINI_EMBED_MAX_ITEM_CHARS: "6000"` → bound inputs (~1500–2000 tok) before they reach the embedder.
- `MEMINI_EMBED_MAX_CONCURRENCY: "2"` → matches the 2 slots.

Mirrors the input-capping approach in [joryirving/home-ops](https://github.com/joryirving/home-ops) (which runs the same model, GPU-accelerated, with a 6000-char cap).

## Validation

After this reconciles, re-running the backfill picks up the 15 stragglers (the import is idempotent):

```
memini import --source claude-code --remote https://memini.crayon.club --token "$MEMINI_TOKEN" ~/.claude/projects
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)