### PR TITLE
feat(kopiur)!: cut all apps over from volsync to kopiur backups

### DIFF
--- a/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/openclaw/ks.yaml
@@ -15,23 +15,23 @@ spec:
     # OIDC client). Defense-in-depth in front of OpenClaw's own gateway token, so
     # the untrusted-agent UI is never reachable on the LAN without an SSO login.
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   postBuild:
     substitute:
       APP: *app
       OIDC_APP_NAME: OpenClaw
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/openclaw.svg"
-      VOLSYNC_CAPACITY: 10Gi
+      KOPIUR_CAPACITY: 10Gi
       # Restore mover writes files owned by its own uid (non-root restic can't
       # chown). openclaw chmods its own state dir on startup, which needs real
       # ownership (fsGroup only grants group access) — so match the app's uid.
-      VOLSYNC_UID: "1000"
-      VOLSYNC_GID: "1000"
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         pod:
-          # Pin to the chart's default runtime uid/gid so VOLSYNC_UID/GID=65532
+          # Pin to the chart's default runtime uid/gid so KOPIUR_UID/GID=65532
           # (ks.yaml) stays anchored to a real in-repo value and can't drift on a
           # chart bump. fsGroup remaps restored data on mount as a fallback.
           # NOTE: this must live under each controller's pod.securityContext, not

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -7,17 +7,17 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/ai/memini/app
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: llmkube-models
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "65532"
-      VOLSYNC_GID: "65532"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "65532"
+      KOPIUR_GID: "65532"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/documents/paperless/ks.yaml
+++ b/kubernetes/apps/documents/paperless/ks.yaml
@@ -7,14 +7,14 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/documents/paperless/app
   components:
     - ../../../../components/database
     - ../../../../components/oidc
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   postBuild:
     substitute:
       APP: *app
@@ -22,9 +22,9 @@ spec:
       OIDC_APP_NAME: Paperless
       OIDC_PKCE_ENABLED: "true"
       OIDC_CALLBACK_PATH: /accounts/oidc/pocket-id/login/callback/
-      VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_UID: "4001"
-      VOLSYNC_GID: "4001"
+      KOPIUR_CAPACITY: 10Gi
+      KOPIUR_UID: "4001"
+      KOPIUR_GID: "4001"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/finance/actual/ks.yaml
+++ b/kubernetes/apps/finance/actual/ks.yaml
@@ -5,11 +5,11 @@ metadata:
   name: &app actual
 spec:
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/oidc
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/finance/actual/app
   postBuild:
@@ -18,9 +18,9 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/actual-budget.svg"
       OIDC_APP_NAME: Actual
       OIDC_CALLBACK_PATH: /openid/callback
-      VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_UID: "1000"
-      VOLSYNC_GID: "1000"
+      KOPIUR_CAPACITY: 1Gi
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/maker/orcaslicer/ks.yaml
+++ b/kubernetes/apps/maker/orcaslicer/ks.yaml
@@ -5,13 +5,13 @@ metadata:
   name: &app orcaslicer
 spec:
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: intel-gpu-resource-driver
       namespace: kube-system
   components:
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/maker/orcaslicer/app
   postBuild:
@@ -19,9 +19,9 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/orca-slicer.svg"
       OIDC_APP_NAME: OrcaSlicer
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "911"
-      VOLSYNC_GID: "911"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "911"
+      KOPIUR_GID: "911"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -7,11 +7,11 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/bazarr/app
   postBuild:
@@ -19,9 +19,9 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/bazarr.svg"
       OIDC_APP_NAME: Bazarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "4009"
-      VOLSYNC_GID: "4009"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "4009"
+      KOPIUR_GID: "4009"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -8,16 +8,16 @@ spec:
   path: ./kubernetes/apps/media/jellyfin/app
   components:
     - ../../../../components/oidc
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   postBuild:
     substitute:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/jellyfin.svg"
       OIDC_APP_NAME: Jellyfin
       OIDC_CALLBACK_PATH: /sso/OID/redirect/PocketID
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "4006"
-      VOLSYNC_GID: "4006"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "4006"
+      KOPIUR_GID: "4006"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
@@ -29,7 +29,7 @@ spec:
   targetNamespace: media
   wait: false
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: intel-gpu-resource-driver
       namespace: kube-system

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -7,12 +7,12 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/database
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/prowlarr/app
   postBuild:
@@ -20,9 +20,9 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/prowlarr.svg"
       OIDC_APP_NAME: Prowlarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "65534"
-      VOLSYNC_GID: "65534"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "65534"
+      KOPIUR_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -7,11 +7,11 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/qbittorrent/app
   postBuild:
