### PR TITLE
feat(kopiur): deploy the kopia web UI

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -30,3 +30,18 @@ spec:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
+  # Kopia web UI (operator-created Deployment/Service `homelab-kopia-ui`,
+  # exposed by the HTTPRoute alongside this file). Read-only: snapshots and
+  # policies are managed from Git via the operator, so the UI is for browsing
+  # and restores only. Login creds are minted into `homelab-kopia-ui-auth`.
+  server:
+    namespace: kopiur-system
+    readOnly: true
+    auth:
+      generate: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/kopiur-system/kopiur/repository/httproute.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/httproute.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kopia-ui
+spec:
+  hostnames: ["kopia.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: homelab-kopia-ui
+          port: 51515

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./secret.sops.yaml
   - ./clusterrepository.yaml
   - ./repositoryreplication.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Adds the kopia web UI for browsing the shared `homelab` repository:

- `spec.server` on the ClusterRepository — the operator deploys `homelab-kopia-ui` (Deployment/Service/ConfigMap) in `kopiur-system`, port 51515
- **read-only** repository connection: snapshots/policies stay Git-managed; the UI is for browsing and restores
- auth: operator-generated credentials in the `homelab-kopia-ui-auth` Secret
- `HTTPRoute` on `envoy-internal` at `kopia.${SECRET_DOMAIN}`

`just test`: 168/168 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4aCjHvsmgL93yH46m8Nmd