### PR TITLE
feat(games): GPU time-slicing so an app can co-schedule with wolf

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/apps.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/apps.yaml
@@ -22,10 +22,11 @@ spec:
   wolfConfig:
     runtimeVariables:
       # renderD128 = RTX 3090 Ti (01:00.0); renderD129 = RTX 3070 (0f:00.0).
-      # The wolf sidecar requests BOTH GPUs (see user.yaml), so CDI injects both
-      # render nodes at their host numbering and renderD128 is always present.
-      # (With a single GPU request the scheduler picks either card, so this node
-      # would be absent ~half the time and wolf falls back to software x264.)
+      # This value is effectively a placeholder: the wolf sidecar now requests a
+      # single GPU (see user.yaml) and its entrypoint detects whichever render
+      # node CDI actually injected, overriding WOLF_RENDER_NODE at startup (see
+      # wolf-entrypoint.yaml). The CRD still requires the field, so leave the
+      # default.
       renderNode: /dev/dri/renderD128
   template:
     spec:

--- a/kubernetes/apps/games/games-on-whales/app/user.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/user.yaml
@@ -54,24 +54,21 @@ spec:
       # virtual-input/controller hotplug needs /dev/uinput on the node (uinput
       # kernel module + device access) -- a follow-up, see README.
       #
-      # Request BOTH of talos1's GPUs (node exposes nvidia.com/gpu: 2, no
-      # time-slicing). CDI injects each allocated GPU's DRM render node at its
-      # host numbering, so taking both guarantees BOTH renderD128 (RTX 3090 Ti,
-      # 01:00.0) and renderD129 (RTX 3070, 0f:00.0) are present in the wolf
-      # container. With only one GPU the scheduler picks either card
-      # non-deterministically, so a hardcoded renderNode (renderD128) is absent
-      # ~half the time and wolf silently falls back to software x264. Taking
-      # both makes renderNode: /dev/dri/renderD128 always valid.
-      #
-      # Trade-off: this consumes the whole node, so an App that also needs a GPU
-      # for its own container (e.g. firefox: nvidia.com/gpu 1) can't schedule
-      # alongside (1 + 2 > 2). Test Ball has no app container, so it's fine.
-      # Revisit with GPU time-slicing if concurrent app+wolf GPU use is needed.
+      # Single GPU. CDI injects whichever physical card the scheduler picked at
+      # its host render-node number (renderD128 = RTX 3090 Ti 01:00.0,
+      # renderD129 = RTX 3070 0f:00.0), so the card is non-deterministic. Rather
+      # than grab BOTH GPUs to force renderD128 to exist (the old approach, which
+      # consumed the whole node and blocked an App's own GPU container), the wolf
+      # entrypoint wrapper now detects the actually-injected render node and
+      # exports WOLF_RENDER_NODE to it (see wolf-entrypoint.yaml), so a single
+      # GPU on either card works. Combined with GPU time-slicing (see the
+      # nvidia-gpu operator HelmRelease) this leaves slices for the App's own GPU
+      # container (e.g. firefox: nvidia.com/gpu 1) to co-schedule.
       resources:
         requests:
-          nvidia.com/gpu: "2"
+          nvidia.com/gpu: "1"
         limits:
-          nvidia.com/gpu: "2"
+          nvidia.com/gpu: "1"
     wolfAgent:
       volumeMounts:
         - name: udev-data

--- a/kubernetes/apps/games/games-on-whales/app/wolf-entrypoint.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/wolf-entrypoint.yaml
@@ -32,6 +32,25 @@ data:
       source "${init_script}"
     done
 