@@ -20,9 +20,9 @@ spec:
       SUBDOMAIN: qb
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/qbittorrent.svg"
       OIDC_APP_NAME: qBittorrent
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "4005"
-      VOLSYNC_GID: "4005"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "4005"
+      KOPIUR_GID: "4005"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -7,12 +7,12 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/database
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/radarr/app
   postBuild:
@@ -20,9 +20,9 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/radarr.svg"
       OIDC_APP_NAME: Radarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "4010"
-      VOLSYNC_GID: "4010"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "4010"
+      KOPIUR_GID: "4010"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -5,18 +5,18 @@ metadata:
   name: &app recyclarr
 spec:
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/recyclarr/app
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_UID: "1000"
-      VOLSYNC_GID: "1000"
+      KOPIUR_CAPACITY: 1Gi
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -7,11 +7,11 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/sabnzbd/app
   postBuild:
@@ -19,9 +19,9 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/sabnzbd.svg"
       OIDC_APP_NAME: SABnzbd
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "4008"
-      VOLSYNC_GID: "4008"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "4008"
+      KOPIUR_GID: "4008"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -5,19 +5,19 @@ metadata:
   name: &app seerr
 spec:
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/database
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/seerr/app
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "1000"
-      VOLSYNC_GID: "1000"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -7,12 +7,12 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
     - ../../../../components/database
     - ../../../../components/oidc/envoy
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/sonarr/app
   postBuild:
@@ -20,9 +20,9 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/sonarr.svg"
       OIDC_APP_NAME: Sonarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "4007"
-      VOLSYNC_GID: "4007"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "4007"
+      KOPIUR_GID: "4007"
     substituteFrom:
     - name: cluster-secrets
       kind: Secret

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -27,13 +27,13 @@ spec:
     - name: grafana-operator
     - name: pocket-id
       namespace: security
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   components:
     - ../../../../components/oidc
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   postBuild:
     substitute:
       APP: *app
@@ -42,9 +42,9 @@ spec:
       OIDC_APP_NAME: Grafana
       OIDC_PKCE_ENABLED: "true"
       OIDC_CALLBACK_PATH: /login/generic_oauth
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "1000"
-      VOLSYNC_GID: "1000"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -35,16 +35,16 @@ spec:
   dependsOn:
     - name: victoria-metrics-operator
     - name: grafana-instance
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/observability/victoria/k8s-stack
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_CAPACITY: 50Gi
       # VMSingle still runs as root (no securityContext today), but the mover is
       # pre-pinned to 65534 — the uid the VM stack uses for its other workloads
       # (node-exporter, kube-state-metrics) and what the operator's
@@ -52,8 +52,8 @@ spec:
       # data the mover wrote under any uid) and forward-compatible: a later switch
       # to non-root needs no re-chown of restored data.
       # TODO: enable useStrictSecurity / set the VMSingle securityContext to 65534.
-      VOLSYNC_UID: "65534"
-      VOLSYNC_GID: "65534"
+      KOPIUR_UID: "65534"
+      KOPIUR_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
@@ -72,24 +72,24 @@ metadata:
 spec:
   dependsOn:
     - name: victoria-metrics-operator
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/observability/victoria/logs
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 5Gi
+      KOPIUR_CAPACITY: 5Gi
       # VLSingle still runs as root (no securityContext today), but the mover is
       # pre-pinned to 65534 — the VM stack's non-root uid (what the operator's
       # useStrictSecurity assigns to managed pods). Harmless now (root reads/writes
       # data the mover wrote under any uid) and forward-compatible: a later switch
       # to non-root needs no re-chown of restored data.
       # TODO: enable useStrictSecurity / set the VLSingle securityContext to 65534.
-      VOLSYNC_UID: "65534"
-      VOLSYNC_GID: "65534"
+      KOPIUR_UID: "65534"
+      KOPIUR_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -48,9 +48,10 @@ spec:
       # VMSingle still runs as root (no securityContext today), but the mover is
       # pre-pinned to 65534 — the uid the VM stack uses for its other workloads
       # (node-exporter, kube-state-metrics) and what the operator's
-      # useStrictSecurity assigns to managed pods. Harmless now (root reads/writes
-      # data the mover wrote under any uid) and forward-compatible: a later switch
-      # to non-root needs no re-chown of restored data.
+      # useStrictSecurity assigns to managed pods. The backup mover can still
+      # read root-owned files because the component's fsGroup group-remaps the
+      # snapshot clone; forward-compatible: a later switch to non-root needs no
+      # re-chown of restored data.
       # TODO: enable useStrictSecurity / set the VMSingle securityContext to 65534.
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"
@@ -84,9 +85,10 @@ spec:
       KOPIUR_CAPACITY: 5Gi
       # VLSingle still runs as root (no securityContext today), but the mover is
       # pre-pinned to 65534 — the VM stack's non-root uid (what the operator's
