### PR TITLE
fix(games): chown /home/retro so Firefox can write its profile

### DIFF
--- a/kubernetes/apps/games/games-on-whales/app/apps.yaml
+++ b/kubernetes/apps/games/games-on-whales/app/apps.yaml
@@ -61,6 +61,17 @@ spec:
 
               export PULSE_SINK="$(pactl list sinks short | awk '$2 ~ /^virtual_sink/ {print $2; exit}')"
               export PULSE_SOURCE="${PULSE_SINK}.monitor"
+
+              # The Firefox profile lives under /home/retro, which is the
+              # wolf-data volume -- an ephemeral emptyDir (created root:root)
+              # shared with the root wolf sidecar. The GOW entrypoint drops to
+              # retro (uid 1000) but does not chown the home, so Firefox can't
+              # write its profile and dies with "Your Firefox profile cannot be
+              # loaded. It may be missing or inaccessible." This command runs as
+              # root (the entrypoint gosu's to retro afterwards), so fix the
+              # ownership first. (PUID/PGID default to 1000; substitute:disabled
+              # on this App keeps Flux from blanking the braces.)
+              chown -R "${PUID:-1000}:${PGID:-1000}" /home/retro
               exec /entrypoint.sh
 ---
 # yaml-language-server: $schema=https://github.com/games-on-whales/fenrir/raw/refs/heads/main/schemas/direwolf.games-on-whales.github.io/app_v1alpha1.json


### PR DESCRIPTION
## Problem

With time-slicing (#1105), the firefox session now schedules and gets a real GPU — wolf encodes with NVENC and Firefox renders to the client. But Firefox immediately errors:

> Your Firefox profile cannot be loaded. It may be missing or inaccessible.

## Cause

The Firefox profile lives under `/home/retro`, which is the `wolf-data` volume — an ephemeral **emptyDir** (created `root:root`) shared with the **root** wolf sidecar (mounted there as `/mnt/data/wolf`). The GOW entrypoint drops the app to `retro` (uid 1000) but never chowns the home, so `retro` can't create `~/.mozilla`.

## Fix

`chown -R retro /home/retro` before the entrypoint runs. The app command starts as root (the entrypoint `gosu`'s to retro afterwards), so it can fix ownership. This mirrors the chown shrinedogg's Steam app does for the same image/home on a non-default volume.

## Verify after rollout

Restart the firefox session from Moonlight → Firefox should load its profile and show the browser instead of the profile-error dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)