### PR TITLE
fix(volsync): correct restore file ownership (per-app mover UID/GID, no shared default)

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
@@ -27,6 +27,11 @@ spec:
       OIDC_APP_NAME: OpenClaw
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/openclaw.svg"
       VOLSYNC_CAPACITY: 10Gi
+      # Restore mover writes files owned by its own uid (non-root restic can't
+      # chown). openclaw chmods its own state dir on startup, which needs real
+      # ownership (fsGroup only grants group access) — so match the app's uid.
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -14,6 +14,20 @@ spec:
       main:
         annotations:
           reloader.stakater.com/auto: "true"
+        pod:
+          # Pin to the chart's default runtime uid/gid so VOLSYNC_UID/GID=65532
+          # (ks.yaml) stays anchored to a real in-repo value and can't drift on a
+          # chart bump. fsGroup remaps restored data on mount as a fallback.
+          # NOTE: this must live under each controller's pod.securityContext, not
+          # defaultPodOptions — the chart ships per-controller securityContext and
+          # defaultPodOptionsStrategy=overwrite, so a defaultPodOptions value would
+          # be silently dropped.
+          securityContext: &podSecurityContext
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           main:
             env:
@@ -40,6 +54,12 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
+      # The chart's fsck cronjob is disabled by default (not rendered today).
+      # Pre-pin it to the same uid/gid so that if it's ever enabled — it can
+      # touch the RWO PVC — it can't drift from the main pod or restore mover.
+      fsck:
+        pod:
+          securityContext: *podSecurityContext
     persistence:
       data:
         existingClaim: *app

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "65532"
+      VOLSYNC_GID: "65532"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/documents/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/documents/paperless/app/helmrelease.yaml
@@ -19,6 +19,8 @@ spec:
           securityContext:
             runAsUser: 4001
             runAsGroup: 4001
+            fsGroup: 4001
+            fsGroupChangePolicy: OnRootMismatch
             supplementalGroups: [5000]
 
         containers:

--- a/kubernetes/apps/documents/paperless/ks.yaml
+++ b/kubernetes/apps/documents/paperless/ks.yaml
@@ -24,6 +24,8 @@ spec:
       OIDC_PKCE_ENABLED: "true"
       OIDC_CALLBACK_PATH: /accounts/oidc/pocket-id/login/callback/
       VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_UID: "4001"
+      VOLSYNC_GID: "4001"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/finance/actual/ks.yaml
+++ b/kubernetes/apps/finance/actual/ks.yaml
@@ -19,6 +19,8 @@ spec:
       OIDC_APP_NAME: Actual
       OIDC_CALLBACK_PATH: /openid/callback
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/maker/orcaslicer/ks.yaml
+++ b/kubernetes/apps/maker/orcaslicer/ks.yaml
@@ -20,6 +20,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/orca-slicer.svg"
       OIDC_APP_NAME: OrcaSlicer
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "911"
+      VOLSYNC_GID: "911"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/bazarr.svg"
       OIDC_APP_NAME: Bazarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "4009"
+      VOLSYNC_GID: "4009"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -23,6 +23,8 @@ spec:
             runAsNonRoot: true
             runAsUser: 4006
             runAsGroup: 4006
+            fsGroup: 4006
+            fsGroupChangePolicy: OnRootMismatch
             supplementalGroups: [5001]
 
         containers:

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -16,6 +16,8 @@ spec:
       OIDC_APP_NAME: Jellyfin
       OIDC_CALLBACK_PATH: /sso/OID/redirect/PocketID
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "4006"
+      VOLSYNC_GID: "4006"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -14,6 +14,13 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           *app :
             image:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/prowlarr.svg"
       OIDC_APP_NAME: Prowlarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "65534"
+      VOLSYNC_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -21,6 +21,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/qbittorrent.svg"
       OIDC_APP_NAME: qBittorrent
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "4005"
+      VOLSYNC_GID: "4005"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/radarr.svg"
       OIDC_APP_NAME: Radarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "4010"
