### PR TITLE
feat(snmp-exporter): poll PDU metrics once per second

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -30,6 +30,8 @@ spec:
 
     serviceMonitor:
       enabled: true
+      interval: 1s
+      scrapeTimeout: 1s
       auth: [public_v2]
       params:
         - name: compute-pdu


### PR DESCRIPTION
Set serviceMonitor scrape interval to 1s (with matching scrapeTimeout)
so the Geist PDUs are polled every second instead of the global default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HrEjgHdozpyP3yXxV1UfF5