### PR TITLE
feat(cnpg): archive WALs and back up to Backblaze B2

### DIFF
--- a/infra/backblaze/.terraform.lock.hcl
+++ b/infra/backblaze/.terraform.lock.hcl
@@ -1,10 +1,36 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "3.3.1"
+  hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
+    "h1:GqvBYImDNYNPMi9o3kJTSIJDeEnNO7om46RWA0wjeso=",
+    "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
+    "h1:a8DHdeyXt8YaEngXGEWZC75W27OG742wtw5BmRnhrpI=",
+    "h1:bPFt8A+PWGwEj3wQ3D0GxyrTMmr1piNrwEuPJu7AZTo=",
+    "h1:nThx/0XctUKlAa6aAsSEHZvx/mD1tSxCE6pacSnotxU=",
+    "h1:syh+iS5VPBQTLszL503BOi5rLpL1wGl1IjyYqgpKYIg=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
 provider "registry.opentofu.org/backblaze/b2" {
   version     = "0.12.1"
   constraints = "0.12.1"
   hashes = [
+    "h1:Hn2xSuOSMv5rt4aUxwUlLAYF5OdBaIQTD/PpjdjS8Gs=",
+    "h1:JuZ1L8O8rqjFjNttywUYMASnaFep1g3l95LB1jdvi+s=",
+    "h1:PDOAs1wVf2ZXci52JAZyqqKgSlwZpwq2IWGkRkWOc4w=",
+    "h1:Z+NjSzzoCP7A8p65qGab43e6fGQFsuoet2ghAPs4Emg=",
     "h1:xMvfLhQ9+9YFpvyP8oLSwqBVS4LudCSJlqNVbN0CSPA=",
     "zh:4c7a3832f94bb2e46af0ce557bfee4227d4c94c7d626a243fdc58a48268b66ba",
     "zh:58279e49cb9d350b00670c16a7c15ee6f4c2b7b935f25240f490599da6ca674e",

--- a/infra/backblaze/keys.tf
+++ b/infra/backblaze/keys.tf
@@ -1,0 +1,27 @@
+resource "b2_application_key" "cnpg" {
+  key_name   = "cnpg"
+  bucket_ids = [b2_bucket.homelab_backups.bucket_id]
+  capabilities = [
+    "listBuckets",
+    "readBuckets",
+    "listFiles",
+    "readFiles",
+    "writeFiles",
+    "deleteFiles",
+  ]
+  name_prefix = "cnpg/"
+}
+
+data "onepassword_vault" "vault" {
+  name = var.onepassword.vault
+}
+
+resource "onepassword_item" "cnpg_key" {
+  vault    = data.onepassword_vault.vault.uuid
+  title    = "cnpg key"
+  category = "login"
+
+  username            = b2_application_key.cnpg.application_key_id
+  password_wo         = b2_application_key.cnpg.application_key
+  password_wo_version = 1
+}

--- a/infra/backblaze/providers.tf
+++ b/infra/backblaze/providers.tf
@@ -4,7 +4,15 @@ terraform {
       source  = "Backblaze/b2"
       version = "0.12.1"
     }
+    onepassword = {
+      source  = "1password/onepassword"
+      version = "3.3.1"
+    }
   }
 }
 
 provider "b2" {}
+
+provider "onepassword" {
+  account = var.onepassword.account
+}

