### PR TITLE
fix(ai-sandbox): set openclaw OIDC logoUrl to fix dry-run failure

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
@@ -25,6 +25,7 @@ spec:
     substitute:
       APP: *app
       OIDC_APP_NAME: OpenClaw
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/openclaw.svg"
       VOLSYNC_CAPACITY: 10Gi
     substituteFrom:
       - name: cluster-secrets


### PR DESCRIPTION
The components/oidc/envoy client maps APP_ICON_URL to PocketIDOIDCClient spec.logoUrl, which the CRD requires to be a non-null string. Without the substitution Flux resolved it to null, failing the openclaw Kustomization dry-run and blocking every resource in ai-sandbox from applying.