### PR TITLE
fix(llmkube): qwen requests all 8 GPU slices to restore preemption

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
@@ -90,7 +90,21 @@ spec:
   resources:
     cpu: "1"
     memory: 8Gi
-    gpu: 2
+    # Request the WHOLE GPU node (= 2 cards x 4 time-slicing replicas = 8; see
+    # kubernetes/apps/kube-system/nvidia-gpu/operator/helmrelease.yaml). This is
+    # deliberately the k8s SCHEDULING request only -- the model still runs on 2
+    # physical GPUs via hardware.gpu.count + the 6:1 --tensor-split above (8
+    # slices dedupe to the 2 physical UUIDs for CUDA).
+    #
+    # Why grab all 8: GPU time-slicing removed the scarcity that priority
+    # preemption relies on -- at gpu: 2 the node still had 6 free slices, so a
+    # games-on-whales session (needs 2) scheduled WITHOUT preempting this
+    # gpu-preemptible pod, leaving qwen running and contending for VRAM. Holding
+    # all 8 restores scarcity: a session can't fit, so the scheduler preempts
+    # qwen (priority -100) and frees the node. It also guarantees qwen always
+    # lands on BOTH full physical cards (no 2-slices-on-one-card OOM).
+    # Bump this if the node's GPU count or replicas change.
+    gpu: 8
 
   endpoint:
     port: 8080


### PR DESCRIPTION
## Problem

GPU time-slicing (#1105, `replicas: 4` → node advertises `nvidia.com/gpu: 8`) **broke the priority-preemption auto-scaledown** of qwen. K8s preemption only fires under scarcity: at `gpu: 2`, qwen held 2 of 8 and **6 slices stayed free**, so a games-on-whales session (needs 2) scheduled *without* preempting qwen. qwen kept running and **shared cards with wolf** — and time-slicing does **not** partition VRAM.

## Fix

Bump qwen's k8s GPU request to **8** (the whole node) so a session can't fit alongside it → scheduler preempts qwen (priority `-100`) → frees the node → session schedules. Game ends → qwen reschedules into the free 8.

This is the **scheduling request only**:
- `hardware.gpu.count: 2` is unchanged — the model still runs on 2 physical GPUs with `--tensor-split 6,1`.
- The 8 time-sliced replicas **dedupe to the 2 physical GPU UUIDs** for CUDA, so llama.cpp sees 2 devices.
- **Bonus:** grabbing all 8 = all 4+4 slices = guaranteed **both full physical cards**, eliminating the latent "2 slices on one card → OOM" risk.

Safe because the only other GPU consumer is the gaming session (which we *want* mutually exclusive with qwen); the embedding + reranker models are `accelerator: cpu`.

## Verify on rollout
1. qwen pod requests `nvidia.com/gpu: 8` and schedules on talos1.
2. llama.cpp logs still show **2 CUDA devices** with the 6:1 tensor-split (i.e. llmkube honored `resources.gpu: 8` ≠ `hardware.gpu.count: 2`).
3. Launching a Wolf session now **preempts** qwen (pod evicted), and qwen reschedules after the session ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)