### PR TITLE
feat(ai-sandbox): gVisor-sandboxed openclaw agent gateway

### DIFF
--- a/kubernetes/apps/ai-sandbox/kustomization.yaml
+++ b/kubernetes/apps/ai-sandbox/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai-sandbox
+components:
+  - ../../components/sops
+resources:
+  - ./namespace.yaml
+  - ./openclaw/ks.yaml

--- a/kubernetes/apps/ai-sandbox/namespace.yaml
+++ b/kubernetes/apps/ai-sandbox/namespace.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-sandbox
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"
+    # Isolated home for openclaw, which runs untrusted agent code. Kept separate
+    # from the shared `ai` namespace to contain blast radius. The openclaw pod
+    # itself is restricted-compliant AND gVisor-sandboxed (RuntimeClass), which
+    # is the real isolation; the namespace floor is `baseline` rather than
+    # `restricted` only because VolSync's backup/restore mover (NFS volume + an
+    # injected unhardened `jitter` initContainer) is not restricted-compliant
+    # and would otherwise be rejected, breaking backups and blocking the PVC.
+    pod-security.kubernetes.io/enforce: &ps baseline
+    pod-security.kubernetes.io/audit: *ps
+    pod-security.kubernetes.io/warn: *ps

--- a/kubernetes/apps/ai-sandbox/openclaw/README.md
+++ b/kubernetes/apps/ai-sandbox/openclaw/README.md
@@ -25,13 +25,51 @@ and firewalled by a default-deny egress CiliumNetworkPolicy.
   mover (+ an injected unhardened `jitter` initContainer) can't satisfy
   `restricted`. gVisor + the pod's own securityContext are the real isolation.
 - **No kube-API access**: `automountServiceAccountToken: false`, and egress
-  policy denies the API server / other namespaces anyway.
+  policy denies the API server / other namespaces anyway. (Note: JJGadgets'
+  reference deliberately does the *opposite* — it grants the pod a ServiceAccount
+  with `pods/exec`, `deployments` patch, and a cluster `view` ClusterRoleBinding
+  so its agent can deploy/scale LLMs. That is a capability grant, not hardening;
+  we keep the agent off the API entirely.)
+- **SSO at the gateway (defense-in-depth)**: the HTTPRoute is wrapped by a
+  Pocket-ID OIDC `SecurityPolicy` via the `components/oidc/envoy` component
+  (`ks.yaml`), so reaching the Control UI requires an SSO login *before* traffic
+  ever hits OpenClaw's own gateway-token auth. Two independent auth layers.
 - **Pinned to `talos1`** (worker, has the gVisor extension); never the
   control-plane / GPU host `talos0`.
 - **Egress is default-deny** (`app/networkpolicy.yaml`): only cluster DNS, the
   in-cluster LLMs (`ai` namespace :8080), and the *public* internet (private /
   link-local CIDRs excluded). kube-apiserver, the LAN, and other namespaces are
-  unreachable.
+  unreachable. See **Egress hardening** below for tightening this to a per-domain
+  allowlist.
+
+## Storage
+
+- **`config` PVC (`openclaw`, VolSync-backed)**: mounted at `$HOME=/home/node`.
+  Holds config, agents, auth-profiles, workspace — the stuff worth backing up.
+- **`cache` (ephemeral `emptyDir`, NOT backed up)**: mounted over `$HOME/.cache`
+  with a `sizeLimit` cap. Holds regenerable agent/toolchain caches (npm, pip,
+  go, …) so they don't bloat the restic backups of the config PVC. Discarded on
+  pod recreation (re-downloaded as needed) — cheaper than a dedicated PVC for
+  throwaway data. Add more sub-mounts (or switch to a PVC) if a tool caches
+  outside `~/.cache` or the re-download cost becomes annoying. (JJGadgets keeps a
+  similar split — a separate non-backed `misc` PVC for brew/nix/go/mise.)
+
+## Egress hardening (deferred follow-up)
+
+The egress policy currently allows the agent to reach **any** public host on
+443/80. The tighter model — adopted from JJGadgets' reference — is a Cilium
+`toFQDNs` allowlist of only the provider domains the agent needs (e.g.
+`api.anthropic.com`, `*.openrouter.ai`). To switch:
+
+1. Upgrade the CoreDNS egress rule in `app/networkpolicy.yaml` to L7 by adding
+   `rules: { dns: [{ matchPattern: "*" }] }` under its `toPorts`, so Cilium's
+   DNS proxy can learn name→IP mappings.
+2. Replace the `0.0.0.0/0` `toCIDRSet` rule with a `toFQDNs` rule listing the
+   allowed domains.
+
+Deferred because it trades the agent's general web access for tighter
+containment — enable it once the needed domain set is known. `ndots:1` is
+already set (`helmrelease.yaml`) in preparation.
 
 ## Node prerequisites (apply to talos1 BEFORE Flux reconciles)
 
