### PR TITLE
fix(kopiur): switch B2 replication to the S3-compatible endpoint

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -9,9 +9,16 @@ spec:
     kind: ClusterRepository
     name: homelab
   destination:
-    b2:
+    # B2 via its S3-compatible API: kopia's native b2 provider is deprecated
+    # and Backblaze now rejects its old native-API calls ("not currently
+    # supported on API version number 1" — first scheduled sync, 2026-07-13).
+    # The same application key works; the secret carries it under the S3 names
+    # (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY) alongside the legacy B2_* keys.
+    s3:
       bucket: crayon-club-backups
       prefix: kopia/
+      endpoint: s3.us-west-000.backblazeb2.com
+      region: us-west-000
       auth:
         secretRef:
           name: kopiur-repository-secret

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -12,6 +12,8 @@ stringData:
   #ENC[AES256_GCM,data:TsFPlnpwnt/94cQtrW4h,iv:K5HkaAryjppmMgjmPFoPRmAYmPytSWDFo+8/xwBcnjU=,tag:thjlKNUr9ay+PaAbnXuNPA==,type:comment]
   B2_KEY_ID: ENC[AES256_GCM,data:FzriY74LYuWevP0TH74//1a+WYK/UxBUjw==,iv:P+f8dSLomN2a7hw9UyuUzfvDPDlNFQwTeP/5oPIQlns=,tag:sZYlX3Kdd6IXSovTpKX0mg==,type:str]
   B2_KEY: ENC[AES256_GCM,data:92OYaH6yg+K7+JqMsrTTQKl5Gb5eJ2XVXG1ya+0v7A==,iv:qJMcLdM99FCRe+pb3UGXRuqKvaTNJ+pcAgbbD1FvBnU=,tag:hR9EvuzSa/dJpRknQoCI9w==,type:str]
+  AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:EtvFfN6X4L8Qt0SQAUhWRNPtq9LIejUwCg==,iv:j25GbtrtI6eYahU7AkzxTAdDDXyj6GTj6OeBKQ5ec78=,tag:1KKk4nGeO5Lq+oDh9Msqqw==,type:str]
+  AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:sFUS0Zqa2vrHVvAx3SlKYa92rZGYEEerHKxbJRgZ4A==,iv:BnjLNUJY8UfF9vTQ3lWSbzyKlNuQpQs+Ra7Xcen/xho=,tag:tm4E4RbO0xjEz3LwSntTBQ==,type:str]
 sops:
   age:
     - enc: |
@@ -24,7 +26,7 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-07-12T19:44:51Z"
-  mac: ENC[AES256_GCM,data:HWsbL+aZQHKjdKFgGmZnaoXUI+XG9hNpgOqbyXne1w+cQSJoq96h9l7HUwlt8khX5knJNjOgU5OhT5kqeQyHsqr/m2NVrwOILPD67B+wwG3CXfn4RmL6icIU5J15WpoPSP4tta78BeCs06LWb+k7O1VDR2cpjpxlrbjstU7eNcA=,iv:qb4ssHPR/Iy5uZYTBLTP2s2hXjhrVMheneK9O6gS9nk=,tag:Az9SFZAxma8OUYQFAYjcqA==,type:str]
+  lastmodified: "2026-07-13T04:01:42Z"
+  mac: ENC[AES256_GCM,data:8Hx1dab3McxkwmjsQXFxdcZ2By2Zx6qe4TveVmVmf5oVSQNe3oU4Kka9CTQW3Xb7nLPYbNSwAACZAT+hi4Y/2miZOP/GBf2bBDbP8FQ8XKJyvnsD5oeeTc9rMGE3C/YPWS86Q1UbF13iU/ojVgmpjwN2/5XW34y1ZOlAf8X5yaw=,iv:zZY9/wJcUmxWICQvskbyOM/swJbjfsNRqyL3LJCi/YE=,tag:cF/c5Q86dF3t5vLvw5b6YA==,type:str]
   mac_only_encrypted: true
   version: 3.13.2


### PR DESCRIPTION
The first scheduled offsite sync (tracked in #1265) failed with:

> The B2 storage provider is deprecated and will be removed in the future, use the S3-compatible storage provider instead
> can't connect to storage: unable to create client: bad_request: This request is not currently supported on API version number 1

kopia's native `b2` provider is deprecated and Backblaze no longer accepts the old native-API version it speaks. Fix: same bucket (`crayon-club-backups`), same `kopia/` prefix, same application key — via B2's S3-compatible API.

- `RepositoryReplication homelab-offsite`: `destination.b2` → `destination.s3` with `endpoint: s3.us-west-000.backblazeb2.com` + `region: us-west-000` (from the account's live `s3ApiUrl`).
- Secret: adds `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (the kopiur s3 backend's expected env names) carrying the existing key pair; legacy `B2_KEY_ID`/`B2_KEY` retained until the S3 path is proven, then can be dropped.

`just test`: 168 passed.

**Watch on first sync**: the application key is name-prefix-restricted to `kopia/`; the S3 API honors that for object operations but not every bucket-level call. If kopia's S3 client requires an unrestricted bucket listing, the sync will fail with an access error and the key needs widening in `infra/backblaze`.

Verify after merge: trigger/wait a sync, then `kubectl get repositoryreplication -n kopiur-system` → phase `Succeeded` + `lastReplicated` set (#1265, and relevant to the #1262 topology decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)