### PR TITLE
feat(kopiur): deploy kopiur alongside VolSync with pilot apps

### DIFF
--- a/infra/backblaze/keys.tf
+++ b/infra/backblaze/keys.tf
@@ -12,6 +12,20 @@ resource "b2_application_key" "cnpg" {
   name_prefix = "cnpg/"
 }
 
+resource "b2_application_key" "kopiur" {
+  key_name   = "kopiur"
+  bucket_ids = [b2_bucket.homelab_backups.bucket_id]
+  capabilities = [
+    "listBuckets",
+    "readBuckets",
+    "listFiles",
+    "readFiles",
+    "writeFiles",
+    "deleteFiles",
+  ]
+  name_prefix = "kopiur/"
+}
+
 data "onepassword_vault" "vault" {
   name = var.onepassword.vault
 }
@@ -23,5 +37,15 @@ resource "onepassword_item" "cnpg_key" {
 
   username            = b2_application_key.cnpg.application_key_id
   password_wo         = b2_application_key.cnpg.application_key
+  password_wo_version = 1
+}
+
+resource "onepassword_item" "kopiur_key" {
+  vault    = data.onepassword_vault.vault.uuid
+  title    = "kopiur key"
+  category = "login"
+
+  username            = b2_application_key.kopiur.application_key_id
+  password_wo         = b2_application_key.kopiur.application_key
   password_wo_version = 1
 }

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  interval: 1h
+  values:
+    # ClusterRepository support
+    installScope: cluster
+    installCRDs: true
+    features:
+      # allow projecting the ClusterRepository secret into mover namespaces
+      credentialProjection:
+        enabled: true
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+    grafanaDashboard:
+      enabled: true
+      grafanaOperator:
+        enabled: true
+        allowCrossNamespaceImport: true
+        matchLabels:
+          dashboards: grafana

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.4.13
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  dependsOn:
+    - name: openebs
+      namespace: openebs-system
+    - name: snapshot-controller
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository
+spec:
+  dependsOn:
+    - name: kopiur
+  healthCheckExprs:
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: ClusterRepository
+      current: status.conditions.filter(c, c.type == 'Ready').exists(c, c.status == 'True')
+      failed: status.conditions.filter(c, c.type == 'Stalled').exists(c, c.status == 'True')
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: true

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -35,6 +35,13 @@ spec:
       kind: ClusterRepository
       current: status.conditions.filter(c, c.type == 'Ready').exists(c, c.status == 'True')
       failed: status.conditions.filter(c, c.type == 'Stalled').exists(c, c.status == 'True')
+  # Health-gate only the ClusterRepository, not every object in the path:
+  # `wait: true` would also gate on RepositoryReplication, letting a failed
+  # nightly NFS sync block rollouts of every app that dependsOn this.
+  healthChecks:
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: ClusterRepository
+      name: homelab
   interval: 1h
   path: ./kubernetes/apps/kopiur-system/kopiur/repository
   postBuild:
@@ -47,4 +54,3 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: kopiur-system
-  wait: true

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: homelab
+spec:
+  backend:
+    b2:
+      bucket: crayon-club-backups
+      prefix: kopiur/
+      auth:
+        secretRef:
+          name: kopiur-repository
+          namespace: kopiur-system
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  # create-time settings (encryption/splitter/hash/ecc) are immutable after init
+  create:
+    enabled: true
+  allowedNamespaces:
+    list:
+      - ai
+      - ai-sandbox
+      - documents
+      - finance
+      - kopiur-system
+      - maker
+      - media
+      - observability
+      - social
+  credentialProjection:
+    allowed: true
+  moverDefaults:
+    cache:
+      capacity: 8Gi
+      storageClassName: openebs-hostpath

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -21,16 +21,7 @@ spec:
   create:
     enabled: true
   allowedNamespaces:
-    list:
-      - ai
-      - ai-sandbox
-      - documents
-      - finance
-      - kopiur-system
-      - maker
-      - media
-      - observability
-      - social
+    all: true
   credentialProjection:
     allowed: true
   moverDefaults:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -24,6 +24,9 @@ spec:
     all: true
   credentialProjection:
     allowed: true