--- a/infra/backblaze/terragrunt.hcl
+++ b/infra/backblaze/terragrunt.hcl
@@ -15,4 +15,5 @@ terraform {
 
 inputs = {
   backup_bucket_name = include.root.locals.secrets.backblaze.backup_bucket_name
+  onepassword        = include.root.locals.secrets.onepassword
 }

--- a/infra/backblaze/variables.tf
+++ b/infra/backblaze/variables.tf
@@ -1,3 +1,10 @@
 variable "backup_bucket_name" {
   type = string
 }
+
+variable "onepassword" {
+  type = object({
+    account = string
+    vault   = string
+  })
+}

--- a/infra/secrets.sops.yaml
+++ b/infra/secrets.sops.yaml
@@ -13,7 +13,7 @@ sw_core:
 backblaze:
     key_id: ENC[AES256_GCM,data:ZSQp8p30cVClUEWak2sTMx7YqAG3oDVtHw==,iv:yfDYNmLwyH7P0Q/G+Aqmrn5GfNT72s4QvYVEkToOj78=,tag:jKthicTBkfjiussAjhRxCA==,type:str]
     application_key: ENC[AES256_GCM,data:/5tpr5THQpC7JWKq3ary16+2q42xCnYj4BifJ8584Q==,iv:87x1KH3PHkrEqrCOzmopQzWUt0cO1CJ4Z2yWqEjqWQg=,tag:eOBIEWOf6f6tcfRoNYC87w==,type:str]
-    backup_bucket_name: ENC[AES256_GCM,data:SLYTyub5yahoJnnhn9etzQKcIA==,iv:9OQmnHhYcv9pLlgA7X/PYGQEYczXopmNOhEo7mIWeUE=,tag:0QeaftWt8Zk85sAX7jFMTQ==,type:str]
+    backup_bucket_name: ENC[AES256_GCM,data:jLCZczARvYBuRx1oClD7GaeU1w==,iv:RzLDMsNu+F+lo3J1IbWHt/f2f5+ktPR4rZqosLq4Y1Y=,tag:IzVC+u3jgNRJl6P7ytUUVw==,type:str]
 migadu:
     username: ENC[AES256_GCM,data:c1n7WUiHxdMwsknHJsLAMNWR9Cw=,iv:YfEHuA4GFupjPjsrSzTXdiqnFsQx9YjbkhVo7qJYmhY=,tag:tapRZ3TWFHIA0POW77ENXQ==,type:str]
     token: ENC[AES256_GCM,data:06Dq8GXOvANh9yrpuEfyXQs2aEXC7X0usrQebPe8DQ74iaa87Xk5ChDWxRGBE4SYN2ZlDjcIdpMDt3oSndAqq4DudYZwxLjl3odXwCBJU6SRbc018Ds=,iv:fOSqJPjOFMhAy5qk+UIcD8PcrsR/hDCqBonKHGCm+1o=,tag:LDqdt2bjVhai1YIco0TzKw==,type:str]
@@ -32,8 +32,8 @@ sops:
             +luoF4GfFBUy/i8p5ylxMvhea0aLbyox5lcUpZ7Vls7eZlNL9TB6DA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
-    lastmodified: "2026-06-06T17:35:36Z"
-    mac: ENC[AES256_GCM,data:BO2AFVJYKzDkuCHCydy6UwipU+TLCKTurYP3OPaKrt/BhvJ6DrYS0hFHT6MhRmQ1wYq0RQZDua/tHUVyIM7nL36MH+U2o7eBE6CZlx8kB3HicDvpKy2vpY4jNF5IMRVInYCjVhLRcgezYoFFu3qvgr9p0TAvwNNxdDiJM9rCrYk=,iv:rk94or8/0socqe9ZkNteCHOCcFZV77rSSH1uL8YIZyA=,tag:8rpGwvPj5guMvoQDyS2SzQ==,type:str]
+    lastmodified: "2026-06-28T16:41:01Z"
+    mac: ENC[AES256_GCM,data:kylKIIKTf99yIh4AHZ8V69t76+YbaG4esl2C2a65zfMvk5eQJuNX7AvuzOH6lvoG6mvMFMIu58IitWGnvvDUvjlxY+o+gPPBzxEhOkLY5oEfEc7IDIQe2vXrzQjchh1bfz8X2dHgHL8c03ERxJnIrJxCoURfppj3DbDuYAWxPyg=,iv:yjGOaHl97gMAN9h3k165xcP7HHuyKvyW3iKSHPA6Qhg=,tag:3l0hMve4bJQbcXTXJtDBgQ==,type:str]
     mac_only_encrypted: true
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -64,7 +64,8 @@ spec:
       enabled: true
       isWALArchiver: true
       parameters:
-        barmanObjectName: garage
+        # WALs + primary (PITR-capable) base backups go to Backblaze B2.
+        barmanObjectName: backblaze
 
   bootstrap:
     # initdb:
@@ -73,9 +74,17 @@ spec:
     recovery:
       database: *default
       owner: *default
-      source: garage
+      source: backblaze
 
   externalClusters:
+    # recovery.source picks one of these; the others are just available targets
+    # to flip to (e.g. recover from garage before B2 has its first backup).
+    - name: backblaze
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: backblaze
+          serverName: postgres
     - name: garage
       plugin:
         name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
@@ -8,10 +9,33 @@ spec:
     endpointURL: "${GARAGE_ENDPOINT_URL}"
     s3Credentials:
       accessKeyId:
-        name: garage-cnpg
+        name: &secret garage-cnpg
         key: ACCESS_KEY_ID
       secretAccessKey:
-        name: garage-cnpg
+        name: *secret
+        key: SECRET_ACCESS_KEY
+    wal:
+      compression: zstd
+      maxParallel: 8
+    data:
+      compression: gzip
+  retentionPolicy: 15d
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: backblaze
+spec:
+  configuration:
+    destinationPath: s3://crayon-club-backups/cnpg
+    endpointURL: "https://s3.us-west-000.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: &secret b2-cnpg
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: *secret
         key: SECRET_ACCESS_KEY
     wal:
       compression: zstd

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: postgres-daily
+  name: postgres-daily-b2
 spec:
   # 7:30 AM UTC => 2:30 EST/3:30 EDT
   schedule: "0 30 7 * * *"
@@ -13,5 +13,25 @@ spec:
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
+    # primary, PITR-capable backup (same store as the WAL archive)
+    parameters:
+      barmanObjectName: backblaze
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres-daily-garage
+spec:
+  # offset 1h from the B2 backup
+  # 8:30 AM UTC => 3:30 EST/4:30 EDT
+  schedule: "0 30 8 * * *"
+  backupOwnerReference: cluster
+  cluster:
+    name: postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+    # secondary cold base backup (no WAL archive here -> not PITR)
     parameters:
       barmanObjectName: garage

--- a/kubernetes/apps/database/cloudnative-pg/cluster/secret.sops.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/secret.sops.yaml
@@ -8,8 +8,7 @@ stringData:
     SECRET_ACCESS_KEY: ENC[AES256_GCM,data:J9mYaWk8dWf0SD/XkB3l0Mh/JljvzknHn1JUWYY5irdeh6IFvDV0BysfxbmMI744jHR//yA6gT4BMly1Wcpn4Q==,iv:6RLFcsiyDa5/eaEaGlSxNGZlsnU/HgVDRxmqjIZG1Ow=,tag:ITDebp1Kd6mJfvOGqWzzAA==,type:str]
 sops:
     age:
-        - recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VUJ4US82MlM0cUR4SkMy
             cHlDTC9CNTlQR1ZTUHlUU2dvZ2tDMXRmVlI4CitXUGhpcHh3WDBNdmovc2IvZzNx
@@ -17,8 +16,34 @@ sops:
             RmdqNjNyYlNCMmlNUlhrV2xKYTFzMEEK+A0RKMRpqAdIgO5Oa/0BH5uzlhEDXdke
             A4YLDPZ1OGzPxaE2sCl2UsoBvL5Lvp7FSt5ZC4o3zs6+FtQTW4x9og==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-14T21:53:32Z"
-    mac: ENC[AES256_GCM,data:I/28UICsE4aQDgvcdlr+kColZvbjuIZS0X2AAn0nDC9MYp6kFe2bZiEvoQBDOe4CMo0JKAzGtsiR63nvyCa3mOpIpb1PoVY1h6BLfOosnnOXeIGAofS+LoYevwQ2/ocxiW3dgeZiUhkdpfV5T4eNMkuHW+63S55EomkGA609WZg=,iv:59wqBXVT7vuvmZaAahKTP9+a+EulCfhxfYP/QIcFua8=,tag:aWoXtkMGCNEpYhH0VM4Ogg==,type:str]
+          recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
     encrypted_regex: ^(data|stringData|crt|key|token|bootstraptoken|secretboxencryptionsecret|secret|id)$
+    lastmodified: "2026-06-28T20:35:58Z"
+    mac: ENC[AES256_GCM,data:RVs/1zrVltcg19Ixcd3I5k0Ctbu/kyPbo1TobmsDRfblzRs5cJvDl0Ojefrr9bU8b3/XdnB2/naLmsFhqYacnrqVqbRUatQa2BDpGHOVVLSRUPOTwMEa9XIn8QfUjkQtqsfvTzMEYh0SgtuATzlhPS8aERakofZfXmsAV8mK8Zc=,iv:XCGVOhInZi2nnL3VXEDi32+8g4TAvlvB1lzx0lF2KjM=,tag:HoCzuS61US9dhccQCSNFdA==,type:str]
     mac_only_encrypted: true
-    version: 3.11.0
+    version: 3.13.1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: b2-cnpg
+type: Opaque
+stringData:
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:kKOjClOgWJ/dUT7JNBgXP7M1s6j4r1C7Nw==,iv:EUnmeEBh0A3tM7LE/TdFh8dFdBxLSrJyKnpePrHCZd4=,tag:3+bk+IvSSdYjo3JEmY3XSw==,type:str]
+    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:F64eudZO3jnmEOlpmBadzb/HtttSsLf6R9IwM6ed9A==,iv:BvKank6LRf423Rp08SJyT7tW14dnHY/WmytzeYWTqOE=,tag:M9fNB85f07d8+kw4bcVSRQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VUJ4US82MlM0cUR4SkMy
+            cHlDTC9CNTlQR1ZTUHlUU2dvZ2tDMXRmVlI4CitXUGhpcHh3WDBNdmovc2IvZzNx
+            aCtLODRudU9PazFncU12NjRQVXh6WjQKLS0tIEs4VVN0N3NLYis1OFFEVldoVzE5
+            RmdqNjNyYlNCMmlNUlhrV2xKYTFzMEEK+A0RKMRpqAdIgO5Oa/0BH5uzlhEDXdke
+            A4YLDPZ1OGzPxaE2sCl2UsoBvL5Lvp7FSt5ZC4o3zs6+FtQTW4x9og==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+    encrypted_regex: ^(data|stringData|crt|key|token|bootstraptoken|secretboxencryptionsecret|secret|id)$
+    lastmodified: "2026-06-28T20:35:58Z"
+    mac: ENC[AES256_GCM,data:RVs/1zrVltcg19Ixcd3I5k0Ctbu/kyPbo1TobmsDRfblzRs5cJvDl0Ojefrr9bU8b3/XdnB2/naLmsFhqYacnrqVqbRUatQa2BDpGHOVVLSRUPOTwMEa9XIn8QfUjkQtqsfvTzMEYh0SgtuATzlhPS8aERakofZfXmsAV8mK8Zc=,iv:XCGVOhInZi2nnL3VXEDi32+8g4TAvlvB1lzx0lF2KjM=,tag:HoCzuS61US9dhccQCSNFdA==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.1


### PR DESCRIPTION
Wires CloudNative-PG to use Backblaze B2 as the primary backup target, alongside the existing Garage store.

## What changed
- **WAL archiving → B2.** The cluster's `isWALArchiver` plugin now points at the new `backblaze` ObjectStore, making B2 the primary, PITR-capable backup store.
- **Recovery → B2.** `bootstrap.recovery.source` is set to `backblaze`, with `garage` retained as a second `externalCluster` so we can flip the recovery source without re-adding config.
- **Two scheduled backups.** `postgres-daily-b2` (B2, PITR-capable — WALs co-located) and `postgres-daily-garage` (Garage, cold base backup, offset +1h). The Garage copy is second-class: restorable only to its base-backup consistency point, since WALs no longer flow there.
- **Infra.** New scoped B2 application key (`infra/backblaze/keys.tf`) + provider/variable wiring feeding the `b2-cnpg` secret.

## Deploy order / caveat
B2 is empty until the first backup completes. Until then, `recovery.source: backblaze` has nothing to restore from, so:
1. Apply `infra/backblaze` Terraform (creates the B2 key).
2. Merge / reconcile — WAL archiving starts flowing to B2.
3. Trigger `kubectl cnpg backup postgres -n database` and confirm it reaches `completed`.
4. Only then is the B2 recovery path usable. In the gap, flip `recovery.source` to `garage` if a rebuild is needed; old Garage backups remain intact.

Validated with `just test` (159 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)