### PR TITLE
feat(observability): manage prometheus-operator CRDs via Flux

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -19,7 +19,10 @@ releases:
     chart: oci://mirror.gcr.io/envoyproxy/gateway-helm
     version: v1.8.2
 
-  - name: kube-prometheus-stack
+  # pre-seeds the monitoring.coreos.com CRDs so first reconcile is clean;
+  # steady-state they're owned by the prometheus-operator-crds HelmRelease
+  # in kubernetes/apps/observability/
+  - name: prometheus-operator-crds
     namespace: observability
-    chart: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
-    version: 87.14.0
+    chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
+    version: 30.0.1

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ./namespace.yaml
   - ./grafana/ks.yaml
   - ./kepler/ks.yaml
+  - ./prometheus-operator-crds/ks.yaml
   - ./snmp-exporter/ks.yaml
   - ./victoria/ks.yaml

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-operator-crds
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: prometheus-operator-crds
+  interval: 1h

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/kustomization.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: prometheus-operator-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 30.0.1
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds

--- a/kubernetes/apps/observability/prometheus-operator-crds/ks.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prometheus-operator-crds
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: prometheus-operator-crds
+      namespace: observability
+  interval: 1h
+  path: ./kubernetes/apps/observability/prometheus-operator-crds/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: true

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 metadata:
   name: victoria-metrics-operator
 spec:
+  dependsOn:
+    # the VM operator watches prometheus-operator CRs (ServiceMonitor,
+    # PodMonitor, PrometheusRule, ...) and converts them to VM equivalents
+    - name: prometheus-operator-crds
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease


### PR DESCRIPTION
## Problem

The `monitoring.coreos.com` CRDs were only installed by `bootstrap/helmfile.d/00-crds.yaml`, which runs once at cluster bootstrap. Renovate has been dutifully bumping the kube-prometheus-stack pin there (86.3.2 → 87.14.0 across 7+ PRs), but nothing re-applied the CRDs in-cluster — they were stuck at prometheus-operator `0.89.0` while the pin advanced to `0.92.1`.

## Changes

- **New `prometheus-operator-crds` HelmRelease** under `kubernetes/apps/observability/` — Flux now owns and continuously reconciles the CRDs, so Renovate bumps actually land.
- **Bootstrap swap**: `00-crds.yaml` now uses the same CRDs-only `prometheus-operator-crds` chart instead of kube-prometheus-stack. Validated byte-identical output: both charts vendor the same `crds` subchart, and rendering both through the bootstrap script's exact pipeline (`helm template --include-crds --no-hooks` + yq CRD filter) diffs to zero YAML changes (only `# Source:` comments). The bootstrap entry is now just a pre-seed for first-boot ordering.
- **`dependsOn`**: `victoria-metrics-operator` now depends on `prometheus-operator-crds` (the VM operator watches these CRDs for prometheus→VM conversion), transitively ordering vmks and victoria-logs.

## Out-of-band (already done)

The existing in-cluster CRDs were applied via `kubectl apply --server-side` with no Helm ownership metadata, which would make the first `helm install` fail with "invalid ownership metadata". All 10 CRDs have been annotated (`meta.helm.sh/release-name`/`-namespace`) and labeled (`app.kubernetes.io/managed-by=Helm`) for adoption.

## After merge

First reconcile will adopt the CRDs and upgrade them 0.89.0 → 0.92.1 — expect diffs on all 10 CRDs (three chart-versions of catch-up, purely additive schema fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)