### PR TITLE
fix(kopiur): drop prowlarr from backups, correct vmks mover uid

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -107,8 +107,6 @@ spec:
                 port: *port
 
     persistence:
-      data:
-        existingClaim: *app
       cache:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -7,12 +7,9 @@ spec:
   dependsOn:
     - name: pocket-id
       namespace: security
-    - name: kopiur-repository
-      namespace: kopiur-system
   components:
     - ../../../../components/database
     - ../../../../components/oidc/envoy
-    - ../../../../components/kopiur
   interval: 1h
   path: ./kubernetes/apps/media/prowlarr/app
   postBuild:
@@ -20,9 +17,6 @@ spec:
       APP: *app
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/prowlarr.svg"
       OIDC_APP_NAME: Prowlarr
-      KOPIUR_CAPACITY: 5Gi
-      KOPIUR_UID: "65534"
-      KOPIUR_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -45,16 +45,15 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 50Gi
-      # VMSingle still runs as root (no securityContext today), but the mover is
-      # pre-pinned to 65534 — the uid the VM stack uses for its other workloads
-      # (node-exporter, kube-state-metrics) and what the operator's
-      # useStrictSecurity assigns to managed pods. The backup mover can still
-      # read root-owned files because the component's fsGroup group-remaps the
-      # snapshot clone; forward-compatible: a later switch to non-root needs no
-      # re-chown of restored data.
-      # TODO: enable useStrictSecurity / set the VMSingle securityContext to 65534.
-      KOPIUR_UID: "65534"
-      KOPIUR_GID: "65534"
+      # The mover uid must match the data's actual on-disk ownership: fsGroup
+      # does NOT remap a read-only snapshot-clone mount (kubelet skips the
+      # chown), so a mismatched mover hits PermissionDenied on any file that
+      # isn't world-readable. VMSingle's data is owned 1000:1000 (verified
+      # 2026-07-13) with several cache/ dirs not world-readable.
+      # TODO: enable useStrictSecurity / set an explicit VMSingle
+      # securityContext, and keep this uid in lockstep with it.
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
@@ -83,13 +82,13 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 5Gi
-      # VLSingle still runs as root (no securityContext today), but the mover is
-      # pre-pinned to 65534 — the VM stack's non-root uid (what the operator's
-      # useStrictSecurity assigns to managed pods). The backup mover can still
-      # read root-owned files because the component's fsGroup group-remaps the
-      # snapshot clone; forward-compatible: a later switch to non-root needs no
-      # re-chown of restored data.
-      # TODO: enable useStrictSecurity / set the VLSingle securityContext to 65534.
+      # VLSingle runs as root but writes world-readable files (0644/0755), so a
+      # 65534 mover can read everything today (verified 2026-07-13). fsGroup
+      # does NOT remap a read-only snapshot-clone mount — if VL ever writes a
+      # non-world-readable file, snapshots fail PermissionDenied and this uid
+      # must be revisited.
+      # TODO: enable useStrictSecurity / set the VLSingle securityContext to
+      # 65534, then this pinning becomes exact.
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"
     substituteFrom:


### PR DESCRIPTION
Mid-migration-window fixes discovered while seeding the kopia repository. **Must merge before the `resume` phase** — otherwise Flux reapplies the vmks SnapshotPolicy at uid 65534 (hourly snapshots fail `PermissionDenied`) and creates a prowlarr Restore-populated PVC that has no seed snapshot to restore from (PVC Pending forever).

## prowlarr: remove from the backup set

prowlarr keeps all state in CNPG Postgres (`PROWLARR__POSTGRES__*`) and runs with `readOnlyRootFilesystem` + emptyDirs. Its `data` PVC has been **empty since 2026-02-25** — every volsync backup of it was a backup of nothing. The seed correctly produced a 0-byte snapshot, which `verify-seeds` correctly rejects.

- drop `components/kopiur`, the `KOPIUR_*` vars, and the `kopiur-repository` dependsOn from `ks.yaml`
- drop the unused `persistence.data` (existingClaim) mount from the HelmRelease

On resume, Flux prunes the empty PVC and the leftover volsync CRs. Post-merge manuals (tracked in the window punch list): `kubectl delete snapshotpolicy prowlarr -n media` (seed-script-created, Flux-unowned) and `flux resume ks/hr prowlarr -n media` (the migrate script's resume loop no longer includes prowlarr).

## vmks: mover uid 65534 → 1000

The old pinning relied on "the component's fsGroup group-remaps the snapshot clone" — **that premise is false**: kubelet skips the fsGroup chown on read-only volume mounts, so the kopiur mover reads the clone with plain uid permissions. vmks data is owned 1000:1000 on disk (verified by debug pod during the window) with several `cache/` dirs not world-readable, so the mover must run as 1000. Verified live: the uid-1000 seed succeeded at 34.0 GiB after a one-time chown of root-owned 0700 cache dirs left over from VMSingle's run-as-root era.

Comments on both vmks and victoria-logs rewritten to state the real constraint (victoria-logs keeps 65534 — its root-owned data is world-readable today, fragile but working; the durable fix is the existing useStrictSecurity TODO).

## Validation

- `just test` (flate offline render): 171 passed
- `migrate-kopiur.sh apps` derives 17 apps (prowlarr gone, vmks uid 1000)
- all 17 seeds Succeeded with `filesFailed=0`, sizes matching on-disk usage; `verify-seeds` gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)