### PR TITLE
fix(openebs): restrict zfs-localpv CSI topology to hostname

### DIFF
--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -29,6 +29,13 @@ spec:
     zfs-localpv:
       zfsNode:
         encrKeysDir: "/var/openebs/zfs"
+        # Restrict CSI topology to hostname only. The default ("All") registers
+        # every node label (NFD, nvidia, transient tuppr upgrade labels) as a
+        # topology key, which breaks storageCapacity tracking: the capacity
+        # controller can't build clean per-node CSIStorageCapacity segments, so a
+        # node ends up with no capacity object and the scheduler reports "not
+        # enough free storage" — leaving VolSync mover pods stuck Pending.
+        allowedTopologyKeys: "kubernetes.io/hostname"
 
       analytics:
         enabled: false


### PR DESCRIPTION
## Problem

All VolSync `volsync-src-*` mover pods were stuck `Pending` for ~3 days, halting backups across `media`, `documents`, `finance`, `observability`, `social`, and `maker`. The scheduler reported:

```
0/2 nodes are available: 1 node(s) did not have enough free storage,
1 node(s) didn't match PersistentVolume's node affinity.
```

…despite `tank` having **744G free on talos0** and 788G on talos1.

## Root cause

`zfs-localpv.zfsNode.allowedTopologyKeys` defaulted to `"All"`, which makes the node driver register **every** node label (NFD `feature.node.kubernetes.io/*`, `nvidia.com/*`, talos extension labels, and the transient `tuppr.home-operations.com/upgrading` label) as a CSI topology key.

With `storageCapacity: true` on the CSIDriver, the external-provisioner's capacity controller could not build clean per-node `CSIStorageCapacity` segments out of that huge, per-node-divergent key set. It ended up maintaining a **single** capacity object (matching talos1 only), leaving **talos0 with no capacity object**. The scheduler therefore treated talos0 as having zero storage, while talos1 failed the PV node-affinity check (the data lives on talos0) — so no node was ever viable.

The `tuppr.../upgrading` label baked into talos0's topology keys points to a past tuppr Talos upgrade as the trigger.

## Fix

Pin `allowedTopologyKeys` to `kubernetes.io/hostname`, so the capacity controller produces exactly one `CSIStorageCapacity` per node and survives future tuppr upgrades.

A manual restart of the openebs pods recovered the cluster (now 2 capacity objects, 0 pending pods); this change makes the recovery durable.

## Validation

- `just test` passes for openebs (HelmRelease + Kustomization). The only failures are an unrelated transient Codeberg 503 for `network/towonel-agent`.
- After merge, Flux rolls the daemonset; confirm `ALLOWED_TOPOLOGIES=kubernetes.io/hostname` on the `openebs-zfs-localpv-node` pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)