+    # Render-node selection (dual-GPU node, single nvidia.com/gpu request).
+    # CDI injects only the scheduler-picked card's DRM render node, at its host
+    # number (renderD128 = RTX 3090 Ti 01:00.0, renderD129 = RTX 3070 0f:00.0),
+    # and which card we get is non-deterministic. WOLF_RENDER_NODE comes from the
+    # App's wolfConfig.runtimeVariables.renderNode (default /dev/dri/renderD128),
+    # so a fixed value is absent ~half the time and wolf silently falls back to
+    # software x264. Point wolf at whichever render node actually got injected.
+    # talos1 is an NVIDIA-only GPU node (no iGPU), so with one GPU there is
+    # exactly one renderD* and it is always the NVIDIA card.
+    shopt -s nullglob
+    render_nodes=(/dev/dri/renderD*)
+    shopt -u nullglob
+    if [ ${#render_nodes[@]} -gt 0 ]; then
+      export WOLF_RENDER_NODE="${render_nodes[0]}"
+      gow_log "Detected render node ${WOLF_RENDER_NODE}; overriding WOLF_RENDER_NODE"
+    else
+      gow_log "WARNING: no /dev/dri/renderD* present; leaving WOLF_RENDER_NODE=${WOLF_RENDER_NODE:-unset}"
+    fi
+
     gow_log "Launching the container's startup script as root"
     chmod +x /opt/gow/startup.sh
     exec /opt/gow/startup.sh

--- a/kubernetes/apps/kube-system/nvidia-gpu/operator/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-gpu/operator/helmrelease.yaml
@@ -25,6 +25,29 @@ spec:
       enabled: true
     gfd:
       enabled: true
+    # GPU time-slicing. A fenrir/wolf streaming session pod needs two
+    # nvidia.com/gpu (the wolf sidecar's compositor+NVENC, plus the app
+    # container's own rendering); with two physical GPUs that's the whole node
+    # and nothing co-schedules. Time-slicing advertises each physical card as
+    # `replicas` logical nvidia.com/gpu so wolf + app + llmkube can share.
+    # NOTE: time-slicing only multiplexes CUDA contexts, it does NOT partition
+    # VRAM -- co-tenants share the card's memory. The 27B llmkube model needs
+    # both cards' combined VRAM, so verify it still lands on two DISTINCT
+    # physical cards after this rolls out (it's gpu-preemptible and scaled down
+    # while gaming, so a collision is low-stakes, but worth checking).
+    devicePlugin:
+      config:
+        create: true
+        name: time-slicing-config
+        default: time-slicing
+        data:
+          time-slicing: |-
+            version: v1
+            sharing:
+              timeSlicing:
+                resources:
+                  - name: nvidia.com/gpu
+                    replicas: 4
     dcgmExporter:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## Problem

A fenrir/wolf streaming **session pod** needs two `nvidia.com/gpu` — the wolf sidecar (Wayland compositor + NVENC) **and** the app container's own rendering. On the 2-GPU node that's the whole node, so a real App (firefox) can't schedule alongside wolf:

```
0/2 nodes are available: 2 Insufficient nvidia.com/gpu.
preemption: ... Preemption is not helpful for scheduling.
```

(Test Ball schedules fine — it has no app container, just wolf.) wolf previously grabbed **both** GPUs (#1104) purely to guarantee `renderD128` exists, since a 1-GPU request lands on either card non-deterministically.

## Change

- **Time-slicing** (`replicas: 4`) on the nvidia-gpu operator → each physical card advertises 4 logical `nvidia.com/gpu` (node: 2 → **8**). Mirrors shrinedogg's reference deploy.
- **wolf sidecar 2 → 1 GPU.** The determinism trap that forced wolf=2 is now handled in the wolf entrypoint wrapper: it detects whichever DRM render node CDI actually injected and exports `WOLF_RENDER_NODE` to it. The fork delivers `renderNode` to wolf as exactly that env var (`session.go`: `wolfEnvVars["WOLF_RENDER_NODE"]`), so a single GPU on **either** card now encodes with NVENC instead of falling back to software x264.
- App `renderNode` is now a placeholder (entrypoint overrides it).

## ⚠️ Verify after rollout

1. **firefox session schedules** + wolf still HW-encodes (`renderDxxx vendor: NVIDIA`, `nvcodec`, not x264).
2. **llmkube/qwen still lands on two DISTINCT physical cards.** Time-slicing multiplexes CUDA contexts but does **not** partition VRAM — if the plugin packs qwen's 2 slices onto one card, the 27B model OOMs. Mitigated (gpu-preemptible, scaled down while gaming), but check `NVIDIA_VISIBLE_DEVICES` on the qwen pod once live.
3. **Zero-copy** needs wolf + app on the *same* physical card — time-slicing makes that possible but doesn't guarantee scheduler co-location; confirm at first firefox run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)