### PR TITLE
feat(kopiur): deploy kopiur operator, NFS ClusterRepository, and backup component

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -27,6 +27,7 @@ TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 "aqua:cilium/cilium-cli" = "0.19.5"
 "aqua:cloudflare/cloudflared" = "2026.7.1"
 "github:cloudnative-pg/cloudnative-pg" = "1.30.0"
+"github:home-operations/kopiur" = "0.7.2"
 # flux
 "aqua:FiloSottile/age" = "1.3.1"
 "aqua:fluxcd/flux2" = "2.9.1"

--- a/infra/backblaze/keys.tf
+++ b/infra/backblaze/keys.tf
@@ -12,6 +12,20 @@ resource "b2_application_key" "cnpg" {
   name_prefix = "cnpg/"
 }
 
+resource "b2_application_key" "kopiur" {
+  key_name   = "kopiur"
+  bucket_ids = [b2_bucket.homelab_backups.bucket_id]
+  capabilities = [
+    "listBuckets",
+    "readBuckets",
+    "listFiles",
+    "readFiles",
+    "writeFiles",
+    "deleteFiles",
+  ]
+  name_prefix = "kopiur/"
+}
+
 data "onepassword_vault" "vault" {
   name = var.onepassword.vault
 }
@@ -23,5 +37,15 @@ resource "onepassword_item" "cnpg_key" {
 
   username            = b2_application_key.cnpg.application_key_id
   password_wo         = b2_application_key.cnpg.application_key
+  password_wo_version = 1
+}
+
+resource "onepassword_item" "kopiur_key" {
+  vault    = data.onepassword_vault.vault.uuid
+  title    = "kopiur key"
+  category = "login"
+
+  username            = b2_application_key.kopiur.application_key_id
+  password_wo         = b2_application_key.kopiur.application_key
   password_wo_version = 1
 }

--- a/infra/backblaze/keys.tf
+++ b/infra/backblaze/keys.tf
@@ -23,7 +23,7 @@ resource "b2_application_key" "kopiur" {
     "writeFiles",
     "deleteFiles",
   ]
