### PR TITLE
fix(ai-sandbox): allowlist openclaw Control UI browser origin

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
@@ -61,6 +61,11 @@ spec:
               # setup initContainer below — env-based bind does nothing here.
               OPENCLAW_GATEWAY_PORT: &port 18789
               OPENCLAW_AUTH_PROFILE_SECRET_DIR: /home/node/.openclaw/.secrets
+              # Browser origin the Control UI is served from; the setup
+              # initContainer writes it to gateway.controlUi.allowedOrigins so the
+              # WebSocket Origin check passes. Not read by OpenClaw directly — it's
+              # consumed by the config patch script (Flux substitutes SECRET_DOMAIN).
+              CONTROL_UI_ORIGIN: "https://openclaw.${SECRET_DOMAIN}"
               PATH: /home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             envFrom: &envFrom
               - secretRef:
@@ -82,14 +87,18 @@ spec:
                 # a container runtime; gVisor isn't detected, so it fell back to
                 # loopback (127.0.0.1) and was unreachable by Envoy + the kubelet
                 # probe (CrashLoop). gateway.bind="lan" resolves to 0.0.0.0
-                # unconditionally. Idempotent; runs every start so it self-heals
-                # if `openclaw setup` rewrites the config.
+                # unconditionally. Also allowlist the Control UI browser origin:
+                # the dashboard opens a WebSocket and the gateway rejects it unless
+                # the page origin is in gateway.controlUi.allowedOrigins (exact
+                # origin, no wildcards). Idempotent; runs every start so it
+                # self-heals if `openclaw setup` rewrites the config.
                 node -e '
                   const fs = require("fs"), f = process.env.HOME + "/.openclaw/openclaw.json";
                   const c = JSON.parse(fs.readFileSync(f, "utf8"));
                   c.gateway = Object.assign({}, c.gateway, { bind: "lan" });
+                  c.gateway.controlUi = Object.assign({}, c.gateway.controlUi, { allowedOrigins: [process.env.CONTROL_UI_ORIGIN] });
                   fs.writeFileSync(f, JSON.stringify(c, null, 2));
-                  console.log("openclaw gateway.bind forced to lan (0.0.0.0)");
+                  console.log("openclaw gateway.bind=lan, controlUi.allowedOrigins=[" + process.env.CONTROL_UI_ORIGIN + "]");
                 '
             securityContext: &sc
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Problem

After the bind fix, the OpenClaw Control UI loads and SSO passes, but the dashboard shows **"Browser origin not allowed — The Gateway rejected this page origin before accepting the Control UI connection."**

The Control UI opens a WebSocket to the gateway, which validates the browser `Origin` header against `gateway.controlUi.allowedOrigins`. That list is empty, so the connection is refused.

## Fix

Extend the `setup` initContainer config patch to also write the served origin into `gateway.controlUi.allowedOrigins`:

- Origin `https://openclaw.${SECRET_DOMAIN}` is passed via a new `CONTROL_UI_ORIGIN` env (so Flux substitutes the domain, same as the route hostname).
- The node patch sets `gateway.controlUi.allowedOrigins: [<origin>]` alongside the existing `gateway.bind: "lan"`. Idempotent, self-heals on every start.

Merging recovers it automatically: Flux reconcile → new pod → init patches config → WebSocket origin check passes → dashboard connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)