### PR TITLE
fix(cilium): DSR dispatch geneve -> opt (fixes agent crash-loop)

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -48,10 +48,13 @@ spec:
       algorithm: maglev
       mode: snat
       # Dispatch method for Services that opt into DSR via annotation (see
-      # bpf.lbModeAnnotation). geneve encapsulates the original tuple so it
-      # survives any L2 switch that would mangle IPv4-option (opt) dispatch;
-      # works with routingMode: native.
-      dsrDispatch: geneve
+      # bpf.lbModeAnnotation). opt embeds the original tuple in an IPv4 option
+      # and is the only dispatch compatible with routingMode: native + the
+      # default snat NodePort mode. (geneve dispatch requires the geneve tunnel
+      # protocol, which we don't run, and crash-loops the agent here. The two
+      # nodes are L2-adjacent through an L2 switch that forwards by MAC and does
+      # not strip IPv4 options, so opt is safe on this LAN.)
+      dsrDispatch: opt
     localRedirectPolicy: true
     operator:
       dashboards:


### PR DESCRIPTION
## 🚨 Active incident — merge ASAP

After #1102 merged, **both cilium agents are in CrashLoopBackOff** cluster-wide:

```
level=fatal ... Node Port "snat" mode with "geneve" dispatch requires geneve tunnel protocol.
```

`loadBalancer.dsrDispatch: geneve` requires the geneve **tunnel** protocol, which this cluster does not run (`routingMode: native`). Cilium validates this at startup and refuses to boot.

## Fix

`dsrDispatch: geneve` → **`opt`**. `opt` embeds the original tuple in an IPv4 option and is the dispatch compatible with native routing + default snat NodePort mode. The two Talos nodes are L2-adjacent through an L2 switch (forwards by MAC, doesn't strip IPv4 options), so `opt` is safe on this LAN.

Config flags `bpf.lbModeAnnotation: true` and the per-service `service.cilium.io/forwarding-mode: dsr` annotations from #1102 are unchanged and correct — only the dispatch value was wrong.

Fixes the regression introduced in #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)