### PR TITLE
fix(games): preserve client source IP for wolf streaming (ETP Local)

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/helmrelease.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/helmrelease.yaml
@@ -47,6 +47,15 @@ spec:
               digest: sha256:e8b7cf17ea1bab75c1cec1889a1166ebb3da4c5f0972ae8a7d7cc8dc2571fef0
     service:
       app:
+        # Preserve the client source IP. With the default Cluster policy,
+        # Cilium SNATs the Moonlight client to a node IP, so the proxy reports
+        # the wrong client_ip to the operator and wolf streams video to a node
+        # instead of the client ("No video received"). Local keeps the real
+        # client IP and announces the shared VIP only from the node running the
+        # endpoint (talos1, where all GPU pods are pinned). The operator-created
+        # per-session RTP Services need the same fix — applied via the
+        # MutatingAdmissionPolicy in ./session-service-policy.yaml.
+        externalTrafficPolicy: Local
         annotations:
           # Pin the shared Moonlight LB IP from the Cilium pool
           # (10.0.42.128-254). Per-session RTP Services inherit it via the

--- a/kubernetes/apps/games/games-on-whales/app/kustomization.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./wolf-entrypoint.yaml
   - ./user.yaml
   - ./apps.yaml
+  - ./session-service-policy.yaml

--- a/kubernetes/apps/games/games-on-whales/app/session-service-policy.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/session-service-policy.yaml
@@ -1,0 +1,49 @@
+---
+# The direwolf-operator creates one LoadBalancer Service per streaming session
+# (named <user>-<app>-<id>-rtp) and does not expose externalTrafficPolicy on it.
+# Left at the default Cluster policy, Cilium SNATs the Moonlight client to a node
+# IP, so wolf streams the RTP video to a node instead of the real client and the
+# client reports "No video received". This policy forces externalTrafficPolicy:
+# Local on those Services so the client source IP/port is preserved (the proxy
+# Service gets the same setting directly via the HelmRelease).
+#
+# Remove this once the operator can set the policy/annotations on the Services it
+# generates (tracked upstream); see games-on-whales/games README + repo issue.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: direwolf-session-svc-etp-local
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["services"]
+  matchConditions:
+    - name: is-direwolf-session-rtp-lb
+      expression: >-
+        object.spec.type == 'LoadBalancer' &&
+        object.metadata.name.endsWith('-rtp')
+  reinvocationPolicy: Never
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: >-
+          Object{
+            spec: Object.spec{
+              externalTrafficPolicy: "Local"
+            }
+          }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: direwolf-session-svc-etp-local
+spec:
+  policyName: direwolf-session-svc-etp-local
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: games


### PR DESCRIPTION
Follow-up to #1098. With the render node fixed, the session pod runs, the GPU is detected, and RTSP/control negotiates — but Moonlight still shows **"No video received from host"**.

## Root cause (verified)
Cilium runs in **SNAT** mode and the Services use the default `externalTrafficPolicy: Cluster`, so the Moonlight client's source IP is masqueraded to a **node IP**. Wolf logged the client as `client_ip: 10.0.42.3` — that's **talos0's node IP**, not the real client. Control/RTSP works (client-initiated, conntrack handles the return), but **server-initiated video RTP is sent to the node and never reaches the client**. This is independent of HW vs SW encode (720p/x264 software also failed).

## Fix — `externalTrafficPolicy: Local`
- **Proxy Service** (`direwolf`): set via the HelmRelease (`service.app.externalTrafficPolicy`, supported by bjw-s common).
- **Per-session RTP Services**: the direwolf-operator creates these dynamically and doesn't expose the field, so a **`MutatingAdmissionPolicy`** (in-tree, `admissionregistration.k8s.io/v1` on k8s 1.36) forces `externalTrafficPolicy: Local` on `games` LoadBalancer Services named `*-rtp`.

All GPU pods are pinned to talos1, so the shared VIP announces from a single node and ETP Local is consistent across the IP-sharers.

## Validation
- `kustomize build` OK
- `kubectl apply --dry-run=server` on the policy (CEL compiles)

## Notes / follow-ups
- One residual uncertainty: ETP Local preserves the **inbound** client IP; outbound video still egresses masqueraded to the node IP (not the VIP). Wolf/Moonlight's RTP hole-punch model normally accepts video regardless of source IP, so this should be sufficient — if not, the DSR approach (tracked separately) gives a VIP-sourced return path.
- The MutatingAdmissionPolicy is a workaround; the proper fix is upstream operator support for setting Service policy/annotations (to be filed).
- NVENC hardware encoding is a **separate, secondary** issue (wolf's CUDA-11 image vs the host 595 driver) and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)