### PR TITLE
feat(openclaw): scope egress to named in-cluster services

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/README.md
+++ b/kubernetes/apps/ai-sandbox/openclaw/README.md
@@ -36,11 +36,15 @@ and firewalled by a default-deny egress CiliumNetworkPolicy.
   ever hits OpenClaw's own gateway-token auth. Two independent auth layers.
 - **Pinned to `talos1`** (worker, has the gVisor extension); never the
   control-plane / GPU host `talos0`.
-- **Egress is default-deny** (`app/networkpolicy.yaml`): only cluster DNS, the
-  in-cluster LLMs (`ai` namespace :8080), and the *public* internet (private /
-  link-local CIDRs excluded). kube-apiserver, the LAN, and other namespaces are
-  unreachable. See **Egress hardening** below for tightening this to a per-domain
-  allowlist.
+- **Egress is default-deny** (`app/networkpolicy.yaml`): only cluster DNS, a
+  short allowlist of named in-cluster services (the Qwen model, memini, and the
+  SearXNG MCP proxy — via Cilium `toServices`, which tracks each Service's own
+  backends and self-heals across chart bumps, **not** the whole `ai` namespace),
+  and the *public* internet (private / link-local CIDRs excluded). kube-apiserver,
+  the LAN, and every other namespace/service are unreachable. (`toServices` can't
+  be paired with `toPorts`, so memini's :9090 metrics port is reachable alongside
+  its :8080 API — acceptable for a sandbox allowlist.) See **Egress hardening**
+  below for tightening the public-internet rule to a per-domain allowlist.
 
 ## Storage
 

--- a/kubernetes/apps/ai-sandbox/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/app/networkpolicy.yaml
@@ -26,16 +26,34 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
-    # In-cluster local LLMs (llama-cpp / llmkube model servers in the `ai`
-    # namespace, which serve inference on 8080). Scoped to that namespace +
-    # port only — no other in-cluster service is reachable.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-      toPorts:
-        - ports:
-            - port: "8080"
-              protocol: TCP
+    # In-cluster services openclaw is allowed to reach, named directly — NOT the
+    # whole `ai` namespace, which also runs the embedding/reranker models and the
+    # other MCP servers that openclaw must not reach. `toServices` resolves each
+    # Service to its current backend pods (with kube-proxy replacement Cilium
+    # handles the ClusterIP→pod translation), so this follows the Service's own
+    # endpoint selector and self-heals if llmkube/ToolHive relabel pods on a chart
+    # bump. (Matching the `qwen.${SECRET_DOMAIN}` ingress hostname would be worse —
+    # it resolves to the SHARED envoy-internal gateway IP that fronts every route.)
+    #
+    # NOTE: `toServices` can't be paired with `toPorts`, so this allows whatever
+    # ports the backends expose. qwen and the searxng proxy are 8080-only; memini
+    # also exposes :9090 (metrics), which openclaw can therefore reach. Acceptable
+    # for a sandbox allowlist. Verify enforcement after reconcile with Hubble:
+    # `cilium hubble observe --from-pod ai-sandbox/openclaw`.
+    - toServices:
+        # Qwen chat model (llmkube), reached at http://qwen3-6-27b-mtp.ai:8080/v1.
+        - k8sService:
+            serviceName: qwen3-6-27b-mtp
+            namespace: ai
+        # memini memory API.
+        - k8sService:
+            serviceName: memini
+            namespace: ai
+        # SearXNG MCP server — the proxy is the endpoint clients connect to
+        # (the HTTPRoute backs mcp-mcp-searxng-proxy, not mcp-mcp-searxng).
+        - k8sService:
+            serviceName: mcp-mcp-searxng-proxy
+            namespace: ai
     # Public internet only. NOTE: Cilium's `world` entity also covers RFC1918
     # LAN hosts (the MikroTik at 10.0.42.1, other homelab devices), so we use a
     # CIDR allow that explicitly excludes private + link-local ranges. This


### PR DESCRIPTION
## What

Tightens openclaw's egress CiliumNetworkPolicy. Previously it allowed the **entire `ai` namespace** on `:8080`; now it allows only the three services openclaw actually needs, named directly via Cilium `toServices`:

- `qwen3-6-27b-mtp` — Qwen chat model (llmkube)
- `memini` — memory API
- `mcp-mcp-searxng-proxy` — SearXNG MCP (the proxy the HTTPRoute backs, not `mcp-mcp-searxng`)

## Why

The old rule also exposed the embedding/reranker models, searxng, valkey, and the other ToolHive MCP servers in `ai` — none of which openclaw should reach. Since openclaw runs untrusted/prompt-injected agent code (gVisor-sandboxed), egress containment is the control that limits a breakout.

`toServices` (vs. hardcoded pod-label selectors) follows each Service's own backends, so it **self-heals** if llmkube/ToolHive relabel pods on a chart bump.

## Tradeoff

`toServices` can't be paired with `toPorts`, so memini's `:9090` metrics port is reachable alongside its `:8080` API. Acceptable for a sandbox allowlist.

## Verification (post-reconcile)

- [ ] Flows forwarded, not dropped: `cilium hubble observe --from-pod ai-sandbox/openclaw`
- [ ] Negative check: other `ai` services (e.g. `qwen3-embedding-0-6b`) are unreachable from the pod

> Note: openclaw's config doesn't reference memini/searxng yet — this only opens the path. When wired up, point it at `http://memini.ai:8080` and `http://mcp-mcp-searxng-proxy.ai:8080`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)