+      VOLSYNC_GID: "4010"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -15,6 +15,8 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -20,6 +20,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/sabnzbd.svg"
       OIDC_APP_NAME: SABnzbd
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "4008"
+      VOLSYNC_GID: "4008"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -15,6 +15,8 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/sonarr.svg"
       OIDC_APP_NAME: Sonarr
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "4007"
+      VOLSYNC_GID: "4007"
     substituteFrom:
     - name: cluster-secrets
       kind: Secret

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -43,6 +43,8 @@ spec:
       OIDC_PKCE_ENABLED: "true"
       OIDC_CALLBACK_PATH: /login/generic_oauth
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -41,6 +41,15 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 50Gi
+      # VMSingle still runs as root (no securityContext today), but the mover is
+      # pre-pinned to 65534 — the uid the VM stack uses for its other workloads
+      # (node-exporter, kube-state-metrics) and what the operator's
+      # useStrictSecurity assigns to managed pods. Harmless now (root reads/writes
+      # data the mover wrote under any uid) and forward-compatible: a later switch
+      # to non-root needs no re-chown of restored data.
+      # TODO: enable useStrictSecurity / set the VMSingle securityContext to 65534.
+      VOLSYNC_UID: "65534"
+      VOLSYNC_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
@@ -69,6 +78,14 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
+      # VLSingle still runs as root (no securityContext today), but the mover is
+      # pre-pinned to 65534 — the VM stack's non-root uid (what the operator's
+      # useStrictSecurity assigns to managed pods). Harmless now (root reads/writes
+      # data the mover wrote under any uid) and forward-compatible: a later switch
+      # to non-root needs no re-chown of restored data.
+      # TODO: enable useStrictSecurity / set the VLSingle securityContext to 65534.
+      VOLSYNC_UID: "65534"
+      VOLSYNC_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/social/continuwuity/ks.yaml
+++ b/kubernetes/apps/social/continuwuity/ks.yaml
@@ -15,6 +15,8 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "1001"
+      VOLSYNC_GID: "1001"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -22,9 +22,13 @@ spec:
     copyMethod: Snapshot
     enableFileDeletion: true
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_UID:=4003}
-      runAsGroup: ${VOLSYNC_GID:=4003}
-      fsGroup: ${VOLSYNC_GID:=4003}
+      # No default: every consumer must set VOLSYNC_UID/GID to its app's runtime
+      # uid/gid so the mover writes restorable ownership. A missing value renders
+      # an empty runAsUser and fails the build loudly instead of silently
+      # defaulting to a uid no app runs as.
+      runAsUser: ${VOLSYNC_UID}
+      runAsGroup: ${VOLSYNC_GID}
+      fsGroup: ${VOLSYNC_GID}
     repository: ${APP}-volsync-secret
     storageClassName: ${VOLSYNC_STORAGECLASS:=openebs-zfspv}
     volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=openebs-zfs-snapshot}

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -17,9 +17,13 @@ spec:
     cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
     copyMethod: Snapshot
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_UID:=4003}
-      runAsGroup: ${VOLSYNC_GID:=4003}
-      fsGroup: ${VOLSYNC_GID:=4003}
+      # No default: every consumer must set VOLSYNC_UID/GID to its app's runtime
+      # uid/gid so the mover writes restorable ownership. A missing value renders
+      # an empty runAsUser and fails the build loudly instead of silently
+      # defaulting to a uid no app runs as.
+      runAsUser: ${VOLSYNC_UID}
+      runAsGroup: ${VOLSYNC_GID}
+      fsGroup: ${VOLSYNC_GID}
     pruneIntervalDays: 14
     repository: ${APP}-volsync-secret
     retain:


### PR DESCRIPTION
## Problem

The VolSync restic mover runs **non-root**, so it can't `chown` — every restored file lands owned by the mover's own uid. With the old shared default of `4003` (a uid no app runs as), restored data is unreadable/unwritable by the app. `fsGroup` only remaps the *group* (granting read/write), so it's **not sufficient** for apps that `chmod`/`chown` their own files on startup: those get a Ready-but-degraded pod spewing `EPERM ... chmod`. The breakage is **silent until a restore**, i.e. exactly at the DR moment — so we fix it correct-by-construction rather than reactively.

