### PR TITLE
fix(renovate): dedupe Talos PRs by unifying on the talos-factory dep

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,7 +6,7 @@ metadata:
   name: talos
 spec:
   talos:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
     version: v1.13.5
   policy:
     rebootMode: powercycle

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -1,7 +1,6 @@
 ---
 clusterName: homelab
 
-# renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.5
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.2


### PR DESCRIPTION
## Problem

Since adopting `github>home-operations/renovate-presets`, every Talos bump produces **two** PRs (currently #1217 and #1218):

- The preset's **talosFactory** custom manager matches `talosVersion:` in `talos/talconfig.yaml` as dep `siderolabs/talos` (datasource `custom.talos-factory`) → #1218, which only touches talconfig.
- The pre-existing `# renovate: depName=ghcr.io/siderolabs/installer` annotations (picked up by the preset's **annotated** manager) match the same version in talconfig **and** the tuppr `TalosUpgrade` → #1217.

Same bump, two deps, two branches.

## Fix

Make the talos-factory dep the single owner of the Talos version:

- `talos/talconfig.yaml`: drop the installer annotation — talosFactory matches the `talosVersion:` line natively. (The kubelet annotation on `kubernetesVersion` is untouched.)
- `kubernetes/.../tuppr/upgrades/talosupgrade.yaml`: repoint the annotation to `datasource=custom.talos-factory depName=siderolabs/talos`, so it resolves to the same dep and rides the same branch.

No `.renovaterc.json5` changes needed.

## Aftermath

Once merged: dep `ghcr.io/siderolabs/installer` disappears → Renovate autocloses #1217; #1218's branch gets updated to include both files and becomes the single Talos PR.

Verified: `renovate-config-validator` passes, `just test` passes (159), and `https://factory.talos.dev/versions` serves v1.13.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)