+  identityDefaults:
+    hostnameExpr: namespace
+    usernameExpr: namespace + '-' + policyName
   moverDefaults:
     cache:
       capacity: 8Gi

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./clusterrepository.yaml
+  - ./repositoryreplication.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: RepositoryReplication
+metadata:
+  name: homelab-nfs
+spec:
+  sourceRef:
+    kind: ClusterRepository
+    name: homelab
+  destination:
+    filesystem:
+      path: /repository
+      volume:
+        nfs:
+          server: storage.lan
+          path: /mnt/tank/backup/kopiur
+  # daily, in the same overnight window as the CNPG B2 backup (07:30 UTC);
+  # destinationEncryption omitted -> true mirror reusing the source password
+  schedule:
+    cron: H 7 * * *
+    jitter: 15m

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kopiur-repository
+stringData:
+  B2_KEY_ID: ENC[AES256_GCM,data:f7Bd9RWStPXpbQ==,iv:MXAaxUoknxfFhLURPKdXFTUYJ1fI6K00tee28ZX/nUs=,tag:fyCWgjixyWKh0DEYLQ5Mvg==,type:str]
+  B2_KEY: ENC[AES256_GCM,data:WMjjX5PWxwFOzw==,iv:cKPxQHL/zoNrR7z0gNKDm9ntqNn7Eoyap28ZRnBARks=,tag:/DnhEqQtC+Pj3unn/G/VrQ==,type:str]
+  KOPIA_PASSWORD: ENC[AES256_GCM,data:f9VOMPKZxyu4rg==,iv:60yJHl1sScKmT7HVj4Ift3BjebpwO4jfGMzxsM96Dzk=,tag:o3YGcOv/mma23VndpwbTlA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLdzJxTFlTQStUK25PSld3
+        aFNtSFpzK1J1VzRrOWtxemg4U3B0S3M3UkNnCnhZNXh4Tk9qWGZqVlJiSjFBWmdp
+        OEdXMTRoRDdNZUpoWGtTb1lOTWpYT1UKLS0tIGdLY1NoODJNRkdZdjY2UDM2VXNo
+        NEV4SFV2YXVWcjlieENMUFRzdW11bmMKkHbTxpx0TsoJ4+RKQkTcAKwAG15hbtkE
+        XLYR1hf1nNsJZWq2Pm8JAEA2TtApD/Y0OcX/FnT5rC2wuUco1IVwpA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-02T18:12:37Z"
+  mac: ENC[AES256_GCM,data:ggHM5DN8U6HL/A49y3VrEm6G1MDt+F8GAAeG9xiwWjYKPvFRuVZlKkseZkUA/F+n5Nx3FQf45hiUHvYUo9r1dVLbEnurmxpph8f48XiY2plgsVvBGwN6iOm2Carr/89+JMFI74iGctNuoYtfocYYaNZXufIK8hQbPSYwMvp8JUY=,iv:VvsYcD+Lllbesj+c4Z543zwRxS1W4Em/w0Xlszji3QM=,tag:9+F9md8lw20DNCx267EDfw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./kopiur/ks.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -7,8 +7,11 @@ spec:
   dependsOn:
     - name: volsync
       namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/media/recyclarr/app
   postBuild:

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -7,8 +7,11 @@ spec:
   dependsOn:
     - name: volsync
       namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/media/seerr/app
   postBuild:

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -15,3 +15,7 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
+      expr: |-
+        status.phase != "Running"

--- a/kubernetes/components/kopiur/backup/kustomization.yaml
+++ b/kubernetes/components/kopiur/backup/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${APP}
+spec:
+  repository:
+    kind: ClusterRepository
+    name: homelab
+  credentialProjection:
+    enabled: true
+  sources:
+    - pvc:
+        name: ${APP}
+  copyMethod: Snapshot
+  volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=openebs-zfs-snapshot}
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+  mover:
+    securityContext:
+      runAsUser: ${VOLSYNC_UID}
+      runAsGroup: ${VOLSYNC_GID}
+    podSecurityContext:
+      fsGroup: ${VOLSYNC_GID}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -17,6 +17,14 @@ spec:
   retention:
     keepHourly: 24
     keepDaily: 7
+  verification:
+    quick:
+      cron: H 4 * * *
+      jitter: 1h
+    deep:
+      schedule:
+        cron: H 5 1 * *
+        jitter: 1h
   mover:
     securityContext:
       runAsUser: ${VOLSYNC_UID}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -13,6 +13,9 @@ spec:
     - pvc:
         name: ${APP}
   copyMethod: Snapshot
+  files:
+    ignoreRules:
+      - lost+found
   volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=openebs-zfs-snapshot}
   retention:
     keepHourly: 24

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: ${APP}
+spec:
+  policyRef:
+    name: ${APP}
+  schedule:
+    cron: H * * * *
+    concurrencyPolicy: Forbid

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -9,3 +9,4 @@ spec:
   schedule:
     cron: H * * * *
     concurrencyPolicy: Forbid