@@ -67,9 +105,10 @@ kubectl -n ai-sandbox exec -it <pod> -c setup -- openclaw setup
 ```
 
 Once `$HOME/.openclaw/openclaw.json` exists the gate clears and the gateway
-starts. The Control UI is then at `https://openclaw.${SECRET_DOMAIN}/`. An
-in-cluster model is already reachable per the egress policy; external provider
-APIs work over the public-internet rule.
+starts. The Control UI is then at `https://openclaw.${SECRET_DOMAIN}/`, behind a
+Pocket-ID SSO login (the Envoy OIDC `SecurityPolicy`). An in-cluster model is
+already reachable per the egress policy; external provider APIs work over the
+public-internet rule.
 
 > Auth + bind are **fail-loud**, not fail-open: with `OPENCLAW_GATEWAY_BIND=lan`
 > (a non-loopback bind) OpenClaw refuses to start without a credential, so a
@@ -91,6 +130,12 @@ Can't be verified from manifests:
       only writable persistent path).
 - [ ] **NetworkPolicy selects the pod** (`app.kubernetes.io/name: openclaw`);
       confirm with `cilium endpoint list` / Hubble that it's enforced.
+- [ ] **SSO works end-to-end**: `https://openclaw.${SECRET_DOMAIN}/` redirects to
+      Pocket-ID and back. Watch for OIDC interfering with non-browser clients —
+      the OpenClaw Control UI's API/websocket calls must survive the forward-auth
+      filter (if a CLI/agent client needs unauthenticated access, carve out its
+      path in the `SecurityPolicy` rather than disabling OIDC).
+- [ ] **`cache` emptyDir is writable** at `$HOME/.cache` by uid 1000.
 - [ ] Agent can reach an in-cluster LLM (`ai` :8080) and the public internet.
 - [ ] Negative check: from inside the pod, kube-apiserver and a LAN host
       (e.g. 10.0.42.1) are **unreachable**; DNS still resolves.

