### PR TITLE
chore(gpu): remove time-slicing, keep preemption-based qwen↔gaming handoff

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-6-27b-mtp.yaml
@@ -90,21 +90,15 @@ spec:
   resources:
     cpu: "1"
     memory: 8Gi
-    # Request the WHOLE GPU node (= 2 cards x 4 time-slicing replicas = 8; see
-    # kubernetes/apps/kube-system/nvidia-gpu/operator/helmrelease.yaml). This is
-    # deliberately the k8s SCHEDULING request only -- the model still runs on 2
-    # physical GPUs via hardware.gpu.count + the 6:1 --tensor-split above (8
-    # slices dedupe to the 2 physical UUIDs for CUDA).
-    #
-    # Why grab all 8: GPU time-slicing removed the scarcity that priority
-    # preemption relies on -- at gpu: 2 the node still had 6 free slices, so a
-    # games-on-whales session (needs 2) scheduled WITHOUT preempting this
-    # gpu-preemptible pod, leaving qwen running and contending for VRAM. Holding
-    # all 8 restores scarcity: a session can't fit, so the scheduler preempts
-    # qwen (priority -100) and frees the node. It also guarantees qwen always
-    # lands on BOTH full physical cards (no 2-slices-on-one-card OOM).
-    # Bump this if the node's GPU count or replicas change.
-    gpu: 8
+    # Request BOTH physical GPUs on talos1 (no time-slicing -- the node
+    # advertises exactly nvidia.com/gpu: 2). Holding both is what makes the
+    # gpu-preemptible PriorityClass work: a games-on-whales session also needs 2
+    # (wolf sidecar + app), so the node has zero free GPUs and the scheduler must
+    # preempt this -100 pod to fit the session. (Time-slicing previously broke
+    # this by inflating the node to 8 slices, so a session fit alongside qwen
+    # without preempting -- see issue #1109.) Matches hardware.gpu.count + the
+    # 6:1 --tensor-split above.
+    gpu: 2
 
   endpoint:
     port: 8080

--- a/kubernetes/apps/games/games-on-whales/README.md
+++ b/kubernetes/apps/games/games-on-whales/README.md
@@ -56,6 +56,11 @@ Trade-offs: preemption evicts llmkube's whole pod (both GPUs — a Test Ball ses
 needs 1, a Firefox session needs 2: wolf + app); the LLM is offline during play and
 takes time to reload afterward.
 
+> ⚠️ **Do not enable GPU time-slicing on the gpu-operator.** Preemption relies on
+> the node advertising exactly `nvidia.com/gpu: 2`; time-slicing inflates that (e.g.
+> 8 slices) so a session schedules *alongside* qwen without preempting it, and they
+> contend for VRAM. See issue #1109.
+
 ## Pairing / using it
 
 1. Get the shared LB IP: `kubectl -n games get svc -o wide` (pinned to

--- a/kubernetes/apps/kube-system/nvidia-gpu/operator/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-gpu/operator/helmrelease.yaml
@@ -25,29 +25,6 @@ spec:
       enabled: true
     gfd:
       enabled: true
-    # GPU time-slicing. A fenrir/wolf streaming session pod needs two
-    # nvidia.com/gpu (the wolf sidecar's compositor+NVENC, plus the app
-    # container's own rendering); with two physical GPUs that's the whole node
-    # and nothing co-schedules. Time-slicing advertises each physical card as
-    # `replicas` logical nvidia.com/gpu so wolf + app + llmkube can share.
-    # NOTE: time-slicing only multiplexes CUDA contexts, it does NOT partition
-    # VRAM -- co-tenants share the card's memory. The 27B llmkube model needs
-    # both cards' combined VRAM, so verify it still lands on two DISTINCT
-    # physical cards after this rolls out (it's gpu-preemptible and scaled down
-    # while gaming, so a collision is low-stakes, but worth checking).
-    devicePlugin:
-      config:
-        create: true
-        name: time-slicing-config
-        default: time-slicing
-        data:
-          time-slicing: |-
-            version: v1
-            sharing:
-              timeSlicing:
-                resources:
-                  - name: nvidia.com/gpu
-                    replicas: 4
     dcgmExporter:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## What

Remove GPU **time-slicing** from the nvidia-gpu-operator and revert qwen's
scheduling request `8 → 2`, while **keeping** the `gpu-preemptible` PriorityClass.
Result: automatic qwen↔games-on-whales GPU handoff via plain scheduler preemption.

**Supersedes #1108.** That PR ripped out *both* time-slicing and the priorityClass
(going fully manual). Testing showed only time-slicing needed to go — removing the
priorityClass too was an over-correction.

## Why

Time-slicing (`devicePlugin replicas: 4` → talos1 advertises `nvidia.com/gpu: 8`)
**broke preemption** and never delivered co-location:

- Preemption only fires under scarcity. qwen's real request is 2 (llmkube binds it
  to `hardware.gpu.count` and ignores higher values — so #1107's "request 8" was a
  no-op), leaving **6 free slices**. A session needs 2 → it scheduled *alongside*
  qwen with no preemption, and the two contended for VRAM on the same physical card.
- Time-slicing also only multiplexes CUDA contexts across cards; it never co-located
  wolf + app on one GPU (the device plugin spreads them).

With time-slicing gone the node advertises exactly `nvidia.com/gpu: 2`; qwen holds
both, a session needs both, so the scheduler preempts the `-100` qwen pod to fit.

## Validation (live, 2026-06-23)

A Firefox session launched while qwen held both GPUs:

```
Normal  Preempted  pod/qwen3-6-27b-mtp-...-nj765
  Preempted by pod eaef996d-... (alex-firefox) on node talos1
```

- talos1 `nvidia.com/gpu`: capacity **2**, allocatable **2** (time-slicing dropped)
- Firefox session: Running 4/4 on talos1, holding both GPUs
- qwen: now `Pending` (`Insufficient nvidia.com/gpu`; "No preemption victims found"
  — correctly can't preempt the default-priority session back); reschedules + reloads
  the model when the session ends.

## Notes

- Full post-mortem of the automatic-handoff dead ends: #1109.
- Co-location (app HW-accel for *real games*, vs. software-rendered Firefox) remains
  open — the DRA path is tracked in #1109.
- Alternative (manual scaling, time-slicing kept) lives on branch
  `chore/gpu-without-preemption`; not pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
