### PR TITLE
feat(games): preserve Moonlight client source IP via Cilium DSR

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/helmrelease.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/helmrelease.yaml
@@ -53,3 +53,12 @@ spec:
           # sharing-key above.
           lbipam.cilium.io/sharing-key: direwolf
           lbipam.cilium.io/ips: "10.0.42.135"
+          # Preserve the Moonlight client source IP. The cluster default is
+          # SNAT, which masquerades the client to a node IP, so the operator
+          # reports the wrong client_ip and wolf streams RTP video to a node
+          # ("No video received"). DSR keeps the real client IP without changing
+          # externalTrafficPolicy, so Cilium LB-IPAM can still share this VIP
+          # with the per-session RTP Services (which get the same annotation via
+          # ./session-service-policy.yaml). Requires bpf.lbModeAnnotation on the
+          # Cilium HelmRelease.
+          service.cilium.io/forwarding-mode: dsr

--- a/kubernetes/apps/games/games-on-whales/app/kustomization.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./wolf-entrypoint.yaml
   - ./user.yaml
   - ./apps.yaml
+  - ./session-service-policy.yaml

--- a/kubernetes/apps/games/games-on-whales/app/session-service-policy.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/session-service-policy.yaml
@@ -1,0 +1,60 @@
+---
+# The direwolf-operator creates one LoadBalancer Service per streaming session
+# (named <user>-<app>-<id>-rtp) and exposes no way to configure it. Left at the
+# cluster-default SNAT forwarding mode, Cilium masquerades the Moonlight client
+# to a node IP, so wolf streams the RTP video to a node instead of the real
+# client and Moonlight reports "No video received". Control/RTSP works
+# (client-initiated); only the server-initiated video breaks.
+#
+# This policy injects service.cilium.io/forwarding-mode: dsr on those Services
+# at creation time so Cilium preserves the client source IP. DSR is used instead
+# of externalTrafficPolicy: Local because Local makes Cilium LB-IPAM refuse to
+# share the proxy's VIP with the session Services (RTSP then times out); DSR
+# keeps externalTrafficPolicy: Cluster, so the shared VIP is preserved. The
+# proxy Service gets the same annotation directly via the HelmRelease, and the
+# global opt-in lives on the Cilium HelmRelease (bpf.lbModeAnnotation: true).
+#
+# Remove this once the operator can set annotations on the Services it generates
+# (tracked upstream); see the repo README.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: direwolf-session-svc-dsr
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["services"]
+  matchConditions:
+    - name: is-direwolf-session-rtp-lb
+      expression: >-
+        object.spec.type == 'LoadBalancer' &&
+        object.metadata.name.endsWith('-rtp')
+  reinvocationPolicy: Never
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        # forwarding-mode must be set at Service creation time and not changed
+        # during its lifetime, so this policy only matches CREATE.
+        expression: >-
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "service.cilium.io/forwarding-mode": "dsr"
+              }
+            }
+          }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: direwolf-session-svc-dsr
+spec:
+  policyName: direwolf-session-svc-dsr
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: games

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
       masquerade: true
       # Ref: https://github.com/siderolabs/talos/issues/10002
       hostLegacyRouting: true
+      # Allow per-Service forwarding-mode overrides via the
+      # service.cilium.io/forwarding-mode annotation. The cluster default stays
+      # SNAT (loadBalancer.mode below); only the games/direwolf Moonlight
+      # Services opt into DSR so wolf sees the real client source IP and streams
+      # RTP video to the client instead of a node. (games-on-whales bring-up)
+      lbModeAnnotation: true
     cni:
       # Required for pairing with Multus CNI
       exclusive: false
@@ -41,6 +47,11 @@ spec:
     loadBalancer:
       algorithm: maglev
       mode: snat
+      # Dispatch method for Services that opt into DSR via annotation (see
+      # bpf.lbModeAnnotation). geneve encapsulates the original tuple so it
+      # survives any L2 switch that would mangle IPv4-option (opt) dispatch;
+      # works with routingMode: native.
+      dsrDispatch: geneve
     localRedirectPolicy: true
     operator:
       dashboards:


### PR DESCRIPTION
## Why

The fenrir/Games-on-Whales Wolf streaming path needs the **real client source IP**. Under the cluster-default SNAT, Cilium masquerades the Moonlight client to a node IP, so the operator reports the wrong `client_ip` and wolf streams RTP video to a node → Moonlight shows **"No video received"**. Control/RTSP works (client-initiated); only the server-initiated video breaks.

This is the correct fix for the source-IP blocker tracked in #1100. It replaces the `externalTrafficPolicy: Local` approach (reverted in #1099/#1101) — `Local` made Cilium LB-IPAM refuse to share the proxy VIP with the per-session RTP Services, breaking RTSP ("Error 60").

## What

| Change | File |
|---|---|
| `bpf.lbModeAnnotation: true` + `loadBalancer.dsrDispatch: geneve` | `cilium/app/helmrelease.yaml` |
| Proxy Service `service.cilium.io/forwarding-mode: dsr` | `games-on-whales/app/helmrelease.yaml` |
| Recreate MutatingAdmissionPolicy injecting the DSR annotation on `*-rtp` Services at CREATE | `session-service-policy.yaml` |

- **Global LB mode stays `snat`** — only the 3 annotated direwolf Services use DSR. No behavior change for any other service.
- `forwarding-mode` is a **datapath** setting, independent of LB-IPAM `sharing-key`, so the proxy + session Services keep sharing VIP `10.0.42.135` (unlike ETP:Local).
- `geneve` dispatch survives any L2 switch that would mangle `opt` (IPv4-option) dispatch and works with `routingMode: native`.

## ⚠️ Blast radius

Merging reconciles the Cilium HelmRelease, which **recompiles the BPF datapath and rolls the cilium-agent DaemonSet on both nodes** (`rollOutCiliumPods: true`). Brief per-node network blip, cluster-wide. The DSR *behavior* is scoped to the annotated services only.

Refs #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)