### PR TITLE
fix(games): unblock fenrir sessions (PSA + Flux envsubst)

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/apps.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/apps.yaml
@@ -7,6 +7,10 @@ apiVersion: direwolf.games-on-whales.github.io/v1alpha1
 kind: App
 metadata:
   name: firefox
+  annotations:
+    # The container command uses shell ${PULSE_SINK}; Flux postBuild envsubst
+    # would blank it. The App needs no Flux substitution, so exclude it.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   appAssetWebP: UklGRhwBAABXRUJQVlA4IBABAADQHACdASosAZABPm02mUmkIqKhICgAgA2JaW7hd2EbQAnsA99snIe+2Yy09snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPekAAD+/9O4f/1K366KRn9B8NO3tyIAAAAAAAAAAAAAAAAAA
   id: 1

--- a/kubernetes/apps/games/games-on-whales/app/wolf-entrypoint.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/wolf-entrypoint.yaml
@@ -9,6 +9,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: wolf-root-entrypoint
+  annotations:
+    # The ks.yaml postBuild envsubst would otherwise blank the script's
+    # ${init_script} refs (undefined Flux var -> ""), turning the cont-init.d
+    # loop into `source ""` and crash-looping wolf. This script needs no Flux
+    # substitution, so exclude it.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   entrypoint.sh: |
     #!/usr/bin/env bash

--- a/kubernetes/apps/games/namespace.yaml
+++ b/kubernetes/apps/games/namespace.yaml
@@ -6,4 +6,7 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
+    # Wolf session pods need NET_ADMIN (fake-udev) + run as root, which the
+    # cluster-default baseline PSS rejects. Match media/openebs-system.
+    pod-security.kubernetes.io/enforce: privileged
     resource.kubernetes.io/admin-access: "true"


### PR DESCRIPTION
Follow-up to #1082. Three issues blocked wolf session pods from ever starting; found while bringing up the first Moonlight session.

## 1. Pod Security — `NET_ADMIN` rejected
Session pods set `NET_ADMIN` on the wolf-agent sidecar (fake-udev). The `games` namespace had no PSA label, so it inherited the cluster-default `baseline`, which forbids added capabilities:
```
pods "alex-firefox-..." is forbidden: violates PodSecurity "baseline:latest":
non-default capabilities (container "wolf-agent" must not include "NET_ADMIN" ...)
```
→ `enforce: privileged` on the namespace, matching `media`/`openebs-system`.

## 2. Flux envsubst blanked the wolf entrypoint (the crash)
`ks.yaml` runs `postBuild.substitute`/`substituteFrom`, and Flux envsubst rewrites **braced** `${...}` refs across all rendered manifests — including the `wolf-root-entrypoint` ConfigMap's shell script. `${init_script}` is not a Flux var, so it became empty. Rendered in-cluster:
```bash
for init_script in /etc/cont-init.d/*.sh; do
  gow_log "[ : executing... ]"
  source ""          # <-- crash: set -e -> exit 1
done
```
Wolf crash-looped → no wolf session ID → operator GC'd the session after 60s → repeat.
→ `kustomize.toolkit.fluxcd.io/substitute: disabled` on the ConfigMap.

## 3. Same envsubst blanked `${PULSE_SINK}` in the firefox App command
Latent (masked by #2): `PULSE_SOURCE="${PULSE_SINK}.monitor"` rendered as `.monitor`.
→ `substitute: disabled` on the firefox App.

## Verified live
- PSA fix let session pods schedule on talos1.
- **GPU preemption worked**: launching Firefox preempted the negative-priority llmkube qwen pod and freed both GPUs (qwen parked Pending, as designed).
- Confirmed the envsubst clobber directly in the rendered in-cluster ConfigMap (`source ""`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)