### PR TITLE
chore(ci): drop flate diff job, konflate renders PR diffs in-cluster

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -46,72 +46,10 @@ jobs:
       - name: Run Flate test
         run: flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets
 
-  diff:
-    if: ${{ needs.filter.outputs.changed-files != '[]' }}
-    needs: filter
-    name: Flate - Diff
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    strategy:
-      matrix:
-        resource:
-          - helmrelease
-          - kustomization
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # Full history so flate can materialize the base tree (FLATE_BASE,
-          # default "main") and diff the PR against it in changed-only mode.
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Install Flate
-        uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
-
-      - name: Run Flate diff
-        id: diff
-        env:
-          KIND: ${{ matrix.resource }}
-        run: |
-          set -eo pipefail
-          flate diff "$KIND" \
-            --path ./kubernetes/flux/cluster \
-            --allow-missing-secrets \
-            -o github | tee diff.patch
-          {
-            echo 'diff<<EOF'
-            cat diff.patch
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-          {
-            echo "### Diff — ${KIND}"
-            echo '```diff'
-            cat diff.patch
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Add Comment
-        if: ${{ steps.diff.outputs.diff != '' }}
-        continue-on-error: true
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
-        with:
-          message-id: ${{ github.event.pull_request.number }}/flate/${{ matrix.resource }}
-          message-failure: Diff was not successful
-          message: |
-            #### Flate diff — `${{ matrix.resource }}`
-            ```diff
-            ${{ steps.diff.outputs.diff }}
-            ```
-
   success:
     if: ${{ !cancelled() }}
     needs:
       - test
-      - diff
     name: Flate - Success
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

konflate now renders each PR's diff and posts a PR comment + status check from in-cluster (see #1230), so the CI **`diff`** job in `flate.yaml` is redundant. This removes it and drops it from the `success` aggregator's `needs`.

- **Removed** the `diff` job (`flate diff helmrelease|kustomization` matrix + `mshick/add-pr-comment`) — 100% duplicated by konflate's PR comment.
- **Updated** `success.needs` to `[test]`.
- **Kept** the `test` job.

## Why keep `test`

konflate's status check is scoped to a PR's **changed** resources and depends on the in-cluster service + webhook being up. `flate test all` renders the **whole** cluster tree in a clean-room GitHub Actions gate — independent of cluster/konflate health and deterministic per-push. Different guarantee, so it stays as the required gate.

## Bonus

Removes the known flake where `Flate - Diff (helmrelease)` spuriously failed on PRs that bump a Flux `GitRepository` commit ref.

## Note

Best merged after #1230 (the konflate GitHub App switch) is live, so PR-diff coverage is continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)