-  name_prefix = "kopiur/"
+  name_prefix = "kopia/"
 }
 
 data "onepassword_vault" "vault" {
@@ -47,5 +47,5 @@ resource "onepassword_item" "kopiur_key" {
 
   username            = b2_application_key.kopiur.application_key_id
   password_wo         = b2_application_key.kopiur.application_key
-  password_wo_version = 1
+  password_wo_version = 2
 }

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  interval: 1h
+  values:
+    monitoring:
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana
+      prometheusRule:
+        enabled: true
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        memory: 2Gi

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -10,6 +10,15 @@ spec:
     name: kopiur
   interval: 1h
   values:
+    features:
+      credentialProjection:
+        # Third leg of the projection handshake (with `allowed` on the
+        # ClusterRepository and `enabled` on each SnapshotPolicy/Restore):
+        # grants the operator cluster-wide Secret create/patch/delete RBAC so
+        # it can copy the repository credentials into mover namespaces. Off by
+        # default in the chart; without it every projected mover fails with an
+        # HTTP 403 condition on the CR.
+        enabled: true
     monitoring:
       dashboards:
         enabled: true

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -24,5 +24,8 @@ spec:
     resources:
       requests:
         cpu: 100m
+        # Without an explicit request, Kubernetes copies the 2Gi limit into
+        # the request and permanently reserves it on a node.
+        memory: 256Mi
       limits:
         memory: 2Gi

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.7.2
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -26,6 +26,21 @@ metadata:
 spec:
   dependsOn:
     - name: kopiur
+  # Every app's ks gates on this Kustomization, so it must only report Ready
+  # once the repository actually connects — otherwise a bad NFS export or
+  # KOPIA_PASSWORD leaves every PVC Pending on an unresolvable Restore while
+  # Flux shows the backup stack green. `wait` stays false so the offsite
+  # RepositoryReplication (auth-failing until the B2 key lands) never gates
+  # app reconciliation.
+  healthChecks:
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: ClusterRepository
+      name: homelab
+  healthCheckExprs:
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: ClusterRepository
+      current: has(status.phase) && status.phase == 'Ready'
+      failed: has(status.phase) && status.phase in ['Failed', 'Degraded']
   interval: 1h
   path: ./kubernetes/apps/kopiur-system/kopiur/repository
   postBuild:

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  dependsOn:
+    - name: openebs
+      namespace: openebs-system
+    - name: snapshot-controller
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository
+spec:
+  dependsOn:
+    - name: kopiur
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: false

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   allowedNamespaces:
     all: true
+  credentialProjection:
+    # Movers run in each app's namespace and need KOPIA_PASSWORD co-resident
+    # there. Projection is fail-closed: this owner-side gate AND the
+    # consumer-side `credentialProjection.enabled` on every SnapshotPolicy/
+    # Restore (components/kopiur) must both be set or movers outside
+    # kopiur-system can't open the repository.
+    allowed: true
   backend:
     filesystem:
       # In-pod mount point; the NFS export below is what's behind it. The

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: homelab
+spec:
+  allowedNamespaces:
+    all: true
+  backend:
+    filesystem:
+      # In-pod mount point; the NFS export below is what's behind it. The
+      # export is mapall=4003:4003 (like the volsync one was), so every mover
+      # uid presents as the directory owner server-side and repo writes never
+      # depend on the per-app mover uid.
+      path: /repo
+      volume:
+        nfs:
+          server: storage.lan
+          path: /mnt/tank/backup/kopia
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./clusterrepository.yaml
+  - ./repositoryreplication.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -16,7 +16,8 @@ spec:
         secretRef:
           name: kopiur-repository-secret
   schedule:
-    # After the nightly snapshots (H 8 * * *) have landed.
+    # Daily offsite sync of the hourly snapshots. Planned follow-up: flip the
+    # topology so B2 is the primary repository and TrueNAS the replica.
     cron: H 10 * * *
   sync:
     # kopia sync-to defaults to one blob at a time; without this the initial

--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repositoryreplication_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: RepositoryReplication
+metadata:
+  name: homelab-offsite
+spec:
+  sourceRef:
+    kind: ClusterRepository
+    name: homelab
+  destination:
+    b2:
+      bucket: crayon-club-backups
+      prefix: kopiur/
+      auth:
+        secretRef:
+          name: kopiur-repository-secret
+  schedule:
+    # After the nightly snapshots (H 8 * * *) have landed.
+    cron: H 10 * * *
+  sync:
+    # kopia sync-to defaults to one blob at a time; without this the initial
+    # seed to B2 would take days.
+    parallel: 8

--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -11,7 +11,7 @@ spec:
   destination:
     b2:
       bucket: crayon-club-backups
-      prefix: kopiur/
+      prefix: kopia/
       auth:
         secretRef:
           name: kopiur-repository-secret

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kopiur-repository-secret
+stringData:
+  #ENC[AES256_GCM,data:mNhie4tRMgz+vrG4FvdV9lSo9kn6E9SAvo79RScAiK+HAblUITGjPqogQqDChwP9NWEuzUrU+hGH8QH0zLbD,iv:KWHkVa5xPVs2Slh0gR2sC1At2rPZfR3+4L6BbqJryPE=,tag:Y/pp8f1NDqXCK+G4RzP1qA==,type:comment]
+  #ENC[AES256_GCM,data:wFMfNv2jjpCBaBK/zjcgfP1saPOMHj6Uf776Wy/CJeXdUWjTv7dW9uszbhopONwdzRsMUZoELTUqicIWKKe2VV9cDQ==,iv:d8PUkgPstLqKt7dJYH+1cFm5QW3flqnt0LWqcPV6pzI=,tag:yd2Xh0C8W+pR/Wb1W3fYgQ==,type:comment]
+  #ENC[AES256_GCM,data:f93GEu7aGKNwbN0Q,iv:U9kms5Q/doyZ1CxKUdiqiMlVtfrvmDNky+sox1y88do=,tag:/0ytx/sd8zI0I4wtHF0lrA==,type:comment]
+  KOPIA_PASSWORD: ENC[AES256_GCM,data:kcHQmNsvsMDLGQbKaxbGAzb1uc3jRH8PGrt1gDSR5eejz/fYcmFxKROzuT0IIYUy,iv:od2/ULq5ghTDl2IbZcvQ94cbfUyvcEu7YqL8ofJiQJQ=,tag:3y/PnxtrQbghASFdKWkQcg==,type:str]
+  #ENC[AES256_GCM,data:aOzga2GDTCpUsOXPbQ0gGIiYVSH415++TjCWfvm3xF43EDrRiU63Yz5l9dI0DJQ2fgyQ5Q==,iv:4MlHOx5cRvhxxr67kKjOSXfdcrhKycx75ivrPYKTlp0=,tag:E4OR7jSdu6+5DILzT8nQlg==,type:comment]
+  #ENC[AES256_GCM,data:90kUwVnAqmgAdQ4pqp1Xi7tXNzrZyKHHBs7dAHk12RgmxnMIRhH52O4CqqbXSeihPUIi7MwUiPuXcf+FuHIs850V8GQ=,iv:MO7ODgW77rGNDPrnVfDzshMRmviyhmYuaLSYz9Uua9Y=,tag:EL+nU1zYUhsB3R5yOs0SEQ==,type:comment]
+  #ENC[AES256_GCM,data:TsFPlnpwnt/94cQtrW4h,iv:K5HkaAryjppmMgjmPFoPRmAYmPytSWDFo+8/xwBcnjU=,tag:thjlKNUr9ay+PaAbnXuNPA==,type:comment]
+  B2_KEY_ID: ENC[AES256_GCM,data:p+5MlMVkYACSNqtyEfz7bx4GgEDWw3vV,iv:SMirKikrPmny0VjmvcvReAEKw81AnyJcXzgVMSz4XdI=,tag:7xyyp2O+Zmygkvsux5RViw==,type:str]
+  B2_KEY: ENC[AES256_GCM,data:0J9//zuz2t3dC7e8jyntDOKnN8uN5pjo,iv:NC3KLmBmsCa+9TbtYf/i4tEAvoWK7HfEp2Tb7L+8e40=,tag:d4rrKawbGljoeSDFQacOQg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBV2FhTVNmWGxRc0sveTQ4
+        akJZLzN2VE04OXgxbjNNb0FZYVkxZXJ4SkUwCnhBdStxb3pSamd1REc2d1BkaXlB
+        NjNLTEt4V2JDOUlsQm1yT291RGdBMjgKLS0tIHlOSDgxZGZNbFZPMlE4N0pYYjhs
+        ZDB3VHJOTHZaaitnTGRBYnhuc3ZxcncKHSC/knYP6O8RGBPrF83n4hdvHu5sBZE2
+        OH9CbVADtC0jJzfAtCcKDvLFhnF4rbXR/7GiF80pr7qEZeSbJCcOSw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-12T04:33:05Z"
+  mac: ENC[AES256_GCM,data:ZhZUva6wTh6TPt5Hp4SjH7uHEwFRSRerbdjxbSAkQ/h8gxlgMTzv5ZzjandALedWiHrdlYknuA3QJnTY8MvRNpSQNav/Z/emdnN0EiDzhPHQ8Z9x/sVfPz1rF6I510+JZ/Im4tVEkJoX7cOyuBHQiEVKJ7GTfJkKLqRe9tStFak=,iv:3rf3UE9pgsINmgb82mYQprh+IoQMRdghX58O7lX3Qws=,tag:o06VOGT7afI72M8bArw0Kg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kopiur-repository-secret
+    name: kopiur-repository-secret
 stringData:
-  #ENC[AES256_GCM,data:mNhie4tRMgz+vrG4FvdV9lSo9kn6E9SAvo79RScAiK+HAblUITGjPqogQqDChwP9NWEuzUrU+hGH8QH0zLbD,iv:KWHkVa5xPVs2Slh0gR2sC1At2rPZfR3+4L6BbqJryPE=,tag:Y/pp8f1NDqXCK+G4RzP1qA==,type:comment]
-  #ENC[AES256_GCM,data:wFMfNv2jjpCBaBK/zjcgfP1saPOMHj6Uf776Wy/CJeXdUWjTv7dW9uszbhopONwdzRsMUZoELTUqicIWKKe2VV9cDQ==,iv:d8PUkgPstLqKt7dJYH+1cFm5QW3flqnt0LWqcPV6pzI=,tag:yd2Xh0C8W+pR/Wb1W3fYgQ==,type:comment]
-  #ENC[AES256_GCM,data:f93GEu7aGKNwbN0Q,iv:U9kms5Q/doyZ1CxKUdiqiMlVtfrvmDNky+sox1y88do=,tag:/0ytx/sd8zI0I4wtHF0lrA==,type:comment]
-  KOPIA_PASSWORD: ENC[AES256_GCM,data:kcHQmNsvsMDLGQbKaxbGAzb1uc3jRH8PGrt1gDSR5eejz/fYcmFxKROzuT0IIYUy,iv:od2/ULq5ghTDl2IbZcvQ94cbfUyvcEu7YqL8ofJiQJQ=,tag:3y/PnxtrQbghASFdKWkQcg==,type:str]
-  #ENC[AES256_GCM,data:aOzga2GDTCpUsOXPbQ0gGIiYVSH415++TjCWfvm3xF43EDrRiU63Yz5l9dI0DJQ2fgyQ5Q==,iv:4MlHOx5cRvhxxr67kKjOSXfdcrhKycx75ivrPYKTlp0=,tag:E4OR7jSdu6+5DILzT8nQlg==,type:comment]
-  #ENC[AES256_GCM,data:90kUwVnAqmgAdQ4pqp1Xi7tXNzrZyKHHBs7dAHk12RgmxnMIRhH52O4CqqbXSeihPUIi7MwUiPuXcf+FuHIs850V8GQ=,iv:MO7ODgW77rGNDPrnVfDzshMRmviyhmYuaLSYz9Uua9Y=,tag:EL+nU1zYUhsB3R5yOs0SEQ==,type:comment]
-  #ENC[AES256_GCM,data:TsFPlnpwnt/94cQtrW4h,iv:K5HkaAryjppmMgjmPFoPRmAYmPytSWDFo+8/xwBcnjU=,tag:thjlKNUr9ay+PaAbnXuNPA==,type:comment]
-  B2_KEY_ID: ENC[AES256_GCM,data:p+5MlMVkYACSNqtyEfz7bx4GgEDWw3vV,iv:SMirKikrPmny0VjmvcvReAEKw81AnyJcXzgVMSz4XdI=,tag:7xyyp2O+Zmygkvsux5RViw==,type:str]
-  B2_KEY: ENC[AES256_GCM,data:0J9//zuz2t3dC7e8jyntDOKnN8uN5pjo,iv:NC3KLmBmsCa+9TbtYf/i4tEAvoWK7HfEp2Tb7L+8e40=,tag:d4rrKawbGljoeSDFQacOQg==,type:str]
+    #ENC[AES256_GCM,data:mNhie4tRMgz+vrG4FvdV9lSo9kn6E9SAvo79RScAiK+HAblUITGjPqogQqDChwP9NWEuzUrU+hGH8QH0zLbD,iv:KWHkVa5xPVs2Slh0gR2sC1At2rPZfR3+4L6BbqJryPE=,tag:Y/pp8f1NDqXCK+G4RzP1qA==,type:comment]
+    #ENC[AES256_GCM,data:wFMfNv2jjpCBaBK/zjcgfP1saPOMHj6Uf776Wy/CJeXdUWjTv7dW9uszbhopONwdzRsMUZoELTUqicIWKKe2VV9cDQ==,iv:d8PUkgPstLqKt7dJYH+1cFm5QW3flqnt0LWqcPV6pzI=,tag:yd2Xh0C8W+pR/Wb1W3fYgQ==,type:comment]
+    #ENC[AES256_GCM,data:f93GEu7aGKNwbN0Q,iv:U9kms5Q/doyZ1CxKUdiqiMlVtfrvmDNky+sox1y88do=,tag:/0ytx/sd8zI0I4wtHF0lrA==,type:comment]
+    KOPIA_PASSWORD: ENC[AES256_GCM,data:xCATQMNr5arhFTN/LXLVihk26cWgAf3DnhNNiAUSwYRfmQE51lA5tWVm,iv:3A3Z5qr45KLglwOZJreZxj5BIrgo/u8Nl6PuFTW4MDE=,tag:BCHJ9NwAkUt+UwbuIkb8nQ==,type:str]
+    #ENC[AES256_GCM,data:aOzga2GDTCpUsOXPbQ0gGIiYVSH415++TjCWfvm3xF43EDrRiU63Yz5l9dI0DJQ2fgyQ5Q==,iv:4MlHOx5cRvhxxr67kKjOSXfdcrhKycx75ivrPYKTlp0=,tag:E4OR7jSdu6+5DILzT8nQlg==,type:comment]
+    #ENC[AES256_GCM,data:90kUwVnAqmgAdQ4pqp1Xi7tXNzrZyKHHBs7dAHk12RgmxnMIRhH52O4CqqbXSeihPUIi7MwUiPuXcf+FuHIs850V8GQ=,iv:MO7ODgW77rGNDPrnVfDzshMRmviyhmYuaLSYz9Uua9Y=,tag:EL+nU1zYUhsB3R5yOs0SEQ==,type:comment]
+    #ENC[AES256_GCM,data:TsFPlnpwnt/94cQtrW4h,iv:K5HkaAryjppmMgjmPFoPRmAYmPytSWDFo+8/xwBcnjU=,tag:thjlKNUr9ay+PaAbnXuNPA==,type:comment]
+    B2_KEY_ID: ENC[AES256_GCM,data:7SM0RLB1JxaB64t8tmCAyFD59gUsBhTQJQ==,iv:T14O7cfmhda7R+6Z/Q4hlrJgAVeLG8G0rUyrsn/oK5c=,tag:/M+VARZsD8bw1mfRPVA4qQ==,type:str]
+    B2_KEY: ENC[AES256_GCM,data:abjrl1CJeRoM9mYkdz5rOcC4j6zfwu5El90NPTWMJw==,iv:+KF2tKtl9QKoRtw/2Zbqk1jVyWWQ62BuWK5Mo30UiRc=,tag:Km53I649xzEdoD5uiVPXlw==,type:str]
 sops:
-  age:
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBV2FhTVNmWGxRc0sveTQ4
-        akJZLzN2VE04OXgxbjNNb0FZYVkxZXJ4SkUwCnhBdStxb3pSamd1REc2d1BkaXlB
-        NjNLTEt4V2JDOUlsQm1yT291RGdBMjgKLS0tIHlOSDgxZGZNbFZPMlE4N0pYYjhs
-        ZDB3VHJOTHZaaitnTGRBYnhuc3ZxcncKHSC/knYP6O8RGBPrF83n4hdvHu5sBZE2
-        OH9CbVADtC0jJzfAtCcKDvLFhnF4rbXR/7GiF80pr7qEZeSbJCcOSw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
-  encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-07-12T04:33:05Z"
-  mac: ENC[AES256_GCM,data:ZhZUva6wTh6TPt5Hp4SjH7uHEwFRSRerbdjxbSAkQ/h8gxlgMTzv5ZzjandALedWiHrdlYknuA3QJnTY8MvRNpSQNav/Z/emdnN0EiDzhPHQ8Z9x/sVfPz1rF6I510+JZ/Im4tVEkJoX7cOyuBHQiEVKJ7GTfJkKLqRe9tStFak=,iv:3rf3UE9pgsINmgb82mYQprh+IoQMRdghX58O7lX3Qws=,tag:o06VOGT7afI72M8bArw0Kg==,type:str]
-  mac_only_encrypted: true
-  version: 3.13.2
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBV2FhTVNmWGxRc0sveTQ4
+            akJZLzN2VE04OXgxbjNNb0FZYVkxZXJ4SkUwCnhBdStxb3pSamd1REc2d1BkaXlB
+            NjNLTEt4V2JDOUlsQm1yT291RGdBMjgKLS0tIHlOSDgxZGZNbFZPMlE4N0pYYjhs
+            ZDB3VHJOTHZaaitnTGRBYnhuc3ZxcncKHSC/knYP6O8RGBPrF83n4hdvHu5sBZE2
+            OH9CbVADtC0jJzfAtCcKDvLFhnF4rbXR/7GiF80pr7qEZeSbJCcOSw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-12T17:29:54Z"
+    mac: ENC[AES256_GCM,data:1kHlOY7t9fuErfPF9KvdkIxfs45Lyc9HtXTEP+sl36op2fElbl6w3V7Kdq6WRMO927/TpPkpndkGNOWWXq00W5+C2YIvk/eIrJbYAN3dzSojTkkph0fv7v6xtgXylMlZbFF3GnJf7+rtOcni1+NR4BeQm7jvZFI4Pf+xDQm1klI=,iv:+uTad9pALX6+i8XZ6u3n6almE4jdHreKFKEwbpYcS8g=,tag:xj/v4bHCeyYVhw8P0N+1AQ==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.2

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: kopiur-repository-secret
+  name: kopiur-repository-secret
 stringData:
-    #ENC[AES256_GCM,data:mNhie4tRMgz+vrG4FvdV9lSo9kn6E9SAvo79RScAiK+HAblUITGjPqogQqDChwP9NWEuzUrU+hGH8QH0zLbD,iv:KWHkVa5xPVs2Slh0gR2sC1At2rPZfR3+4L6BbqJryPE=,tag:Y/pp8f1NDqXCK+G4RzP1qA==,type:comment]
-    #ENC[AES256_GCM,data:wFMfNv2jjpCBaBK/zjcgfP1saPOMHj6Uf776Wy/CJeXdUWjTv7dW9uszbhopONwdzRsMUZoELTUqicIWKKe2VV9cDQ==,iv:d8PUkgPstLqKt7dJYH+1cFm5QW3flqnt0LWqcPV6pzI=,tag:yd2Xh0C8W+pR/Wb1W3fYgQ==,type:comment]
-    #ENC[AES256_GCM,data:f93GEu7aGKNwbN0Q,iv:U9kms5Q/doyZ1CxKUdiqiMlVtfrvmDNky+sox1y88do=,tag:/0ytx/sd8zI0I4wtHF0lrA==,type:comment]
-    KOPIA_PASSWORD: ENC[AES256_GCM,data:xCATQMNr5arhFTN/LXLVihk26cWgAf3DnhNNiAUSwYRfmQE51lA5tWVm,iv:3A3Z5qr45KLglwOZJreZxj5BIrgo/u8Nl6PuFTW4MDE=,tag:BCHJ9NwAkUt+UwbuIkb8nQ==,type:str]
-    #ENC[AES256_GCM,data:aOzga2GDTCpUsOXPbQ0gGIiYVSH415++TjCWfvm3xF43EDrRiU63Yz5l9dI0DJQ2fgyQ5Q==,iv:4MlHOx5cRvhxxr67kKjOSXfdcrhKycx75ivrPYKTlp0=,tag:E4OR7jSdu6+5DILzT8nQlg==,type:comment]
-    #ENC[AES256_GCM,data:90kUwVnAqmgAdQ4pqp1Xi7tXNzrZyKHHBs7dAHk12RgmxnMIRhH52O4CqqbXSeihPUIi7MwUiPuXcf+FuHIs850V8GQ=,iv:MO7ODgW77rGNDPrnVfDzshMRmviyhmYuaLSYz9Uua9Y=,tag:EL+nU1zYUhsB3R5yOs0SEQ==,type:comment]
-    #ENC[AES256_GCM,data:TsFPlnpwnt/94cQtrW4h,iv:K5HkaAryjppmMgjmPFoPRmAYmPytSWDFo+8/xwBcnjU=,tag:thjlKNUr9ay+PaAbnXuNPA==,type:comment]
-    B2_KEY_ID: ENC[AES256_GCM,data:7SM0RLB1JxaB64t8tmCAyFD59gUsBhTQJQ==,iv:T14O7cfmhda7R+6Z/Q4hlrJgAVeLG8G0rUyrsn/oK5c=,tag:/M+VARZsD8bw1mfRPVA4qQ==,type:str]
-    B2_KEY: ENC[AES256_GCM,data:abjrl1CJeRoM9mYkdz5rOcC4j6zfwu5El90NPTWMJw==,iv:+KF2tKtl9QKoRtw/2Zbqk1jVyWWQ62BuWK5Mo30UiRc=,tag:Km53I649xzEdoD5uiVPXlw==,type:str]
+  #ENC[AES256_GCM,data:mNhie4tRMgz+vrG4FvdV9lSo9kn6E9SAvo79RScAiK+HAblUITGjPqogQqDChwP9NWEuzUrU+hGH8QH0zLbD,iv:KWHkVa5xPVs2Slh0gR2sC1At2rPZfR3+4L6BbqJryPE=,tag:Y/pp8f1NDqXCK+G4RzP1qA==,type:comment]
+  #ENC[AES256_GCM,data:wFMfNv2jjpCBaBK/zjcgfP1saPOMHj6Uf776Wy/CJeXdUWjTv7dW9uszbhopONwdzRsMUZoELTUqicIWKKe2VV9cDQ==,iv:d8PUkgPstLqKt7dJYH+1cFm5QW3flqnt0LWqcPV6pzI=,tag:yd2Xh0C8W+pR/Wb1W3fYgQ==,type:comment]
+  #ENC[AES256_GCM,data:f93GEu7aGKNwbN0Q,iv:U9kms5Q/doyZ1CxKUdiqiMlVtfrvmDNky+sox1y88do=,tag:/0ytx/sd8zI0I4wtHF0lrA==,type:comment]
+  KOPIA_PASSWORD: ENC[AES256_GCM,data:xCATQMNr5arhFTN/LXLVihk26cWgAf3DnhNNiAUSwYRfmQE51lA5tWVm,iv:3A3Z5qr45KLglwOZJreZxj5BIrgo/u8Nl6PuFTW4MDE=,tag:BCHJ9NwAkUt+UwbuIkb8nQ==,type:str]
+  #ENC[AES256_GCM,data:aOzga2GDTCpUsOXPbQ0gGIiYVSH415++TjCWfvm3xF43EDrRiU63Yz5l9dI0DJQ2fgyQ5Q==,iv:4MlHOx5cRvhxxr67kKjOSXfdcrhKycx75ivrPYKTlp0=,tag:E4OR7jSdu6+5DILzT8nQlg==,type:comment]
+  #ENC[AES256_GCM,data:90kUwVnAqmgAdQ4pqp1Xi7tXNzrZyKHHBs7dAHk12RgmxnMIRhH52O4CqqbXSeihPUIi7MwUiPuXcf+FuHIs850V8GQ=,iv:MO7ODgW77rGNDPrnVfDzshMRmviyhmYuaLSYz9Uua9Y=,tag:EL+nU1zYUhsB3R5yOs0SEQ==,type:comment]
+  #ENC[AES256_GCM,data:TsFPlnpwnt/94cQtrW4h,iv:K5HkaAryjppmMgjmPFoPRmAYmPytSWDFo+8/xwBcnjU=,tag:thjlKNUr9ay+PaAbnXuNPA==,type:comment]
+  B2_KEY_ID: ENC[AES256_GCM,data:FzriY74LYuWevP0TH74//1a+WYK/UxBUjw==,iv:P+f8dSLomN2a7hw9UyuUzfvDPDlNFQwTeP/5oPIQlns=,tag:sZYlX3Kdd6IXSovTpKX0mg==,type:str]
+  B2_KEY: ENC[AES256_GCM,data:92OYaH6yg+K7+JqMsrTTQKl5Gb5eJ2XVXG1ya+0v7A==,iv:qJMcLdM99FCRe+pb3UGXRuqKvaTNJ+pcAgbbD1FvBnU=,tag:hR9EvuzSa/dJpRknQoCI9w==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBV2FhTVNmWGxRc0sveTQ4
-            akJZLzN2VE04OXgxbjNNb0FZYVkxZXJ4SkUwCnhBdStxb3pSamd1REc2d1BkaXlB
-            NjNLTEt4V2JDOUlsQm1yT291RGdBMjgKLS0tIHlOSDgxZGZNbFZPMlE4N0pYYjhs
-            ZDB3VHJOTHZaaitnTGRBYnhuc3ZxcncKHSC/knYP6O8RGBPrF83n4hdvHu5sBZE2
-            OH9CbVADtC0jJzfAtCcKDvLFhnF4rbXR/7GiF80pr7qEZeSbJCcOSw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-12T17:29:54Z"
-    mac: ENC[AES256_GCM,data:1kHlOY7t9fuErfPF9KvdkIxfs45Lyc9HtXTEP+sl36op2fElbl6w3V7Kdq6WRMO927/TpPkpndkGNOWWXq00W5+C2YIvk/eIrJbYAN3dzSojTkkph0fv7v6xtgXylMlZbFF3GnJf7+rtOcni1+NR4BeQm7jvZFI4Pf+xDQm1klI=,iv:+uTad9pALX6+i8XZ6u3n6almE4jdHreKFKEwbpYcS8g=,tag:xj/v4bHCeyYVhw8P0N+1AQ==,type:str]
-    mac_only_encrypted: true
-    version: 3.13.2
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBV2FhTVNmWGxRc0sveTQ4
+        akJZLzN2VE04OXgxbjNNb0FZYVkxZXJ4SkUwCnhBdStxb3pSamd1REc2d1BkaXlB
+        NjNLTEt4V2JDOUlsQm1yT291RGdBMjgKLS0tIHlOSDgxZGZNbFZPMlE4N0pYYjhs
+        ZDB3VHJOTHZaaitnTGRBYnhuc3ZxcncKHSC/knYP6O8RGBPrF83n4hdvHu5sBZE2
+        OH9CbVADtC0jJzfAtCcKDvLFhnF4rbXR/7GiF80pr7qEZeSbJCcOSw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-12T19:44:51Z"
+  mac: ENC[AES256_GCM,data:HWsbL+aZQHKjdKFgGmZnaoXUI+XG9hNpgOqbyXne1w+cQSJoq96h9l7HUwlt8khX5knJNjOgU5OhT5kqeQyHsqr/m2NVrwOILPD67B+wwG3CXfn4RmL6icIU5J15WpoPSP4tta78BeCs06LWb+k7O1VDR2cpjpxlrbjstU7eNcA=,iv:qb4ssHPR/Iy5uZYTBLTP2s2hXjhrVMheneK9O6gS9nk=,tag:Az9SFZAxma8OUYQFAYjcqA==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./kopiur/ks.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/components/kopiur/kustomization.yaml
+++ b/kubernetes/components/kopiur/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./pvc.yaml
+  - ./restore.yaml
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/components/kopiur/pvc.yaml
+++ b/kubernetes/components/kopiur/pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "${APP}"
+spec:
+  accessModes:
+    - "${KOPIUR_ACCESSMODES:=ReadWriteOnce}"
+  dataSourceRef:
+    kind: Restore
+    apiGroup: kopiur.home-operations.com
+    name: "${APP}"
+  resources:
+    requests:
+      storage: "${KOPIUR_CAPACITY:=5Gi}"
+  storageClassName: "${KOPIUR_STORAGECLASS:=openebs-zfspv}"

--- a/kubernetes/components/kopiur/restore.yaml
+++ b/kubernetes/components/kopiur/restore.yaml
@@ -6,15 +6,16 @@ metadata:
   name: ${APP}
 spec:
   mover:
-    securityContext:
+    podSecurityContext:
       # No default: the restore mover writes every restored file owned by its
       # own uid, and a non-root mover cannot chown. Apps that chmod/chown
       # their state need the files OWNED by their runtime uid, so every
       # consumer must set KOPIUR_UID/GID to match the app. A missing value
       # fails the build loudly instead of silently defaulting to a uid no app
-      # runs as.
+      # runs as. fsGroup mirrors VolSync's moverSecurityContext.
       runAsUser: ${KOPIUR_UID}
       runAsGroup: ${KOPIUR_GID}
+      fsGroup: ${KOPIUR_GID}
   policy:
     onMissingSnapshot: Continue
   source:

--- a/kubernetes/components/kopiur/restore.yaml
+++ b/kubernetes/components/kopiur/restore.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: ${APP}
+spec:
+  mover:
+    securityContext:
+      # No default: the restore mover writes every restored file owned by its
+      # own uid, and a non-root mover cannot chown. Apps that chmod/chown
+      # their state need the files OWNED by their runtime uid, so every
+      # consumer must set KOPIUR_UID/GID to match the app. A missing value
+      # fails the build loudly instead of silently defaulting to a uid no app
+      # runs as.
+      runAsUser: ${KOPIUR_UID}
+      runAsGroup: ${KOPIUR_GID}
+  policy:
+    onMissingSnapshot: Continue
+  source:
+    fromPolicy:
+      name: ${APP}
+      offset: 0
+  target:
+    populator: {}

--- a/kubernetes/components/kopiur/restore.yaml
+++ b/kubernetes/components/kopiur/restore.yaml
@@ -5,6 +5,10 @@ kind: Restore
 metadata:
   name: ${APP}
 spec:
+  credentialProjection:
+    # See snapshotpolicy.yaml — required for the restore mover to open the
+    # repository from the app's namespace.
+    enabled: true
   mover:
     podSecurityContext:
       # No default: the restore mover writes every restored file owned by its

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -8,12 +8,14 @@ spec:
   compression:
     compressor: zstd
   mover:
-    securityContext:
+    podSecurityContext:
       # Match the app's runtime uid/gid (see restore.yaml for why there is no
-      # default). The backup mover reads a fsGroup-agnostic snapshot clone
-      # whose files the app's own uid already owns.
+      # default). fsGroup group-remaps the snapshot clone on mount — like
+      # VolSync's moverSecurityContext did — so the mover can also read files
+      # the app wrote under a different uid (e.g. victoria's root-owned data).
       runAsUser: ${KOPIUR_UID}
       runAsGroup: ${KOPIUR_GID}
+      fsGroup: ${KOPIUR_GID}
   repository:
     kind: ClusterRepository
     name: homelab

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -7,6 +7,12 @@ metadata:
 spec:
   compression:
     compressor: zstd
+  credentialProjection:
+    # Consumer half of the projection handshake (owner half: `allowed` on the
+    # ClusterRepository). Copies the repository credentials into this app's
+    # namespace for the mover Job; fail-closed by default, and without it a
+    # mover outside kopiur-system cannot open the repository.
+    enabled: true
   mover:
     podSecurityContext:
       # Match the app's runtime uid/gid (see restore.yaml for why there is no
@@ -21,6 +27,7 @@ spec:
     name: homelab
   retention:
     keepLatest: 3
+    keepHourly: 24
     keepDaily: 7
     keepWeekly: 4
   sources:

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${APP}
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    securityContext:
+      # Match the app's runtime uid/gid (see restore.yaml for why there is no
+      # default). The backup mover reads a fsGroup-agnostic snapshot clone
+      # whose files the app's own uid already owns.
+      runAsUser: ${KOPIUR_UID}
+      runAsGroup: ${KOPIUR_GID}
+  repository:
+    kind: ClusterRepository
+    name: homelab
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+    keepWeekly: 4
+  sources:
+    - pvc:
+        name: ${APP}
+  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=openebs-zfs-snapshot}

--- a/kubernetes/components/kopiur/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/snapshotschedule.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: ${APP}
+spec:
+  policyRef:
+    name: ${APP}
+  schedule:
+    # Nightly, in the same window as the CNPG scheduled backups (07:30/08:30).
+    # The hashed `H` staggers the movers within the hour.
+    cron: H 8 * * *

--- a/kubernetes/components/kopiur/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/snapshotschedule.yaml
@@ -8,6 +8,6 @@ spec:
   policyRef:
     name: ${APP}
   schedule:
-    # Nightly, in the same window as the CNPG scheduled backups (07:30/08:30).
+    # Hourly, matching the old VolSync cadence (retention keeps 24 hourlies).
     # The hashed `H` staggers the movers within the hour.
-    cron: H 8 * * *
+    cron: H * * * *


### PR DESCRIPTION
Phase 1 of the VolSync → kopiur/kopia migration (no app changes yet — apps stay on VolSync until the cutover PR, #1246). Purely additive: konflate renders 32 added / 0 changed / 0 removed vs main.

## What's here

- **kopiur operator** in `kopiur-system` — `oci://ghcr.io/home-operations/charts/kopiur` `0.7.2`, with ServiceMonitor, PrometheusRule, Grafana-operator dashboards (`dashboards: grafana` selector), and an explicit 256Mi memory request (without one, Kubernetes copies the 2Gi limit into the request and reserves it permanently).
- **Credential projection, fully enabled.** In 0.7.2 it's a fail-closed three-legged handshake, and all three legs are here: `features.credentialProjection.enabled` on the chart (grants the operator the Secret create/patch/delete RBAC), `credentialProjection.allowed` on the ClusterRepository (owner side), and `credentialProjection.enabled` on the component's SnapshotPolicy/Restore (consumer side). Miss any leg and movers outside `kopiur-system` fail with an HTTP 403 condition on the CR.
- **`ClusterRepository homelab`** — inline-NFS filesystem backend at `storage.lan:/mnt/tank/backup/kopia` (export is `mapall=4003:4003`, so repo writes never depend on the per-app mover uid). We run upstream restic VolSync and restic repos cannot be adopted by kopiur, so this repository starts empty and gets seeded from the live PVCs during the cutover window. The old restic data stays untouched as the recovery baseline.
- **`kopiur-repository` Kustomization is health-gated** — `healthChecks` + `healthCheckExprs` on ClusterRepository `status.phase == 'Ready'`, so the app ks's that will depend on it only reconcile once the repository actually connects (a bad NFS export or wrong `KOPIA_PASSWORD` can't leave PVCs Pending while Flux shows the backup stack green). `wait: false` so the offsite replication never blocks apps.
- **`RepositoryReplication homelab-offsite`** — daily (`H 10 * * *`) blob mirror to the existing `crayon-club-backups` B2 bucket under `kopia/`, `sync.parallel: 8` for the initial seed. (Prefix renamed from `kopiur/` to match the NFS share; the B2 key is immutable, so the rename recreated it and rotated its credentials — SOPS + 1Password carry the new ones.)
- **`components/kopiur`** — drop-in successor to `components/volsync`:
  - `SnapshotPolicy`: zstd, retention keepLatest 3 / keepHourly 24 / keepDaily 7 / keepWeekly 4, openebs-zfs-snapshot staging, and a mover `podSecurityContext` (`runAsUser`/`runAsGroup`/`fsGroup` = `KOPIUR_UID/GID`) — the fsGroup group-remap is what lets the mover read files the app wrote under a different uid (e.g. victoria's root-owned data), matching VolSync's `moverSecurityContext`.
  - `SnapshotSchedule`: hourly `H * * * *`, the old VolSync cadence; the hashed cron staggers movers natively, replacing the volsync jitter MutatingAdmissionPolicy.
  - `Restore` (populator, `onMissingSnapshot: Continue`) + PVC with `dataSourceRef`.
  - `KOPIUR_UID/GID` deliberately have no default, same as `VOLSYNC_UID/GID`.
- **`infra/backblaze`** — new `kopiur` B2 application key (prefix `kopia/`) + 1Password item.
- **mise** — the kopiur CLI pinned (`github:home-operations/kopiur` 0.7.2). It installs as plain `kopiur`, not a `kubectl-` plugin.
- **SOPS secret is live** — `repository/secret.sops.yaml` carries the real B2 key id/key and the final `KOPIA_PASSWORD`; no placeholders remain.

## Pre-merge prep — all done, verified 2026-07-12

- [x] TrueNAS dataset `tank/backup/kopia`, NFS export with `mapall=4003:4003` — in-cluster mount + write verified (test file landed `4003:4003`); export root empty, ready for repo init
- [x] `tofu apply` in `infra/backblaze` — key live-authenticated against the B2 API, scoped to the bucket + `kopia/` prefix; credentials in 1Password ("kopiur key") and hash-matched in the SOPS secret
- [x] `KOPIA_PASSWORD` set (user-chosen, 42 chars), hash-matched to the 1Password "kopia" item

## Verification

- `just test` — 171 checks pass, including the new `kopiur`/`kopiur-repository` Kustomizations and HelmRelease
- After merge: `flux get ks -n kopiur-system` — `kopiur` then `kopiur-repository` Ready (the health gate means Ready proves repo init on the NFS export worked), then `kopiur doctor` for the full install check. The admission webhook may warn about an NFS repo relying on fsGroup — expected; `mapall=4003` handles ownership server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