Reproduced on **openclaw** (full nuke → restore): restored tree owned `4003`, openclaw's startup `chmod` of `.openclaw/state` failed with EPERM, breaking its plugin state DB / cron / delivery recovery while the pod still reported Ready.

## Fix

Set the mover uid = each app's runtime uid so restored files are owned correctly and the app can `chmod`/read/write its own data. **Every** volsync consumer now pins `VOLSYNC_UID`/`VOLSYNC_GID`, and the shared `:=4003` default is **removed** from the component — a consumer that forgets to set them now **fails the build loudly** (empty `runAsUser`) instead of silently restoring under a uid no app runs as.

This is enabled by a prerequisite NFS change (already applied on TrueNAS): the repo export `storage.lan:/mnt/tank/backup/volsync` uses **`mapall=4003:4003`**, which pins the mover's *NFS* identity to `4003` regardless of its in-cluster uid — so per-app uids don't break backup writes to the shared repo.

### Commits
- `d68401f0` — add `fsGroup` + `fsGroupChangePolicy: OnRootMismatch` to paperless (4001), jellyfin (4006), prowlarr (65534, also `runAsNonRoot` to match the other *arr apps)
- `c56d1046` — `VOLSYNC_UID/GID=1000` for openclaw (validated end-to-end via nuke/restore)
- `98a3a350` — `VOLSYNC_UID/GID` = runtime uid for the remaining non-root volsync apps
- `e4d253d9` — drop the `:=4003` component default (fail loud on missing); pin `vmks`/`victoria-logs`; anchor memini's uid in-repo

### UID assignments

| App | UID | Notes |
| --- | --- | --- |
| openclaw | 1000 | validated via nuke/restore |
| grafana | 1000 | |
| continuwuity | 1001 | |
| memini | 65532 | now also anchored in-repo (see Notes) |
| orcaslicer | 911 | LSIO |
| actual | 1000 | |
| paperless | 4001 | |
| bazarr | 4009 | |
| jellyfin | 4006 | |
| prowlarr | 65534 | |
| qbittorrent | 4005 | |
| sabnzbd | 4008 | |
| radarr | 4010 | |
| seerr | 1000 | |
| recyclarr | 1000 | |
| sonarr | 4007 | |
| vmks | 65534 | root today, pre-pinned (see Notes) |
| victoria-logs | 65534 | root today, pre-pinned (see Notes) |

### Notes
- **vmks / victoria-logs** run as **root** today (VMSingle/VLSingle have no securityContext), so the mover uid is irrelevant to them now (root reads any ownership). They're pre-pinned to **`65534`** — the uid the VM stack already uses for node-exporter/kube-state-metrics and that the operator's `useStrictSecurity` assigns to managed pods — so a later non-root hardening needs no re-chown of restored data. (In-file `TODO` to enable `useStrictSecurity` / set the CR securityContext.)
- **memini** uid/gid `65532` is now anchored in-repo (`controllers.main` + `fsck` `pod.securityContext`) instead of relying on the upstream chart default, so it can't drift on a chart bump. It must live under each controller's `pod.securityContext`, **not** `defaultPodOptions` — the chart ships per-controller securityContext with `defaultPodOptionsStrategy: overwrite`, which silently drops a `defaultPodOptions` value (verified by rendering).
- **qbittorrent** uid (`4005`) ≠ its `fsGroup` (`5001`): `5001` is the media-share group; `4005` owns `/config` and is what the restored files must be owned by. Matched the owner.
- **orcaslicer** (LSIO) self-heals via its root s6-init re-chowning `/config`, but `911` is set for uniformity rather than relying on that.

## Testing
- openclaw: full nuke + restore → restored tree owned `1000:1000`, `chmod` succeeds, logs clean (no EPERM), all plugins load. ✅
- `flate test` (full cluster) passes 154/154 with the default removed and all consumers pinned. ✅
- Others: correct-by-construction (mover uid == app uid); not individually nuke-tested.
