### PR TITLE
feat(ai-sandbox): wire openclaw agent to in-cluster Qwen (llmkube)

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/helmrelease.yaml
@@ -90,15 +90,42 @@ spec:
                 # unconditionally. Also allowlist the Control UI browser origin:
                 # the dashboard opens a WebSocket and the gateway rejects it unless
                 # the page origin is in gateway.controlUi.allowedOrigins (exact
-                # origin, no wildcards). Idempotent; runs every start so it
+                # origin, no wildcards). Also wire the agent to the in-cluster
+                # Qwen model (llmkube InferenceService qwen3-6-27b-mtp in the `ai`
+                # namespace, OpenAI-compatible llama.cpp at :8080/v1 — reachable
+                # per the egress policy). Registered as provider "local" (mode
+                # merge keeps the bundled catalogs) and set as the agent's primary
+                # model, replacing the default external openai/gpt-5.5. The dummy
+                # apiKey satisfies credential resolution; llama.cpp ignores it (no
+                # --api-key on the server). Idempotent; runs every start so it
                 # self-heals if `openclaw setup` rewrites the config.
                 node -e '
                   const fs = require("fs"), f = process.env.HOME + "/.openclaw/openclaw.json";
                   const c = JSON.parse(fs.readFileSync(f, "utf8"));
                   c.gateway = Object.assign({}, c.gateway, { bind: "lan" });
                   c.gateway.controlUi = Object.assign({}, c.gateway.controlUi, { allowedOrigins: [process.env.CONTROL_UI_ORIGIN] });
+                  c.models = Object.assign({}, c.models, { mode: "merge" });
+                  c.models.providers = Object.assign({}, c.models.providers, {
+                    local: {
+                      baseUrl: "http://qwen3-6-27b-mtp.ai:8080/v1",
+                      api: "openai-completions",
+                      apiKey: "sk-local",
+                      models: [{
+                        id: "qwen3-6-27b-mtp",
+                        name: "Qwen3.6 27B MTP (local)",
+                        reasoning: true,
+                        input: ["text"],
+                        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                        contextWindow: 262144,
+                        maxTokens: 8192,
+                        compat: { thinkingFormat: "qwen" }
+                      }]
+                    }
+                  });
+                  c.agents = Object.assign({}, c.agents);
+                  c.agents.defaults = Object.assign({}, c.agents.defaults, { model: { primary: "local/qwen3-27b-mtp" } });
                   fs.writeFileSync(f, JSON.stringify(c, null, 2));
-                  console.log("openclaw gateway.bind=lan, controlUi.allowedOrigins=[" + process.env.CONTROL_UI_ORIGIN + "]");
+                  console.log("openclaw config: bind=lan, controlUi origin set, agent model=local/qwen3-27b-mtp");
                 '
             securityContext: &sc
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Point OpenClaw's agent at the self-hosted Qwen model instead of the default external `openai/gpt-5.5`.

## What

Extends the `setup` initContainer config patch (same declarative, idempotent, self-healing mechanism as the `bind`/`controlUi` fixes) to write into `openclaw.json`:

- **`models.providers.local`** (`mode: merge`, so bundled catalogs stay): `baseUrl: http://qwen3-6-27b-mtp.ai:8080/v1`, `api: openai-completions`, one model `qwen3-27b-mtp` (`contextWindow: 262144`, `compat.thinkingFormat: qwen`). Target is the llmkube `qwen3-6-27b-mtp` InferenceService (OpenAI-compatible llama.cpp), already reachable via the `ai:8080` egress rule.
- **`agents.defaults.model.primary: "local/qwen3-27b-mtp"`** — makes Qwen the agent's model.
- Dummy `apiKey` (`sk-local`) satisfies OpenClaw's credential resolution; the llama.cpp server has no `--api-key` and ignores it.

Config schema verified against OpenClaw source `v2026.6.8` (`types.models.ts`, `types.agent-defaults.ts`, `types.secrets.ts`). The embedded patch was executed against a sample `openclaw.json` to confirm it produces valid merged config; `kustomize build` passes.

## Notes

- No new egress needed — `qwen3-6-27b-mtp.ai:8080` is covered by the existing in-cluster LLM rule.
- Self-hosted end-to-end: no dependency on external providers (no OpenAI key needed).
- Pushed via the GitHub API (SSH git was temporarily unavailable from the workstation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)