### PR TITLE
refactor(llmkube): switch to OCI chart from GHCR

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -4,15 +4,10 @@ kind: HelmRelease
 metadata:
   name: &app llmkube
 spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
   interval: 1h
-  chart:
-    spec:
-      chart: *app
-      version: 0.8.11
-      sourceRef:
-        kind: HelmRepository
-        name: *app
-      interval: 1h
   values:
     crds:
       # CRDs are rendered as templated resources gated on this value (not the

--- a/kubernetes/apps/ai/llmkube/app/helmrepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrepository.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: llmkube
-spec:
-  interval: 1h
-  url: https://defilantech.github.io/LLMKube

--- a/kubernetes/apps/ai/llmkube/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/app/kustomization.yaml
@@ -2,5 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helmrepository.yaml
+  - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.8.11
+  url: oci://ghcr.io/defilantech/charts/llmkube


### PR DESCRIPTION
LLMKube v0.8.11 publishes its Helm chart as an OCI artifact to GHCR (oci://ghcr.io/defilantech/charts). Replace the HTTP HelmRepository source with an OCIRepository and reference it via chartRef.