-      # useStrictSecurity assigns to managed pods). Harmless now (root reads/writes
-      # data the mover wrote under any uid) and forward-compatible: a later switch
-      # to non-root needs no re-chown of restored data.
+      # useStrictSecurity assigns to managed pods). The backup mover can still
+      # read root-owned files because the component's fsGroup group-remaps the
+      # snapshot clone; forward-compatible: a later switch to non-root needs no
+      # re-chown of restored data.
       # TODO: enable useStrictSecurity / set the VLSingle securityContext to 65534.
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"

--- a/kubernetes/apps/social/continuwuity/ks.yaml
+++ b/kubernetes/apps/social/continuwuity/ks.yaml
@@ -5,18 +5,18 @@ metadata:
   name: &app continuwuity
 spec:
   dependsOn:
-    - name: volsync
-      namespace: volsync-system
+    - name: kopiur-repository
+      namespace: kopiur-system
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/social/continuwuity/app
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_UID: "1001"
-      VOLSYNC_GID: "1001"
+      KOPIUR_CAPACITY: 5Gi
+      KOPIUR_UID: "1001"
+      KOPIUR_GID: "1001"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -9,7 +9,11 @@ spec:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
     version: v1.36.2
   healthChecks:
-    - apiVersion: volsync.backube/v1alpha1
-      kind: ReplicationSource
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
       expr: |-
-        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        status.phase != 'Running'
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Restore
+      expr: |-
+        !(status.phase in ['Resolving', 'Restoring'])

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -9,19 +9,19 @@ spec:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
     version: v1.36.2
   healthChecks:
-    # `has()` guards: a just-created CR has no status.phase yet, and an
-    # unguarded dereference is a CEL error, which tuppr treats as unhealthy —
-    # blocking upgrades until the phase appears (forever, if the kopiur
-    # controller is down).
+    # Fail closed: `has()` requires an observed phase before reporting
+    # healthy. A just-created CR (no status yet) or a down kopiur controller
+    # blocks the upgrade instead of racing a mover that is about to start —
+    # a reboot mid-backup/restore is worse than a stalled upgrade.
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot
       expr: |-
-        !has(status.phase) || !(status.phase in ['Pending', 'Running'])
+        has(status.phase) && !(status.phase in ['Pending', 'Running'])
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Restore
       expr: |-
-        !has(status.phase) || !(status.phase in ['Pending', 'Resolving', 'Restoring'])
+        has(status.phase) && !(status.phase in ['Pending', 'Resolving', 'Restoring'])
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: RepositoryReplication
       expr: |-
-        !has(status.phase) || status.phase != 'Replicating'
+        has(status.phase) && status.phase != 'Replicating'

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -9,11 +9,19 @@ spec:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
     version: v1.36.2
   healthChecks:
+    # `has()` guards: a just-created CR has no status.phase yet, and an
+    # unguarded dereference is a CEL error, which tuppr treats as unhealthy —
+    # blocking upgrades until the phase appears (forever, if the kopiur
+    # controller is down).
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot
       expr: |-
-        status.phase != 'Running'
+        !has(status.phase) || !(status.phase in ['Pending', 'Running'])
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Restore
       expr: |-
-        !(status.phase in ['Resolving', 'Restoring'])
+        !has(status.phase) || !(status.phase in ['Pending', 'Resolving', 'Restoring'])
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: RepositoryReplication
+      expr: |-
+        !has(status.phase) || status.phase != 'Replicating'

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -11,11 +11,19 @@ spec:
   policy:
     rebootMode: powercycle
   healthChecks:
+    # `has()` guards: a just-created CR has no status.phase yet, and an
+    # unguarded dereference is a CEL error, which tuppr treats as unhealthy —
+    # blocking upgrades until the phase appears (forever, if the kopiur
+    # controller is down).
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot
       expr: |-
-        status.phase != 'Running'
+        !has(status.phase) || !(status.phase in ['Pending', 'Running'])
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Restore
       expr: |-
-        !(status.phase in ['Resolving', 'Restoring'])
+        !has(status.phase) || !(status.phase in ['Pending', 'Resolving', 'Restoring'])
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: RepositoryReplication
+      expr: |-
+        !has(status.phase) || status.phase != 'Replicating'

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -11,7 +11,11 @@ spec:
   policy:
     rebootMode: powercycle
   healthChecks:
-    - apiVersion: volsync.backube/v1alpha1
-      kind: ReplicationSource
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
       expr: |-
