### PR TITLE
fix(games): point wolf at renderD128 (the real NVIDIA node)

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/apps.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/apps.yaml
@@ -21,12 +21,12 @@ spec:
   # is node-local on talos1) later if profile persistence is wanted.
   wolfConfig:
     runtimeVariables:
-      # The NVIDIA container toolkit injects the GPU's DRM node with its host
-      # numbering; on a CDI-injected dGPU the in-container node is typically
-      # renderD129 (renderD128 may not exist inside the container). With the
-      # wrong node wolf can't detect the GPU vendor and silently falls back to
-      # software x264 encoding. VERIFY on talos1 (see README).
-      renderNode: /dev/dri/renderD129
+      # CDI injects exactly one NVIDIA DRM render node into the wolf container.
+      # On talos1 it lands at renderD128 (verified: DRIVER=nvidia, RTX 3090 Ti;
+      # renderD129 does NOT exist in-container). Pointing wolf at the wrong node
+      # makes it skip every HW encoder ("not a NVIDIA GPU") -> no HEVC -> the
+      # Moonlight client gets "No video received".
+      renderNode: /dev/dri/renderD128
   template:
     spec:
       containers:
@@ -78,7 +78,7 @@ spec:
   # No volumeClaimTemplate -> the operator uses an ephemeral emptyDir.
   wolfConfig:
     runtimeVariables:
-      renderNode: /dev/dri/renderD129
+      renderNode: /dev/dri/renderD128 # see firefox note above
     startAudioServer: false
     startVirtualCompositor: false
     audio:


### PR DESCRIPTION
Follow-up to #1096. With PSA + envsubst fixed, the session pod runs 3/3, RTSP/control negotiates, and the per-session RTP Service correctly shares the LB IP — but Moonlight shows **"No video received from host"**.

## Root cause
Wolf logs at stream start:
```
Skipping NVIDIA encoder, not a NVIDIA GPU (3)
Skipping VAAPI encoder, not an Intel or AMD GPU (3)
Skipping QUICKSYNC encoder, not an Intel GPU (3)
```
It skips every hardware encoder, so no HEVC is produced. Inspected inside the wolf container:
```
/dev/dri: card0, renderD128        # renderD129 does NOT exist
renderD128 -> DRIVER=nvidia, PCI 10DE:2203 (RTX 3090 Ti)
nvidia-smi -L -> GPU 0: NVIDIA GeForce RTX 3090 Ti
```
The config pointed wolf at `renderNode: /dev/dri/renderD129`. CDI injects exactly one NVIDIA render node and on talos1 it's **renderD128**. Wrong node → wolf can't detect the GPU vendor → no encoder → no video.

→ Set `renderNode: /dev/dri/renderD128` for both the firefox and testball Apps.

(Also confirms the earlier `NVIDIA_VISIBLE_DEVICES=all` concern was moot — CDI overrides it to `void` and injects a single GPU.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)