--- a/kubernetes/apps/ai-sandbox/openclaw/README.md
+++ b/kubernetes/apps/ai-sandbox/openclaw/README.md
@@ -1,0 +1,96 @@
+# openclaw
+
+Self-hosted AI agent gateway that runs untrusted agent code. It lives in the
+isolated `ai-sandbox` namespace, pinned to `talos1`, sandboxed by **gVisor**,
+and firewalled by a default-deny egress CiliumNetworkPolicy.
+
+## Security model
+
+- **gVisor (`runtimeClassName: gvisor`)** is the sandbox boundary: agent code
+  runs against runsc's userspace kernel, so a breakout hits gVisor, not the host
+  kernel. This replaces docker-in-docker entirely — **no privileged container,
+  no host Docker daemon**.
+- **gVisor is scoped to openclaw only** — not forced namespace-wide. The openclaw
+  pod opts in via `runtimeClassName: gvisor` (`app/runtimeclass.yaml`); VolSync
+  movers and any other infra in the namespace run on the normal runtime. This is
+  deliberate: the untrusted workload is sandboxed, trusted backup infra is left
+  alone (and JJGadgets' reference does the same — gVisor on the app, not the
+  movers).
+- **Pod hardening (restricted-compliant)**: `runAsNonRoot`,
+  `allowPrivilegeEscalation: false`, all caps dropped, `seccompProfile:
+  RuntimeDefault`, `readOnlyRootFilesystem: true` (HOME is the only writable
+  persistent path; `/tmp` is a memory emptyDir). The hardening is applied per
+  workload (the openclaw pod), not via the namespace floor: the namespace
+  *enforce* level is `baseline`, because VolSync's NFS-mounting backup/restore
+  mover (+ an injected unhardened `jitter` initContainer) can't satisfy
+  `restricted`. gVisor + the pod's own securityContext are the real isolation.
+- **No kube-API access**: `automountServiceAccountToken: false`, and egress
+  policy denies the API server / other namespaces anyway.
+- **Pinned to `talos1`** (worker, has the gVisor extension); never the
+  control-plane / GPU host `talos0`.
+- **Egress is default-deny** (`app/networkpolicy.yaml`): only cluster DNS, the
+  in-cluster LLMs (`ai` namespace :8080), and the *public* internet (private /
+  link-local CIDRs excluded). kube-apiserver, the LAN, and other namespaces are
+  unreachable.
+
+## Node prerequisites (apply to talos1 BEFORE Flux reconciles)
+
+`talos/talconfig.yaml` adds two things to talos1, both needed before the pod
+can run (and on any future cluster rebuild):
+
+1. `siderolabs/gvisor` system extension (provides the `runsc` runtime).
+2. `user.max_user_namespaces: "11255"` sysctl — gVisor needs unprivileged user
+   namespaces to build its sandbox (Talos defaults this to 0).
+
+```sh
+# The extension is a schematic change → talos1 gets a new installer image and
+# REBOOTS. The sysctl applies in the same upgrade.
+talhelper genconfig
+talosctl upgrade -n 10.0.42.4 --image <factory-image-from-clusterconfig>
+# verify after reboot:
+talosctl -n 10.0.42.4 get extensions | grep -i gvisor
+talosctl -n 10.0.42.4 list /usr/local/bin | grep runsc
+talosctl -n 10.0.42.4 read /proc/sys/user/max_user_namespaces   # expect 11255
+```
+
+Only then let Flux reconcile `ai-sandbox` (the RuntimeClass `gvisor` won't
+schedule until the handler exists on talos1).
+
+## Onboarding
+
+OpenClaw setup is interactive, so the `setup` initContainer **blocks pod
+startup** until it's done — no unconfigured gateway ever serves. On first
+deploy the pod sits in Init; complete setup with:
+
+```sh
+kubectl -n ai-sandbox exec -it <pod> -c setup -- openclaw setup
+```
+
+Once `$HOME/.openclaw/openclaw.json` exists the gate clears and the gateway
+starts. The Control UI is then at `https://openclaw.${SECRET_DOMAIN}/`. An
+in-cluster model is already reachable per the egress policy; external provider
+APIs work over the public-internet rule.
+
+> Auth + bind are **fail-loud**, not fail-open: with `OPENCLAW_GATEWAY_BIND=lan`
+> (a non-loopback bind) OpenClaw refuses to start without a credential, so a
+> wrong/missing token CrashLoops rather than exposing an unauthenticated UI.
+> `OPENCLAW_GATEWAY_TOKEN` (`app/secret.sops.yaml`) is the documented token-mode
+> var; `OPENCLAW_GATEWAY_BIND=lan` is the documented container mechanism for
+> binding to the pod interface (env overrides the config key). JJGadgets uses
+> `OPENCLAW_GATEWAY_PASSWORD` only because he selected password-mode auth.
+
+## Runtime validation (after first deploy)
+
+Can't be verified from manifests:
+
+- [ ] Pod schedules on talos1 under RuntimeClass `gvisor` and passes readiness.
+- [ ] **OpenClaw runs cleanly under gVisor** — watch for syscall-compat issues
+      in the node app; gVisor trades some compatibility/perf for isolation.
+- [ ] **`config` PVC is writable** by uid 1000 at `$HOME=/home/node` under
+      `fsGroup: 1000` on OpenEBS-ZFS (with `readOnlyRootFilesystem`, this is the
+      only writable persistent path).
+- [ ] **NetworkPolicy selects the pod** (`app.kubernetes.io/name: openclaw`);
+      confirm with `cilium endpoint list` / Hubble that it's enforced.
+- [ ] Agent can reach an in-cluster LLM (`ai` :8080) and the public internet.
+- [ ] Negative check: from inside the pod, kube-apiserver and a LAN host
+      (e.g. 10.0.42.1) are **unreachable**; DNS still resolves.

--- a/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
@@ -19,6 +19,14 @@ spec:
       runtimeClassName: gvisor
       # The gateway has no business talking to the kube-API.
       automountServiceAccountToken: false
+      # ndots:1 stops the resolver from appending the namespace search domains to
+      # every external lookup (the default ndots:5 turns `api.anthropic.com` into
+      # 5+ failed in-cluster queries first). Cheaper DNS and a prerequisite for a
+      # future toFQDNs egress allowlist (see networkpolicy.yaml).
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000   # upstream "node" user
@@ -125,6 +133,18 @@ spec:
               - path: *home
             setup:
               - path: *home