-        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        status.phase != 'Running'
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Restore
+      expr: |-
+        !(status.phase in ['Resolving', 'Restoring'])

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -11,19 +11,19 @@ spec:
   policy:
     rebootMode: powercycle
   healthChecks:
-    # `has()` guards: a just-created CR has no status.phase yet, and an
-    # unguarded dereference is a CEL error, which tuppr treats as unhealthy —
-    # blocking upgrades until the phase appears (forever, if the kopiur
-    # controller is down).
+    # Fail closed: `has()` requires an observed phase before reporting
+    # healthy. A just-created CR (no status yet) or a down kopiur controller
+    # blocks the upgrade instead of racing a mover that is about to start —
+    # a reboot mid-backup/restore is worse than a stalled upgrade.
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot
       expr: |-
-        !has(status.phase) || !(status.phase in ['Pending', 'Running'])
+        has(status.phase) && !(status.phase in ['Pending', 'Running'])
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Restore
       expr: |-
-        !has(status.phase) || !(status.phase in ['Pending', 'Resolving', 'Restoring'])
+        has(status.phase) && !(status.phase in ['Pending', 'Resolving', 'Restoring'])
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: RepositoryReplication
       expr: |-
-        !has(status.phase) || status.phase != 'Replicating'
+        has(status.phase) && status.phase != 'Replicating'

--- a/scripts/migrate-kopiur.sh
+++ b/scripts/migrate-kopiur.sh
@@ -26,9 +26,11 @@
 # docs/volsync-restic-recovery.sops.yaml.
 set -Eeuo pipefail
 
+# shellcheck source=scripts/lib/common.sh
 source "$(dirname "${0}")/lib/common.sh"
 
-export ROOT_DIR="$(git rev-parse --show-toplevel)"
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+export ROOT_DIR
 
 # App inventory, derived from every ks.yaml that consumes components/kopiur.
 # Emits: <flux-ks-name> <namespace> <app> <uid> <gid>
@@ -75,6 +77,38 @@ function require_volsync_crs() {
     fi
 }
 
