### PR TITLE
fix(victoria): run single-node workloads non-root

### DIFF
--- a/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
@@ -17,6 +17,23 @@ spec:
       spec:
         retentionPeriod: "100y"
         storageDataPath: /victoria-metrics-data
+        useStrictSecurity: true
+        # Keep the workload identity tied to the kopiur mover identity. The
+        # operator does not merge its strict-security defaults when a custom
+        # uid is set, so spell out the complete hardened context here.
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: ${KOPIUR_UID}
+          runAsGroup: ${KOPIUR_GID}
+          fsGroup: ${KOPIUR_GID}
+          fsGroupChangePolicy: OnRootMismatch
+          seccompProfile:
+            type: RuntimeDefault
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
         storage: null # override chart default; use existing PVC via volumes instead
         volumes:
           - name: data

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -45,13 +45,9 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 50Gi
-      # The mover uid must match the data's actual on-disk ownership: fsGroup
-      # does NOT remap a read-only snapshot-clone mount (kubelet skips the
-      # chown), so a mismatched mover hits PermissionDenied on any file that
-      # isn't world-readable. VMSingle's data is owned 1000:1000 (verified
-      # 2026-07-13) with several cache/ dirs not world-readable.
-      # TODO: enable useStrictSecurity / set an explicit VMSingle
-      # securityContext, and keep this uid in lockstep with it.
+      # These values set both VMSingle's runtime uid/gid and the kopiur mover
+      # identity. Keep them in lockstep: kubelet does not fsGroup-remap a
+      # read-only snapshot clone, so the mover needs the data owner's ids.
       KOPIUR_UID: "1000"
       KOPIUR_GID: "1000"
     substituteFrom:
@@ -82,13 +78,9 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 5Gi
-      # VLSingle runs as root but writes world-readable files (0644/0755), so a
-      # 65534 mover can read everything today (verified 2026-07-13). fsGroup
-      # does NOT remap a read-only snapshot-clone mount — if VL ever writes a
-      # non-world-readable file, snapshots fail PermissionDenied and this uid
-      # must be revisited.
-      # TODO: enable useStrictSecurity / set the VLSingle securityContext to
-      # 65534, then this pinning becomes exact.
+      # These values set both VLSingle's runtime uid/gid and the kopiur mover
+      # identity. Keep them in lockstep: kubelet does not fsGroup-remap a
+      # read-only snapshot clone, so the mover needs the data owner's ids.
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"
     substituteFrom:

--- a/kubernetes/apps/observability/victoria/logs/vlsingle.yaml
+++ b/kubernetes/apps/observability/victoria/logs/vlsingle.yaml
@@ -6,6 +6,23 @@ metadata:
 spec:
   retentionPeriod: "7d"
   storageDataPath: /victoria-logs-data
+  useStrictSecurity: true
+  # Keep the workload identity tied to the kopiur mover identity. The
+  # operator does not merge its strict-security defaults when a custom uid is
+  # set, so spell out the complete hardened context here.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: ${KOPIUR_UID}
+    runAsGroup: ${KOPIUR_GID}
+    fsGroup: ${KOPIUR_GID}
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
   volumes:
     - name: data
       persistentVolumeClaim:


### PR DESCRIPTION
## Summary

- run VMSingle as `1000:1000` and VLSingle as `65534:65534` with explicit hardened security contexts
- source workload and Kopiur mover identities from the same `KOPIUR_UID/GID` substitutions
- replace the stale mover-UID warnings with the durable lockstep constraint
- keep the one-time PVC ownership conversion out of the long-lived workload specs

## Rollout

Do not merge until this maintenance sequence is underway. The ownership conversion is deliberately performed by temporary Jobs rather than permanent init containers.

1. Suspend both Flux Kustomizations, pause the operator CRs, and stop the data workloads:

```sh
flux suspend kustomization vmks -n observability
flux suspend kustomization victoria-logs -n observability

kubectl -n observability patch vmsingle vmks-victoria-metrics-k8s-stack --type=merge -p '{"spec":{"paused":true}}'
kubectl -n observability patch vlsingle victoria-logs-single --type=merge -p '{"spec":{"paused":true}}'

kubectl -n observability scale deployment/vmsingle-vmks-victoria-metrics-k8s-stack deployment/vlsingle-victoria-logs-single --replicas=0
kubectl -n observability get pods
```

Wait until both VMSingle and VLSingle pods are gone.

2. Save the following as `/tmp/victoria-chown-jobs.yaml`, apply it, and wait for both Jobs:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: victoria-chown-vmks
  namespace: observability
spec:
  backoffLimit: 0
  ttlSecondsAfterFinished: 600
  template:
    metadata:
      labels:
        app.kubernetes.io/name: victoria-chown-vmks
    spec:
      automountServiceAccountToken: false
      restartPolicy: Never
      securityContext:
        seccompProfile:
          type: RuntimeDefault
      containers:
        - name: chown
          image: mirror.gcr.io/library/busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
          command: ["/bin/chown"]
          args: ["-R", "1000:1000", "/data"]
          volumeMounts:
            - name: data
              mountPath: /data
          securityContext:
            runAsNonRoot: false
            runAsUser: 0
            runAsGroup: 0
            privileged: false
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            capabilities:
              drop: ["ALL"]
              add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
      volumes:
        - name: data
          persistentVolumeClaim:
            claimName: vmks
---
apiVersion: batch/v1
kind: Job
metadata:
  name: victoria-chown-logs
  namespace: observability
spec:
  backoffLimit: 0
  ttlSecondsAfterFinished: 600
  template:
    metadata:
      labels:
        app.kubernetes.io/name: victoria-chown-logs
    spec:
      automountServiceAccountToken: false
      restartPolicy: Never
      securityContext:
        seccompProfile:
          type: RuntimeDefault
      containers:
        - name: chown
          image: mirror.gcr.io/library/busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
          command: ["/bin/chown"]
          args: ["-R", "65534:65534", "/data"]
          volumeMounts:
            - name: data
              mountPath: /data
          securityContext:
            runAsNonRoot: false
            runAsUser: 0
            runAsGroup: 0
            privileged: false
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            capabilities:
              drop: ["ALL"]
              add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
      volumes:
        - name: data
          persistentVolumeClaim:
            claimName: victoria-logs
```

```sh
kubectl apply -f /tmp/victoria-chown-jobs.yaml
kubectl -n observability wait --for=condition=complete job/victoria-chown-vmks job/victoria-chown-logs --timeout=60m
kubectl -n observability logs job/victoria-chown-vmks
kubectl -n observability logs job/victoria-chown-logs
```

3. Merge this PR, then reconcile the merged manifests while the CRs remain paused:

```sh
flux reconcile source git flux-system -n flux-system
flux resume kustomization vmks -n observability
flux resume kustomization victoria-logs -n observability
flux reconcile helmrelease vmks -n observability
flux reconcile kustomization victoria-logs -n observability
```

Verify the CRs now contain `runAsUser: 1000` and `runAsUser: 65534`, respectively. Then unpause them and wait for the non-root workloads:

```sh
kubectl -n observability patch vmsingle vmks-victoria-metrics-k8s-stack --type=merge -p '{"spec":{"paused":false}}'
kubectl -n observability patch vlsingle victoria-logs-single --type=merge -p '{"spec":{"paused":false}}'

kubectl -n observability rollout status deployment/vmsingle-vmks-victoria-metrics-k8s-stack --timeout=10m
kubectl -n observability rollout status deployment/vlsingle-victoria-logs-single --timeout=10m
```

## Validation

- `just test` — 168 passed
- rendered VMSingle and VLSingle accepted by the live API using server-side dry-run
- both temporary Jobs accepted by the live API using server-side dry-run
- `git diff --check`

Closes #1261