+      # Agent toolchain/download caches (npm, pip, go, etc.) on an ephemeral
+      # emptyDir mounted over $HOME/.cache. Regenerable junk: never backed up and
+      # discarded on pod recreation. sizeLimit caps it so a runaway cache can't
+      # fill the node's ephemeral storage and trigger eviction; disk-backed (no
+      # medium: Memory) so it doesn't count against the pod's memory limit.
+      cache:
+        type: emptyDir
+        sizeLimit: 20Gi
+        advancedMounts:
+          *app :
+            *app :
+              - path: /home/node/.cache
       tmp:
         type: emptyDir
         medium: Memory

--- a/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
@@ -1,0 +1,132 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app openclaw
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    defaultPodOptions:
+      # Sandbox the whole pod with gVisor: untrusted/injected agent code runs
+      # against a userspace kernel, not the host kernel. This replaces the
+      # privileged docker-in-docker sandbox entirely (no privileged container,
+      # no host Docker daemon). Requires the siderolabs/gvisor extension +
+      # user.max_user_namespaces>0 on talos1 (see talos/talconfig.yaml).
+      runtimeClassName: gvisor
+      # The gateway has no business talking to the kube-API.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000   # upstream "node" user
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Pinned to the worker (which carries the gVisor extension); never the
+          # control-plane / GPU host talos0.
+          nodeSelector:
+            kubernetes.io/hostname: talos1
+        initContainers:
+          # Onboarding gate: OpenClaw setup is interactive, so block startup
+          # until it has been completed. On first deploy:
+          #   kubectl -n ai-sandbox exec -it <pod> -c setup -- openclaw setup
+          setup:
+            image: &img
+              repository: ghcr.io/openclaw/openclaw
+              tag: 2026.6.8@sha256:9f55f0cb32b2925a983f40726440189b8f422ec61ae2a0fb0cf90403cf6d63d7
+            env: &env
+              HOME: &home /home/node
+              TZ: "${CONFIG_TZ:=Etc/UTC}"
+              OPENCLAW_GATEWAY_BIND: lan
+              OPENCLAW_GATEWAY_PORT: &port 18789
+              OPENCLAW_AUTH_PROFILE_SECRET_DIR: /home/node/.openclaw/.secrets
+              PATH: /home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            envFrom: &envFrom
+              - secretRef:
+                  name: openclaw-secret
+            command:
+              - sh
+              - -c
+              - |
+                while [ ! -s "$HOME/.openclaw/openclaw.json" ]; do
+                  echo 'OpenClaw is not set up yet. Run: kubectl -n ai-sandbox exec -it <pod> -c setup -- openclaw setup';
+                  sleep 60;
+                done
+            securityContext: &sc
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+        containers:
+          *app :
+            image: *img
+            env: *env
+            envFrom: *envFrom
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext: *sc
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                # gVisor adds some overhead; agent workloads are bursty.
+                cpu: "4"
+                memory: 2Gi
+    service:
+      *app :
+        controller: *app
+        primary: true
+        ports:
+          http:
+            port: *port
+    route:
+      internal:
+        enabled: true
+        hostnames:
+          - "openclaw.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+    persistence:
+      # Whole HOME on the backed-up PVC so the read-only rootfs has a writable
+      # home for config, agents, auth-profiles, and workspace.
+      config:
+        existingClaim: *app
+        advancedMounts:
+          *app :
+            *app :
+              - path: *home
+            setup:
+              - path: *home
+      tmp:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai-sandbox/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./networkpolicy.yaml
+  - ./ocirepository.yaml
+  - ./runtimeclass.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/ai-sandbox/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/networkpolicy.yaml
@@ -44,6 +44,15 @@ spec:
     # agent web access). If openclaw is later pointed at an in-cluster or on-LAN
     # model, add a narrow toEndpoints/toCIDR rule for just that host:port rather
     # than relaxing these excepts.
+    #
+    # FUTURE HARDENING (see README "Egress hardening"): replace this broad
+    # 0.0.0.0/0 rule with a Cilium `toFQDNs` allowlist of only the provider
+    # domains the agent actually needs (JJGadgets' reference does this:
+    # api.anthropic.com, *.openrouter.ai, etc.). That requires upgrading the
+    # CoreDNS egress rule above to L7 (add `rules: { dns: [{ matchPattern: "*" }] }`
+    # under its toPorts) so Cilium's DNS proxy can resolve the names. Deferred
+    # for now because it trades the agent's general web access for tighter
+    # containment — turn it on once the set of needed domains is known.
     - toCIDRSet:
         - cidr: 0.0.0.0/0
           except:

--- a/kubernetes/apps/ai-sandbox/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/networkpolicy.yaml
@@ -1,0 +1,60 @@
+---
+# Default-deny egress for openclaw. The pod runs untrusted / prompt-injected
+# agent code (gVisor-sandboxed), so this is the control that contains a
+# breakout: the pod may reach DNS, the in-cluster LLMs, and the public
+# internet, but NOT the Kubernetes API, the LAN, or other in-cluster services.
+#
+# Egress rules switch this endpoint to default-deny egress (ingress is left
+# unrestricted so the envoy-internal route and kubelet probes keep working).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openclaw
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: openclaw
+  egress:
+    # Cluster DNS (Helm-managed CoreDNS in kube-system).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # In-cluster local LLMs (llama-cpp / llmkube model servers in the `ai`
+    # namespace, which serve inference on 8080). Scoped to that namespace +
+    # port only — no other in-cluster service is reachable.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Public internet only. NOTE: Cilium's `world` entity also covers RFC1918
+    # LAN hosts (the MikroTik at 10.0.42.1, other homelab devices), so we use a
+    # CIDR allow that explicitly excludes private + link-local ranges. This
+    # keeps kube-apiserver, the pod/service CIDRs, other namespaces, and the LAN
+    # unreachable while still permitting external egress (e.g. Anthropic API,
+    # agent web access). If openclaw is later pointed at an in-cluster or on-LAN
+    # model, add a narrow toEndpoints/toCIDR rule for just that host:port rather
+    # than relaxing these excepts.
+    - toCIDRSet:
+        - cidr: 0.0.0.0/0
+          except:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+            - 169.254.0.0/16
+            - 100.64.0.0/10
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/ai-sandbox/openclaw/app/ocirepository.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openclaw
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai-sandbox/openclaw/app/runtimeclass.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/runtimeclass.yaml
@@ -1,0 +1,14 @@
+---
+# gVisor (runsc) runtime, provided by the siderolabs/gvisor Talos extension on
+# talos1. Cluster-scoped; scheduling pins gvisor pods to nodes that actually
+# have the runtime handler installed. Only openclaw opts into it (via its pod's
+# runtimeClassName) — it is intentionally NOT forced namespace-wide, so VolSync
+# movers and other infra run on the normal runtime.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+scheduling:
+  nodeSelector:
+    kubernetes.io/hostname: talos1