+    runOnCreate: false


### PR DESCRIPTION
## Summary

Phases 0–2 of the VolSync→kopiur migration. Deploys the kopiur operator (0.4.13, `installScope: cluster`) into a new `kopiur-system` namespace **alongside** VolSync — nothing is removed yet — and pilots the new backup path on **recyclarr** and **seerr**.

- **`infra/backblaze/`** — new prefix-scoped B2 application key `kopiur` (`kopiur/` in the existing `crayon-club-backups` bucket) + 1Password item.
- **`kubernetes/apps/kopiur-system/`** — operator HelmRelease (ServiceMonitor, PrometheusRule, Grafana dashboard), `ClusterRepository homelab` on B2, and a daily additive-only `RepositoryReplication` mirror to `storage.lan:/mnt/tank/backup/kopiur` (`H 7 * * *`).
- **`kubernetes/components/kopiur/backup/`** — SnapshotPolicy + SnapshotSchedule component (hourly, `copyMethod: Snapshot`, reuses `VOLSYNC_UID/GID` substitutions) that coexists with the volsync component on pilot apps.

### Topology (deliberate)

B2 is the **primary** backend; NFS is the daily mirror. This is intentional: the NAS stays powered off outside a daily window to save power, so it can't host hourly movers — and as a side effect the mirror is effectively air-gapped ~23h/day. Do not flip this.

### Review hardening (post-review commits)

- Repository Kustomization health-gates on the ClusterRepository **only** (no `wait: true`), so a failed nightly NFS sync can't block app rollouts that `dependsOn` it.
- `allowedNamespaces: all: true` — credentials still only project into namespaces with an opted-in SnapshotPolicy. Reviewed the credentialProjection blast radius against onedr0p/eleboucher/buroa; accepted (see repo memini notes).
- `identityDefaults` partitions snapshot identities per namespace (community convention).
- Daily quick + monthly deep repository verification (deep reads B2 blobs back → egress, trivial at pilot scale).
- tuppr `TalosUpgrade` now blocks while kopiur Snapshots are running (zfs-localpv movers have been stranded by mid-backup drains before).
- Small touches: `files.ignoreRules: [lost+found]`, `runOnCreate: false`.

## Before merge / before first replication window

- [ ] `just apply` in `infra/backblaze/` (plan is clean: 2 adds — B2 key + 1Password item)
- [ ] Generate `KOPIA_PASSWORD` (e.g. `openssl rand -base64 32`) and store it in 1Password — the repo is unrecoverable without it
- [ ] `sops edit kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml` and fill the three `REPLACE_ME` placeholders (`B2_KEY_ID`, `B2_KEY`, `KOPIA_PASSWORD`)
- [ ] On the NAS: `mkdir /mnt/tank/backup/kopiur && chown 65532:65532 /mnt/tank/backup/kopiur` (fsGroup is a no-op on NFS; replication mover runs as 65532)
- [ ] Confirm the NAS power window covers the replication schedule — `H 7 * * *` resolves to a fixed arbitrary minute in 07:00–07:59 UTC; pin the minute if the window is tight

## After merge

- [ ] Watch `kubectl get clusterrepository homelab` go Ready (bad secret surfaces immediately via the health gate)
- [ ] Verify first hourly snapshots for recyclarr + seerr and the first nightly B2→NFS replication

## Future steps (not this PR)

- [ ] **Phase 3:** restore drills on recyclarr — gates the fleet rollout
- [ ] Fleet rollout: add the kopiur component to the remaining backed-up apps (per-app `VOLSYNC_UID/GID` already established)
- [ ] **At full VolSync cutover:** add the Restore + PVC-populator bootstrap component (replaces volsync `replicationdestination.yaml`/`pvc.yaml`) and `KOPIUR_*` override knobs per eleboucher's convention; rename `VOLSYNC_*` substitutions to `KOPIUR_*` (memini reminder saved)
- [ ] Remove VolSync: components, per-app secrets, operator, `/mnt/tank/backup/volsync`, and the tuppr VolSync health check
- [ ] Treat every Renovate bump of the `kopiur` OCIRepository as a real review — the project is alpha and has renamed CRDs before

🤖 Generated with [Claude Code](https://claude.com/claude-code)