### PR TITLE
feat(tuppr): make node upgrades safe on a two-node cluster

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -8,6 +8,9 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: enabled
 spec:
   instances: 1
+  # single instance on node-local storage: the PDB can never be satisfied (no
+  # failover target), so it would deadlock node drains during tuppr upgrades.
+  enablePDB: false
   imageName: ghcr.io/cloudnative-pg/postgresql:18@sha256:c835ea1053376ab101e3528cd9d3712c8f760378af6f6a4b5bd74c119e35e190
 
   primaryUpdateStrategy: unsupervised

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -54,13 +54,26 @@ spec:
           - name: log
             configBlock: |-
               class error
+    # todo: if the cluster becomes all-control-plane (or gains more CP nodes),
+    # revisit — a `required` control-plane affinity is fine there and the
+    # podAntiAffinity below can be relaxed.
     affinity:
+      # prefer (not require) control-plane: with one CP node a `required` rule
+      # collapses both replicas onto talos0, killing DNS during its reboot.
       nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
                 - key: node-role.kubernetes.io/control-plane
                   operator: Exists
+      # keep the two replicas on separate nodes for real HA across reboots
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: coredns
     tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -9,8 +9,16 @@ spec:
     name: *app
   interval: 1h
   values:
-    # todo: multi-node
-    replicaCount: 1
+    replicaCount: 2
     monitoring:
       serviceMonitor:
         enabled: true
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          allowCrossNamespaceImport: true
+          matchLabels:
+            dashboards: grafana


### PR DESCRIPTION
## Context

talos1 joined as a worker node, so tuppr now performs **real drains** during Talos/Kubernetes upgrades (on the single-node cluster, drains were effectively skipped). Three things would otherwise stall or black out a talos0 drain. Mirrors how the tuppr author (onedr0p) runs it on a multi-node cluster.

## Changes

- **tuppr** — `replicaCount: 2` so the leader-elected controller survives its own node being drained; also enabled `prometheusRule` + Grafana dashboards to match upstream. Resolves the long-standing `# todo: multi-node`.
- **cloudnative-pg** — `enablePDB: false`. A single instance on node-local `openebs-hostpath` has no failover target, so the default `minAvailable: 1` PDB can never be satisfied and would **deadlock** the drain. No data-loss impact: eviction is a graceful shutdown, committed WAL is durable, and barman→garage archiving remains. The DB is briefly down during its host node's reboot regardless (inherent to single instance + node-local storage).
- **coredns** — relaxed the control-plane `nodeAffinity` from `required` → `preferred` and added pod anti-affinity. talos0 is the only control-plane node, so the `required` rule pinned **both** replicas onto it, giving zero HA and taking cluster DNS down during talos0's reboot.

## Notes / follow-ups

- The upgrade CRDs need no changes — they already auto-discover and upgrade both nodes serially, gated by the VolSync health check.
- `coredns` carries a todo: if the cluster later becomes all-control-plane, the `required` affinity is fine again and the anti-affinity can be relaxed.
- For true zero-downtime Postgres across upgrades, the next step would be `instances: 2` + `primaryUpdateMethod: switchover` (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)