+# Pods (any phase except Succeeded/Failed) still mounting <app>'s PVC in <ns>.
+# Label-independent: inspects spec.volumes directly, so it also catches
+# operator-created or unlabeled pods that the instance-label wait would miss.
+function pvc_mounters() {
+    local ns="${1}" app="${2}"
+    kubectl get pod -n "${ns}" -o json | jq -r --arg pvc "${app}" '
+        .items[]
+        | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+        | select([.spec.volumes[]? | select(.persistentVolumeClaim.claimName == $pvc)] | length > 0)
+        | .metadata.name'
+}
+
+# Hard quiescence gate: the final backup, seed, and delete phases all assume
+# no writer is left on the PVCs — a straggler would corrupt the baseline or
+# the seed, or turn 'delete' into data loss. Aborts (log error exits) after
+# the timeout; a kubectl/jq failure inside also aborts via set -e.
+function require_pvcs_unmounted() {
+    local timeout="${1:-300}"
+    local deadline=$((SECONDS + timeout)) leftover
+    while true; do
+        leftover=$(apps | while read -r _ ns app _ _; do
+            pvc_mounters "${ns}" "${app}" | sed "s|^|${ns}/|"
+        done)
+        [[ -z "${leftover}" ]] && return 0
+        if ((SECONDS >= deadline)); then
+            log error "Pods still mount app PVCs after ${timeout}s" "pods" "${leftover//$'\n'/,}"
+        fi
+        log info "Waiting for PVC mounters to terminate" "pods" "${leftover//$'\n'/,}"
+        sleep 10
+    done
+}
+
 function cmd_suspend() {
     require_volsync_crs
     scale_operators 0
@@ -84,15 +118,18 @@ function cmd_suspend() {
         flux suspend helmrelease "${app}" -n "${ns}" 2>/dev/null || true
         workloads "${ns}" "${app}" | xargs -r kubectl scale -n "${ns}" --replicas=0
     done
+    # Best-effort progress wait; the real gate is require_pvcs_unmounted.
     apps | while read -r _ ns app _ _; do
         kubectl wait pod -n "${ns}" -l "app.kubernetes.io/instance=${app}" \
             --for=delete --timeout=5m 2>/dev/null || true
     done
+    require_pvcs_unmounted 300
 }
 
 function cmd_final_backup() {
     require_volsync_crs
-    local stamp="pre-kopiur-$(date +%s)"
+    local stamp
+    stamp="pre-kopiur-$(date +%s)"
     apps | while read -r _ ns app _ _; do
         kubectl patch replicationsource "${app}" -n "${ns}" --type merge \
             -p "{\"spec\":{\"trigger\":{\"manual\":\"${stamp}\"}}}"
@@ -169,6 +206,7 @@ function cmd_verify_seeds() {
 }
 
 function cmd_delete() {
+    require_pvcs_unmounted 60
     read -r -p "This deletes every app's PVC + volsync CRs. Seeds verified? (yes/no) " ok
     [[ "${ok}" == "yes" ]] || exit 1
     apps | while read -r _ ns app _ _; do

--- a/scripts/migrate-kopiur.sh
+++ b/scripts/migrate-kopiur.sh
@@ -122,6 +122,8 @@ metadata:
 spec:
   compression:
     compressor: zstd
+  credentialProjection:
+    enabled: true
   mover:
     podSecurityContext:
       runAsUser: ${uid}
@@ -132,6 +134,7 @@ spec:
     name: homelab
   retention:
     keepLatest: 3
+    keepHourly: 24
     keepDaily: 7
     keepWeekly: 4
   sources:
@@ -139,7 +142,9 @@ spec:
         name: ${app}
   volumeSnapshotClassName: openebs-zfs-snapshot
 EOF
-        kubectl kopiur snapshot now --policy "${app}" -n "${ns}" --wait
+        # mise installs the CLI as plain `kopiur` (kubectl plugin discovery
+        # would need a kubectl-kopiur binary, which only krew/brew provide).
+        kopiur snapshot now --policy "${app}" -n "${ns}" --wait
     done
 }
 
@@ -160,7 +165,7 @@ function cmd_verify_seeds() {
     if [[ -n "${failures}" ]]; then
         log error "Seed snapshots missing/failed/empty/incomplete — do NOT run 'delete'" "apps" "${failures//$'\n'/,}"
     fi
-    log info "Also eyeball sizes: kubectl kopiur snapshots list -A"
+    log info "Also eyeball sizes: kopiur snapshots list -A"
 }
 
 function cmd_delete() {

--- a/scripts/migrate-kopiur.sh
+++ b/scripts/migrate-kopiur.sh
@@ -16,6 +16,14 @@
 #   migrate-kopiur.sh delete        # delete RS/RD/PVC per app (destructive!)
 #   migrate-kopiur.sh resume        # flux resume + reconcile (restores PVCs)
 #   migrate-kopiur.sh status        # per-app PVC/pod/snapshot overview
+#
+# ORDERING: run 'suspend' and 'final-backup' BEFORE Flux reconciles the
+# cutover merge — Flux (prune: true) deletes every app's volsync CRs the
+# moment its ks.yaml flips from components/volsync to components/kopiur,
+# taking the final-backup safety net with them. Both phases preflight this
+# and abort if the ReplicationSources are already gone. The restic
+# credentials for the baseline are archived in
+# docs/volsync-restic-recovery.sops.yaml.
 set -Eeuo pipefail
 
 source "$(dirname "${0}")/lib/common.sh"
@@ -55,11 +63,24 @@ function scale_operators() {
     done
 }
 
+# The final restic baseline needs the volsync CRs, which Flux prunes as soon
+# as it reconciles the cutover merge. Refuse to continue once they are gone.
+function require_volsync_crs() {
+    local missing
+    missing=$(apps | while read -r _ ns app _ _; do
+        kubectl get replicationsource "${app}" -n "${ns}" >/dev/null 2>&1 || echo "${ns}/${app}"
+    done)
+    if [[ -n "${missing}" ]]; then
+        log error "ReplicationSources already pruned — Flux reconciled the cutover before the final restic baseline was taken" "apps" "${missing//$'\n'/,}"
+    fi
+}
+
 function cmd_suspend() {
+    require_volsync_crs
     scale_operators 0
     apps | while read -r ks ns app _ _; do
         log info "Suspending" "app" "${app}"
-        flux suspend kustomization "${ks}" -n flux-system
+        flux suspend kustomization "${ks}" -n "${ns}"
         flux suspend helmrelease "${app}" -n "${ns}" 2>/dev/null || true
         workloads "${ns}" "${app}" | xargs -r kubectl scale -n "${ns}" --replicas=0
     done
@@ -70,6 +91,7 @@ function cmd_suspend() {
 }
 
 function cmd_final_backup() {
+    require_volsync_crs
     local stamp="pre-kopiur-$(date +%s)"
     apps | while read -r _ ns app _ _; do
         kubectl patch replicationsource "${app}" -n "${ns}" --type merge \
@@ -83,7 +105,7 @@ function cmd_final_backup() {
 }
 
 function cmd_stop_volsync() {
-    flux suspend kustomization volsync -n flux-system
+    flux suspend kustomization volsync -n volsync-system
     kubectl scale deploy volsync -n volsync-system --replicas=0
 }
 
@@ -101,9 +123,10 @@ spec:
   compression:
     compressor: zstd
   mover:
-    securityContext:
+    podSecurityContext:
       runAsUser: ${uid}
       runAsGroup: ${gid}
+      fsGroup: ${gid}
   repository:
     kind: ClusterRepository
     name: homelab
@@ -125,7 +148,9 @@ function cmd_verify_seeds() {
     failures=$(apps | while read -r _ ns app _ _; do
         if kubectl get snapshot -n "${ns}" -o json | jq -e --arg app "${app}" '
             [.items[] | select(.spec.policyRef.name == $app)
-             | select(.status.phase == "Succeeded")] | length > 0' >/dev/null; then
+             | select(.status.phase == "Succeeded")
+             | select((.status.stats.sizeBytes // 0) > 0)
+             | select((.status.stats.filesFailed // 0) == 0)] | length > 0' >/dev/null; then
             echo "OK   ${ns}/${app}" >&2
         else
             echo "FAIL ${ns}/${app}" >&2
@@ -133,7 +158,7 @@ function cmd_verify_seeds() {
         fi
     done)
     if [[ -n "${failures}" ]]; then
-        log error "Seed snapshots missing/failed — do NOT run 'delete'" "apps" "${failures//$'\n'/,}"
+        log error "Seed snapshots missing/failed/empty/incomplete — do NOT run 'delete'" "apps" "${failures//$'\n'/,}"
     fi
     log info "Also eyeball sizes: kubectl kopiur snapshots list -A"
 }
@@ -153,11 +178,11 @@ function cmd_resume() {
     apps | while read -r ks ns app _ _; do
         log info "Resuming" "app" "${app}"
         flux resume helmrelease "${app}" -n "${ns}" 2>/dev/null || true
-        flux resume kustomization "${ks}" -n flux-system
+        flux resume kustomization "${ks}" -n "${ns}"
     done
     scale_operators 1
-    apps | while read -r ks _ _ _ _; do
-        flux reconcile kustomization "${ks}" -n flux-system || true
+    apps | while read -r ks ns _ _ _; do
+        flux reconcile kustomization "${ks}" -n "${ns}" || true
     done
 }
 

--- a/scripts/migrate-kopiur.sh
+++ b/scripts/migrate-kopiur.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# One-shot VolSync -> kopiur cutover runbook (see docs in the kopiur PRs).
+#
+# Upstream restic repos cannot be adopted by kopiur, so the sequence is:
+# suspend + scale down every volsync-backed app, take a final restic backup
+# (recovery baseline), seed the kopia repository from the still-live PVCs,
+# delete the old PVCs, then let Flux recreate them with dataSourceRef ->
+# kopiur Restore. Run the phases in order; each is idempotent and re-runnable.
+#
+#   migrate-kopiur.sh apps          # show the derived app inventory
+#   migrate-kopiur.sh suspend       # flux suspend + scale workloads to 0
+#   migrate-kopiur.sh final-backup  # trigger + wait for final restic backups
+#   migrate-kopiur.sh stop-volsync  # suspend volsync ks + scale operator to 0
+#   migrate-kopiur.sh seed          # apply SnapshotPolicies + snapshot every PVC
+#   migrate-kopiur.sh verify-seeds  # GATE: all seeds Succeeded w/ bytes moved
+#   migrate-kopiur.sh delete        # delete RS/RD/PVC per app (destructive!)
+#   migrate-kopiur.sh resume        # flux resume + reconcile (restores PVCs)
+#   migrate-kopiur.sh status        # per-app PVC/pod/snapshot overview
+set -Eeuo pipefail
+
+source "$(dirname "${0}")/lib/common.sh"
+
+export ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+# App inventory, derived from every ks.yaml that consumes components/kopiur.
+# Emits: <flux-ks-name> <namespace> <app> <uid> <gid>
+function apps() {
+    grep -rl "components/kopiur" "${ROOT_DIR}/kubernetes/apps" --include=ks.yaml | sort | while read -r f; do
+        yq -r '
+            select(.spec.components[]? | contains("components/kopiur"))
+            | [.metadata.name, .spec.targetNamespace,
+               .spec.postBuild.substitute.APP,
+               .spec.postBuild.substitute.KOPIUR_UID,
+               .spec.postBuild.substitute.KOPIUR_GID]
+            | @tsv' "$f"
+    done | awk 'NF'
+}
+
+# Deployments/statefulsets in <ns> that mount PVC <app>
+function workloads() {
+    local ns="${1}" app="${2}"
+    kubectl get deploy,sts -n "${ns}" -o json | jq -r --arg pvc "${app}" '
+        .items[]
+        | select([.spec.template.spec.volumes[]?
+                  | select(.persistentVolumeClaim.claimName == $pvc)] | length > 0)
+        | "\(.kind | ascii_downcase)/\(.metadata.name)"'
+}
+
+# Operators that would fight a direct scale-down of their managed workloads
+function scale_operators() {
+    local replicas="${1}"
+    for d in victoria-metrics-operator grafana-operator; do
+        kubectl get deploy -n observability -o name | grep "${d}" \
+            | xargs -r kubectl scale -n observability --replicas="${replicas}"
+    done
+}
+
+function cmd_suspend() {
+    scale_operators 0
+    apps | while read -r ks ns app _ _; do
+        log info "Suspending" "app" "${app}"
+        flux suspend kustomization "${ks}" -n flux-system
+        flux suspend helmrelease "${app}" -n "${ns}" 2>/dev/null || true
+        workloads "${ns}" "${app}" | xargs -r kubectl scale -n "${ns}" --replicas=0
+    done
+    apps | while read -r _ ns app _ _; do
+        kubectl wait pod -n "${ns}" -l "app.kubernetes.io/instance=${app}" \
+            --for=delete --timeout=5m 2>/dev/null || true
+    done
+}
+
+function cmd_final_backup() {
+    local stamp="pre-kopiur-$(date +%s)"
+    apps | while read -r _ ns app _ _; do
+        kubectl patch replicationsource "${app}" -n "${ns}" --type merge \
+            -p "{\"spec\":{\"trigger\":{\"manual\":\"${stamp}\"}}}"
+    done
+    apps | while read -r _ ns app _ _; do
+        log info "Waiting for final restic backup" "app" "${app}"
+        kubectl wait replicationsource "${app}" -n "${ns}" \
+            --for=jsonpath="{.status.lastManualSync}=${stamp}" --timeout=30m
+    done
+}
+
+function cmd_stop_volsync() {
+    flux suspend kustomization volsync -n flux-system
+    kubectl scale deploy volsync -n volsync-system --replicas=0
+}
+
+function cmd_seed() {
+    apps | while read -r _ ns app uid gid; do
+        log info "Seeding kopia snapshot" "app" "${app}"
+        # Mirrors kubernetes/components/kopiur/snapshotpolicy.yaml; Flux takes
+        # ownership of the identical object when the app is resumed.
+        kubectl apply -n "${ns}" -f - <<EOF
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${app}
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    securityContext:
+      runAsUser: ${uid}
+      runAsGroup: ${gid}
+  repository:
+    kind: ClusterRepository
+    name: homelab
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+    keepWeekly: 4
+  sources:
+    - pvc:
+        name: ${app}
+  volumeSnapshotClassName: openebs-zfs-snapshot
+EOF
+        kubectl kopiur snapshot now --policy "${app}" -n "${ns}" --wait
+    done
+}
+
+function cmd_verify_seeds() {
+    local failures
+    failures=$(apps | while read -r _ ns app _ _; do
+        if kubectl get snapshot -n "${ns}" -o json | jq -e --arg app "${app}" '
+            [.items[] | select(.spec.policyRef.name == $app)
+             | select(.status.phase == "Succeeded")] | length > 0' >/dev/null; then
+            echo "OK   ${ns}/${app}" >&2
+        else
+            echo "FAIL ${ns}/${app}" >&2
+            echo "${app}"
+        fi
+    done)
+    if [[ -n "${failures}" ]]; then
+        log error "Seed snapshots missing/failed — do NOT run 'delete'" "apps" "${failures//$'\n'/,}"
+    fi
+    log info "Also eyeball sizes: kubectl kopiur snapshots list -A"
+}
+
+function cmd_delete() {
+    read -r -p "This deletes every app's PVC + volsync CRs. Seeds verified? (yes/no) " ok
+    [[ "${ok}" == "yes" ]] || exit 1
+    apps | while read -r _ ns app _ _; do
+        log warn "Deleting volsync CRs + PVC" "app" "${app}"
+        kubectl delete replicationsource "${app}" -n "${ns}" --ignore-not-found
+        kubectl delete replicationdestination "${app}-dst" -n "${ns}" --ignore-not-found
+        kubectl delete pvc "${app}" -n "${ns}" --ignore-not-found
+    done
+}
+
+function cmd_resume() {
+    apps | while read -r ks ns app _ _; do
+        log info "Resuming" "app" "${app}"
+        flux resume helmrelease "${app}" -n "${ns}" 2>/dev/null || true
+        flux resume kustomization "${ks}" -n flux-system
+    done
+    scale_operators 1
+    apps | while read -r ks _ _ _ _; do
+        flux reconcile kustomization "${ks}" -n flux-system || true
+    done
+}
+
+function cmd_status() {
+    apps | while read -r _ ns app _ _; do
+        pvc=$(kubectl get pvc "${app}" -n "${ns}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "-")
+        pods=$(kubectl get pod -n "${ns}" -l "app.kubernetes.io/instance=${app}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        echo "${ns}/${app}: pvc=${pvc} pods=${pods}"
+    done
+}
+
+case "${1:-}" in
+    apps) apps ;;
+    suspend) cmd_suspend ;;
+    final-backup) cmd_final_backup ;;
+    stop-volsync) cmd_stop_volsync ;;
+    seed) cmd_seed ;;
+    verify-seeds) cmd_verify_seeds ;;
+    delete) cmd_delete ;;
+    resume) cmd_resume ;;
+    status) cmd_status ;;
+    *) grep '^#   migrate' "$0" | sed 's|^#   ||'; exit 1 ;;
+esac


### PR DESCRIPTION
Phase 2 of the VolSync → kopiur migration (stacked on #1245). **Draft on purpose — merge only during the migration window, after `migrate-kopiur.sh suspend` and `final-backup` have completed.** Flux (`prune: true`) deletes every app's volsync CRs the moment its ks flips to `components/kopiur`, taking the final-backup safety net with it; both script phases preflight this and abort if the ReplicationSources are already gone. Racing Flux after the merge is otherwise safe: existing PVCs carry an immutable `dataSourceRef`, so the cutover ks's cannot fully reconcile until the old PVCs are deleted and recreated from the seeded kopia snapshots.

## Changes

- **18 apps / 19 Flux Kustomizations** (media ×9, observability ×3, plus openclaw, memini, paperless, actual, orcaslicer, continuwuity): `components/volsync` → `components/kopiur`, `dependsOn` → `kopiur-repository`, `VOLSYNC_CAPACITY/UID/GID` → `KOPIUR_CAPACITY/UID/GID` (values unchanged).
- **tuppr**: node-upgrade health checks gate on kopiur CRs instead of the volsync `ReplicationSource` condition — and they fail closed. Every CEL expr is guarded with `has(status.phase)`, so a just-created CR without a status (or a dead controller) blocks reboots instead of passing while a mover is about to start. `Pending` counts as busy, and a `RepositoryReplication` check keeps nodes from rebooting mid offsite sync.
- **`scripts/migrate-kopiur.sh`** — the cutover runbook: `suspend` → `final-backup` (restic recovery baseline) → `stop-volsync` → `seed` → `verify-seeds` → `delete` → `resume` → `status`. Phases are idempotent and re-runnable; each preflights its own safety gates and aborts loudly. Details:
  - App inventory (ks name, namespace, app, uid/gid) is derived from the ks.yaml files, not hardcoded; Flux Kustomizations are targeted in their per-app namespaces, where they actually live.
  - `suspend` ends with a hard, label-independent gate: no pod may still mount an app PVC (bounded wait, aborts on timeout). `delete` re-checks it before destroying anything.
  - `seed` applies per-app SnapshotPolicies identical to the component's (credential projection, retention, mover podSecurityContext + fsGroup) so Flux adopts them cleanly on resume, then runs `kopiur snapshot now --policy <app> --wait` per app while the old PVCs still exist. (The mise binary is plain `kopiur`, not a kubectl plugin.)
  - `verify-seeds` is the hard gate for `delete`: every app must show a Succeeded snapshot with `sizeBytes > 0` and `filesFailed == 0`.

## Window sequence

1. Merge #1245 first; confirm `ClusterRepository homelab` is `Ready` and `kopiur doctor` is clean.
2. VolSync all green (every RS synced within the hour), then `suspend` → `final-backup`. **Both must finish before this PR reconciles.**
3. Merge this PR (rebase onto main first if #1245 was squash-merged), then `stop-volsync` → `seed` → `verify-seeds` — every app must show OK; eyeball sizes with `kopiur snapshots list -A`.
4. `delete` (prompts, re-checks PVC unmount) → `resume` — kopiur's Restore populator fills the new PVCs from the seed snapshots as pods schedule (WaitForFirstConsumer). Spot-check app data; openclaw's CLI (chmod on its state dir) is the canary for restore ownership, and victoria's data is root-owned.

Restic data on `storage.lan:/mnt/tank/backup/volsync` is untouched throughout and remains the rollback baseline (credentials archived in #1247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
