### PR TITLE
feat(just): recipes to temporarily point Flux source at a branch

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,23 @@ _:
 reconcile:
     flux --namespace flux-system reconcile kustomization flux-system --with-source
 
+# Temporarily point the Flux source at a branch (defaults to current).
+flux-branch branch=`git rev-parse --abbrev-ref HEAD`:
+    # Suspend the HelmRelease so Flux won't reset the FluxInstance back to main.
+    flux --namespace flux-system suspend helmrelease flux-instance
+    # Patch the FluxInstance CR; flux-operator reconciles this into the GitRepository.
+    kubectl --namespace flux-system patch fluxinstance flux --type=merge \
+        -p '{"spec":{"sync":{"ref":"refs/heads/{{branch}}"}}}'
+    flux --namespace flux-system reconcile kustomization flux-system --with-source
+
+# Revert the Flux source back to main (resumes flux-instance).
+flux-branch-reset:
+    # Reset the CR explicitly; resuming the HelmRelease is a no-op when values are unchanged.
+    kubectl --namespace flux-system patch fluxinstance flux --type=merge \
+        -p '{"spec":{"sync":{"ref":"refs/heads/main"}}}'
+    flux --namespace flux-system resume helmrelease flux-instance
+    flux --namespace flux-system reconcile kustomization flux-system --with-source
+
 # Generate boilerplate for a new app.
 newapp:
     copier copy templates . --trust


### PR DESCRIPTION
## What

Adds two `just` recipes to temporarily repoint the Flux Git source at an arbitrary branch for testing, then revert:

- `just flux-branch [branch]` — defaults to the current branch; suspends the `flux-instance` HelmRelease and patches the FluxInstance CR's `spec.sync.ref` to the branch.
- `just flux-branch-reset` — patches the CR back to `main`, resumes the HelmRelease, and reconciles.

## Why this shape

The Flux Git source is owned by the **flux-operator** via the `FluxInstance` CR (`fluxinstance/flux`), not the GitRepository object or the HelmRelease directly. Notable gotchas baked into the recipes:

- Editing the GitRepository directly (`flux create source git`) gets reverted by the operator on its next reconcile — the CR's `spec.sync.ref` is the real lever.
- The HelmRelease is suspended during the override so Flux won't overwrite the CR back to `main`.
- Reset patches the CR back to `main` **explicitly**, because a bare HelmRelease reconcile is a no-op when chart values are unchanged and won't re-push the manifest.

## Notes

- The branch must be pushed to GitHub first — the source URL points at the remote, not the local checkout.
- Verified end-to-end on the live cluster: override persists through an operator reconcile cycle, and reset returns cleanly to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)