--- a/kubernetes/apps/ai-sandbox/openclaw/app/secret.sops.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-secret
+type: Opaque
+stringData:
+  OPENCLAW_GATEWAY_TOKEN: ENC[AES256_GCM,data:2Xn3Hz+YijeahDFJ7cF+wZ0ifr2ncAWofLtv9o3NVvZSet/yR7wVCTfZWCD62mBH6iHjfakfSO+pOfApHImkVg==,iv:Unn/Rq8vWEPqs8u54VHRCrn20gjG0jbK9ZpvdqUT3Vc=,tag:BLBSrU5coObM8iKTJxl/pA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxRnVxVHVPY2JiVDB6eDZr
+        NHdONHU4OGV5RmR2cm9jczFUKzJqMXF1ZDBZClVDR2s3eFF4QVZDTXJEbXBUWWhp
+        eDRES3pJb1BpL3NibFlGZU4rODF5T3cKLS0tIDZqSHBDWTZySzlxWWd0Y0hlOU9N
+        dU5EMUdhNnFNTFFuYzAxTVVhYVFsWDQKMzvgx1QDrsudnTYtgh9zBd+J4Wq38Xm6
+        dAB+VK0ScQlWtqoQlZXUOIXgRtkPQEohlesjFeXywyZ7Ul7/WbpbFA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-16T02:14:07Z"
+  mac: ENC[AES256_GCM,data:9W/PMFQPEG8qE4oSnbM7zyS6CmLkcScibmpC01PKrX/nWc2AjtG1xsG+m250zFN6+0I/LKoZN6A5Pf94BUGMkYyjeEuSmXFOZqA0JDPti4Sjfg3vUarKkdMS+57Pf4WbeRnGlcnU4VATBP2MRBNbZkOlSucnSc92dxSN9cNBiyA=,iv:ShfK2eWAFZaMNrqo+6ckEQWIZoCN0MaWFftWzyV1Few=,tag:a8S+JmXZp7TY8rE9YcxUWw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
@@ -11,13 +11,20 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/ai-sandbox/openclaw/app
   components:
+    # Pocket-ID SSO enforced at the Envoy gateway (forward-auth SecurityPolicy +
+    # OIDC client). Defense-in-depth in front of OpenClaw's own gateway token, so
+    # the untrusted-agent UI is never reachable on the LAN without an SSO login.
+    - ../../../../components/oidc/envoy
     - ../../../../components/volsync
   dependsOn:
+    - name: pocket-id
+      namespace: security
     - name: volsync
       namespace: volsync-system
   postBuild:
     substitute:
       APP: *app
+      OIDC_APP_NAME: OpenClaw
       VOLSYNC_CAPACITY: 10Gi
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
@@ -1,0 +1,31 @@
+---
+# NOTE: this app runs under RuntimeClass "gvisor", which needs the
+# siderolabs/gvisor extension + user.max_user_namespaces>0 on talos1. Apply the
+# Talos config (extension = reboot) to talos1 BEFORE letting Flux reconcile
+# this, or the pod won't schedule. See README.md.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openclaw
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai-sandbox/openclaw/app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai-sandbox
+  wait: false

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -108,6 +108,10 @@ nodes:
         systemExtensions:
           officialExtensions:
             - siderolabs/amd-ucode
+            # gVisor (runsc) container runtime — sandboxes the openclaw agent
+            # pod (RuntimeClass "gvisor") so untrusted/injected agent code is
+            # confined to a userspace kernel instead of the host kernel.
+            - siderolabs/gvisor
             - siderolabs/nvidia-container-toolkit-production
             - siderolabs/nvidia-open-gpu-kernel-modules-production
             - siderolabs/util-linux-tools
@@ -153,6 +157,14 @@ nodes:
         name: enp14s0
         wakeOnLan:
           - magic
+      - |-
+        # gVisor (runsc) requires unprivileged user namespaces to build its
+        # sandbox; Talos defaults user.max_user_namespaces to 0 (disabled).
+        # Scoped to talos1, the only node with the gVisor extension and where
+        # the openclaw agent pod is pinned. (Lowers a KSPP hardening default.)
+        machine:
+          sysctls:
+            user.max_user_namespaces: "11255"
 
 patches:
   - |-


### PR DESCRIPTION
Adds **openclaw**, a self-hosted AI agent gateway that runs untrusted/prompt-injected agent code, in a new isolated `ai-sandbox` namespace. Inspired by [JJGadgets' reference](https://github.com/JJGadgets/Biohazard/tree/main/kube/deploy/apps/openclaw), with the security model adapted to this cluster.

## Security model

- **gVisor sandbox** (`runtimeClassName: gvisor`) — agent code runs against runsc's userspace kernel, replacing privileged docker-in-docker entirely. Scoped to the openclaw pod only (not namespace-wide), so VolSync movers stay on the normal runtime.
- **Pod hardening** — `runAsNonRoot`, `allowPrivilegeEscalation: false`, all caps dropped, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true`.
- **No kube-API access** — `automountServiceAccountToken: false` (deliberately *not* granting the RBAC JJGadgets' reference does).
- **Pocket-ID SSO** at the Envoy gateway (`components/oidc/envoy`) — defense-in-depth in front of OpenClaw's own gateway token.
- **Default-deny egress** (CiliumNetworkPolicy) — only cluster DNS, in-cluster LLMs (`ai`:8080), and the public internet (private/LAN/link-local CIDRs excluded). kube-apiserver, LAN, and other namespaces unreachable.
- **Pinned to `talos1`** (worker carrying the gVisor extension), never the control-plane/GPU host.
- **Cache** on an ephemeral `emptyDir` (sizeLimit) so regenerable toolchain junk never bloats restic backups.

## Node prerequisites (talos1)

`talos/talconfig.yaml` adds the `siderolabs/gvisor` extension + `user.max_user_namespaces` sysctl. **The extension is a schematic change → talos1 reboots; apply it BEFORE Flux reconciles `ai-sandbox`** or the `gvisor` RuntimeClass won't schedule. See `README.md`.

## Onboarding

OpenClaw setup is interactive; the `setup` initContainer blocks startup until `openclaw setup` is run, so no unconfigured gateway ever serves.

## Follow-ups (documented)

- Tighten egress from broad public-internet to a `toFQDNs` allowlist once the needed provider domains are known (`ndots:1` already set in prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)