### PR TITLE
build(renovate): group toolhive operator and crds updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -82,6 +82,21 @@
       minimumGroupSize: 3,
     },
     {
+      description: "ToolHive Operator Group",
+      groupName: "toolhive-operator",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "/stacklok/toolhive/toolhive-operator/",
+        "/stacklok/toolhive/toolhive-operator-crds/"
+      ],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 2,
+    },
+    {
       description: "Auto-merge GitHub Actions",
       matchManagers: [
         "github-actions"


### PR DESCRIPTION
Groups `toolhive-operator` and `toolhive-operator-crds` container updates into a single Renovate PR, modeled on the existing `flux-operator` group rule.

The two images are released in lockstep at the same version (e.g. the current 0.30.1 → 0.31.0 bump opened as #1130 and #1131 separately). `minimumGroupSize: 2` ensures grouping only applies when both update together.

Takes effect on the next Renovate run, which should supersede #1130 and #1131 with a single combined PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)