### PR TITLE
fix(ai-sandbox): force openclaw gateway.bind=lan (gVisor binds loopback)

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/README.md
+++ b/kubernetes/apps/ai-sandbox/openclaw/README.md
@@ -110,13 +110,22 @@ Pocket-ID SSO login (the Envoy OIDC `SecurityPolicy`). An in-cluster model is
 already reachable per the egress policy; external provider APIs work over the
 public-internet rule.
 
-> Auth + bind are **fail-loud**, not fail-open: with `OPENCLAW_GATEWAY_BIND=lan`
-> (a non-loopback bind) OpenClaw refuses to start without a credential, so a
+> **Network bind is config-only, not env** (verified in OpenClaw source
+> v2026.6.8). The gateway reads `gateway.bind` from `openclaw.json` (or the
+> `--bind` flag) — `OPENCLAW_GATEWAY_BIND` is **inert** in a plain pod (only the
+> Docker `setup.sh` would translate it to config, and we don't run that). With no
+> config value the default is `auto`, which binds `0.0.0.0` **only when OpenClaw
+> detects a container runtime**; gVisor isn't detected, so it fell back to
+> loopback and was unreachable (CrashLoop). The `setup` initContainer therefore
+> forces `gateway.bind: "lan"` (→ `0.0.0.0` unconditionally) in the persisted
+> config. `OPENCLAW_GATEWAY_PORT` *is* honored via env (source-confirmed), which
+> is why the gateway listens on 18789.
+>
+> Auth: `OPENCLAW_GATEWAY_TOKEN` (`app/secret.sops.yaml`) is read directly from
+> env. A non-loopback bind makes OpenClaw require a credential, so a
 > wrong/missing token CrashLoops rather than exposing an unauthenticated UI.
-> `OPENCLAW_GATEWAY_TOKEN` (`app/secret.sops.yaml`) is the documented token-mode
-> var; `OPENCLAW_GATEWAY_BIND=lan` is the documented container mechanism for
-> binding to the pod interface (env overrides the config key). JJGadgets uses
-> `OPENCLAW_GATEWAY_PASSWORD` only because he selected password-mode auth.
+> JJGadgets uses `OPENCLAW_GATEWAY_PASSWORD` only because he selected
+> password-mode auth.
 
 ## Runtime validation (after first deploy)
 

--- a/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
@@ -55,7 +55,10 @@ spec:
             env: &env
               HOME: &home /home/node
               TZ: "${CONFIG_TZ:=Etc/UTC}"
-              OPENCLAW_GATEWAY_BIND: lan
+              # NOTE: OpenClaw does NOT auto-map OPENCLAW_GATEWAY_* env vars to
+              # config (only a few like OPENCLAW_GATEWAY_TOKEN are read); bind/port
+              # live in openclaw.json. The bind is forced to all-interfaces by the
+              # setup initContainer below — env-based bind does nothing here.
               OPENCLAW_GATEWAY_PORT: &port 18789
               OPENCLAW_AUTH_PROFILE_SECRET_DIR: /home/node/.openclaw/.secrets
               PATH: /home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -70,6 +73,24 @@ spec:
                   echo 'OpenClaw is not set up yet. Run: kubectl -n ai-sandbox exec -it <pod> -c setup -- openclaw setup';
                   sleep 60;
                 done
+                # Force an all-interfaces bind via the persisted config. The
+                # bind mode is read ONLY from openclaw.json (or the --bind flag),
+                # never from env — OPENCLAW_GATEWAY_BIND is inert in a plain pod
+                # (confirmed in OpenClaw source v2026.6.8: only the Docker
+                # setup.sh writes it to config). With no config value the default
+                # is "auto", which resolves to 0.0.0.0 only when OpenClaw detects
+                # a container runtime; gVisor isn't detected, so it fell back to
+                # loopback (127.0.0.1) and was unreachable by Envoy + the kubelet
+                # probe (CrashLoop). gateway.bind="lan" resolves to 0.0.0.0
+                # unconditionally. Idempotent; runs every start so it self-heals
+                # if `openclaw setup` rewrites the config.
+                node -e '
+                  const fs = require("fs"), f = process.env.HOME + "/.openclaw/openclaw.json";
+                  const c = JSON.parse(fs.readFileSync(f, "utf8"));
+                  c.gateway = Object.assign({}, c.gateway, { bind: "lan" });
+                  fs.writeFileSync(f, JSON.stringify(c, null, 2));
+                  console.log("openclaw gateway.bind forced to lan (0.0.0.0)");
+                '
             securityContext: &sc
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem

After onboarding, the openclaw pod CrashLooped and the route returned `upstream connect error or disconnect/reset before headers. reset reason: remote connection failure`. The gateway was healthy (logged `ready`) but bound only to `127.0.0.1:18789`, so Envoy and the kubelet liveness probe couldn't reach it (probe failure → SIGTERM → restart loop).

## Root cause (verified in OpenClaw source `v2026.6.8`)

- `OPENCLAW_GATEWAY_BIND` is **never read by the gateway runtime** — only the Docker `setup.sh` translates it to config, which a plain pod doesn't run. The env var was inert.
- Bind mode comes only from `gateway.bind` in `openclaw.json` (or the `--bind` flag). With no value the default is `auto`, which binds `0.0.0.0` **only when a container runtime is detected** — gVisor (runsc) isn't detected, so it fell back to `loopback`.
- `OPENCLAW_GATEWAY_PORT` *is* honored via env (so 18789 was correct).

## Fix

- The `setup` initContainer now writes `gateway.bind: "lan"` (→ `0.0.0.0` unconditionally) into the persisted config after onboarding — idempotent, self-heals on every start.
- Dropped the misleading `OPENCLAW_GATEWAY_BIND` env.
- README corrected to document the config-only bind behavior.

Merging recovers the live deployment automatically: Flux reconcile → new pod → init patches the existing `openclaw.json` on the PVC → gateway binds `0.0.0.0:18789` → Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)