### PR TITLE
build(renovate): extend home-operations/renovate-presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -8,6 +8,7 @@
     ":dependencyDashboard",
     ":disableRateLimiting",
     ":semanticCommits",
+    "github>home-operations/renovate-presets",
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: "Renovate Dashboard",
@@ -253,41 +254,6 @@
       addLabels: [
         "renovate/github-release"
       ],
-    },
-  ],
-  customManagers: [
-    {
-      description: "Process annotated dependencies",
-      customType: "regex",
-      managerFilePatterns: [
-        "/(^|/).+\\.env(?:\\.j2)?$/",
-        "/(^|/).+\\.sh(?:\\.j2)?$/",
-        "/(^|/).+\\.ya?ml(?:\\.j2)?$/",
-      ],
-      matchStrings: [
-        // # renovate: datasource=github-releases depName=k3s-io/k3s
-        // k3s_release_version: &version v1.29.0+k3s1
-        // # renovate: datasource=helm depName=cilium repository=https://helm.cilium.io
-        // version: 1.15.1
-        // # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-        // KUBERNETES_VERSION=v1.31.1
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( repository=(?<registryUrl>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
-        // # renovate: datasource=docker depName=ghcr.io/prometheus-operator/prometheus-operator
-        // https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.80.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+/(?<currentValue>(v|\\d)[^/]+)",
-      ],
-      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-    },
-    {
-      customType: "regex",
-      description: "Process OCI dependencies",
-      managerFilePatterns: [
-        "/\\.yaml(?:\\.j2)?$/",
-      ],
-      matchStrings: [
-        "oci://(?<depName>[^:]+):(?<currentValue>\\S+)",
-      ],
-      datasourceTemplate: "docker",
     },
   ],
 }


### PR DESCRIPTION
## What

Adopt the shared [`home-operations/renovate-presets`](https://github.com/home-operations/renovate-presets) bundle via `extends`, and remove the local `customManagers` block (the `annotated` + `oci` regex managers) which the bundle now provides.

`customManagers` arrays **concatenate** across `extends` rather than override, so keeping the local copies would double-run dependency detection on the same files. Everything else stays local because it either wins on override or stacks harmlessly:

- **Kept (local wins on override):** `flux`/`kubernetes`/`helmfile`/`kustomize` `managerFilePatterns` (so scanning stays scoped to `kubernetes/**`), `dependencyDashboardTitle`.
- **Kept (packageRules concatenate, local appended last → wins):** labels, automerge, grouping, semantic-commit policy.

## Net-new capability from the bundle

- `registryAliases`: resolves `mirror.gcr.io` → `docker.io` (qbittorrent, coredns, envoy).
- `managers/cnpg`: tracks CNPG `Cluster.spec.imageName` — previously **untracked**.
- `managers/grafanaDashboards`: tracks the 4 `grafanadashboard.yaml` revisions.
- `managers/talosFactory`: tracks `talosVersion` in `talconfig.yaml`.
- `overrides/mise` + `overrides/changelogs`: tool-name normalization and 1Password/Cloudflared changelog links.

## Verified

- All 4 in-repo `# renovate:` annotations (tuppr upgrades + `talconfig.yaml`) are covered by the preset's `annotated` matchString.
- The two local-only matchString patterns the preset drops (`repository=` registryUrl capture, raw URL-path version) are unused in this repo.
- `renovate-config-validator --strict` passes.

> Note: `talosVersion` in `talconfig.yaml` is now matched by both the `annotated` and `talosFactory` managers; Renovate dedupes these at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)