### PR TITLE
feat(games): allocate both GPUs to wolf for a deterministic render node

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/apps.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/apps.yaml
@@ -21,11 +21,11 @@ spec:
   # is node-local on talos1) later if profile persistence is wanted.
   wolfConfig:
     runtimeVariables:
-      # CDI injects exactly one NVIDIA DRM render node into the wolf container.
-      # On talos1 it lands at renderD128 (verified: DRIVER=nvidia, RTX 3090 Ti;
-      # renderD129 does NOT exist in-container). Pointing wolf at the wrong node
-      # makes it skip every HW encoder ("not a NVIDIA GPU") -> no HEVC -> the
-      # Moonlight client gets "No video received".
+      # renderD128 = RTX 3090 Ti (01:00.0); renderD129 = RTX 3070 (0f:00.0).
+      # The wolf sidecar requests BOTH GPUs (see user.yaml), so CDI injects both
+      # render nodes at their host numbering and renderD128 is always present.
+      # (With a single GPU request the scheduler picks either card, so this node
+      # would be absent ~half the time and wolf falls back to software x264.)
       renderNode: /dev/dri/renderD128
   template:
     spec:

--- a/kubernetes/apps/games/games-on-whales/app/user.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/user.yaml
@@ -53,11 +53,25 @@ spec:
       # (no generic-device-plugin here). Wolf still encodes video without it;
       # virtual-input/controller hotplug needs /dev/uinput on the node (uinput
       # kernel module + device access) -- a follow-up, see README.
+      #
+      # Request BOTH of talos1's GPUs (node exposes nvidia.com/gpu: 2, no
+      # time-slicing). CDI injects each allocated GPU's DRM render node at its
+      # host numbering, so taking both guarantees BOTH renderD128 (RTX 3090 Ti,
+      # 01:00.0) and renderD129 (RTX 3070, 0f:00.0) are present in the wolf
+      # container. With only one GPU the scheduler picks either card
+      # non-deterministically, so a hardcoded renderNode (renderD128) is absent
+      # ~half the time and wolf silently falls back to software x264. Taking
+      # both makes renderNode: /dev/dri/renderD128 always valid.
+      #
+      # Trade-off: this consumes the whole node, so an App that also needs a GPU
+      # for its own container (e.g. firefox: nvidia.com/gpu 1) can't schedule
+      # alongside (1 + 2 > 2). Test Ball has no app container, so it's fine.
+      # Revisit with GPU time-slicing if concurrent app+wolf GPU use is needed.
       resources:
         requests:
-          nvidia.com/gpu: "1"
+          nvidia.com/gpu: "2"
         limits:
-          nvidia.com/gpu: "1"
+          nvidia.com/gpu: "2"
     wolfAgent:
       volumeMounts:
         - name: udev-data


### PR DESCRIPTION
## Root cause (Test Ball "No video received")

After DSR landed (#1102/#1103), a Test Ball run still failed with "No video received" — but the cause was **not** networking. The proxy and wolf both saw the real client IP `10.0.10.104` (DSR works). The wolf log showed:

```
/dev/dri/renderD128 doesn't exists, automatic vendor recognition failed
Unable to detect GPU vendor, disabling zero copy pipeline.
Using h264 encoder: x264  (Software h264 encoder detected)
Skipping NVIDIA encoder, not a NVIDIA GPU
```

`talos1` exposes `nvidia.com/gpu: 2` (RTX 3090 Ti `01:00.0` + RTX 3070 `0f:00.0`, no time-slicing). CDI injects each allocated GPU's DRM render node at its **host numbering** → renderD128 = 3090 Ti, renderD129 = 3070. With a single `nvidia.com/gpu: 1` request the scheduler picks **either** card non-deterministically, so wolf's hardcoded `renderNode: renderD128` is absent ~half the time → software x264, no NVENC → no video.

This also reconciles the #1098 confusion: renderD128 *is* the 3090 Ti (verified then), but that session happened to get the 3090 Ti; this one got the 3070.

## Fix

Request **both** GPUs on the wolf sidecar (`user.yaml`) so both render nodes are always injected and `renderNode: /dev/dri/renderD128` is always valid. This is the simplest deterministic option and unblocks Test Ball validation (the GBM/NVENC/software-fallback symptoms are all downstream of wolf not finding the GPU; `GBM_BACKENDS_PATH` etc. are already set correctly, matching shrinedogg's working deployment).

## Trade-off

The wolf GPU request lives in the `User` CRD (shared across Apps), so taking both GPUs means an App with its own GPU container (firefox: `nvidia.com/gpu 1`) won't schedule alongside wolf (1 + 2 > 2, no time-slicing). **Test Ball has no app container, so it's unaffected.** Concurrent app+wolf GPU use needs GPU time-slicing — a follow-up.

Refs the games-on-whales bring-up (see docs/fenrir-bringup-handoff.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)