### PR TITLE
feat(kopiur): persistent mover cache, explicit schedule timezone, pinned operator security contexts

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -38,3 +38,36 @@ spec:
         memory: 256Mi
       limits:
         memory: 2Gi
+    # Controller pod security, pinned to the chart's current defaults so an
+    # upstream default change can't silently relax them. The controller never
+    # touches the NFS repository in-process here (no extraVolumes), so the
+    # locked-down nobody uid is sufficient.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+      fsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    webhook:
+      # Same pin for the webhook pod (its context is separate from the
+      # controller's by chart design — root-level keys never reach it).
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -42,14 +42,14 @@ spec:
     # upstream default change can't silently relax them. The controller never
     # touches the NFS repository in-process here (no extraVolumes), so the
     # locked-down nobody uid is sufficient.
-    podSecurityContext:
+    podSecurityContext: &podSecurityContext
       runAsNonRoot: true
       runAsUser: 65534
       runAsGroup: 65534
       fsGroup: 65534
       seccompProfile:
         type: RuntimeDefault
-    securityContext:
+    securityContext: &securityContext
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
@@ -58,16 +58,5 @@ spec:
     webhook:
       # Same pin for the webhook pod (its context is separate from the
       # controller's by chart design — root-level keys never reach it).
-      podSecurityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
-        fsGroup: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        capabilities:
-          drop:
-            - ALL
+      podSecurityContext: *podSecurityContext
+      securityContext: *securityContext

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -30,3 +30,24 @@ spec:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
+  moverDefaults:
+    # Warm kopia cache for every mover this repository spawns (backup,
+    # restore, maintenance, replication, bootstrap): a controller-owned
+    # per-recipe PVC reused across runs, so movers stop re-downloading the
+    # repository indexes from NFS on every hourly snapshot. Both `capacity`
+    # and `mode` are load-bearing — without a capacity the mode is ignored
+    # and the cache silently falls back to an emptyDir. Verification movers
+    # coerce Persistent to ephemeral themselves (RWO Multi-Attach safety).
+    # NFS classes can't back the cache (root-squash defeats fsGroup), hence
+    # the node-local zfs class; zvols are thin, so 5Gi per recipe costs only
+    # what the cache actually holds.
+    cache:
+      capacity: 5Gi
+      mode: Persistent
+      storageClassName: openebs-zfspv
+  scheduleDefaults:
+    # Every consuming cron (verification, replication, maintenance) reads in
+    # local time instead of the implicit controller default (UTC). Snapshot
+    # crons are hourly (`H * * * *`), so this shifts nothing there; keep
+    # daily crons' intended wall-clock time in mind when editing them.
+    timezone: America/New_York

--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -23,9 +23,11 @@ spec:
         secretRef:
           name: kopiur-repository-secret
   schedule:
-    # Daily offsite sync of the hourly snapshots. Planned follow-up: flip the
-    # topology so B2 is the primary repository and TrueNAS the replica.
-    cron: H 10 * * *
+    # Daily offsite sync of the hourly snapshots, early morning local time
+    # (the repository's scheduleDefaults.timezone; was `H 10 * * *` back when
+    # crons read in UTC). Planned follow-up: flip the topology so B2 is the
+    # primary repository and TrueNAS the replica.
+    cron: H 6 * * *
   sync:
     # kopia sync-to defaults to one blob at a time; without this the initial
     # seed to B2 would take days.


### PR DESCRIPTION
Closes #1263 — the three optional-hardening items carried over from the pre-migration review.

## Persistent mover cache

Set once at `ClusterRepository.spec.moverDefaults.cache` rather than per-SnapshotPolicy (onedr0p's placement): every mover the repository spawns — backup, restore, maintenance, replication, bootstrap — inherits it, and a per-recipe `mover.cache` can still overlay field-by-field.

- `mode: Persistent` + `capacity: 5Gi`: **both are load-bearing** — `resolve_cache_volume` silently falls back to an emptyDir when `capacity` is unset, even with the mode set.
- The PVC is per-owning-CR (e.g. the SnapshotPolicy, so the warm cache survives individual Snapshot CRs), controller-owned, and ownerRef'd for GC — no shared-RWO Multi-Attach risk between a snapshot and a restore in the same namespace, and verification movers coerce Persistent → ephemeral themselves.
- `storageClassName: openebs-zfspv` (the cluster default, made explicit): the cache must be a node-local block class — kopiur's docs call out that root-squashed NFS defeats the `fsGroup` chown and the mover dies with `mkdir /var/cache/kopia/logs: permission denied`. zvols are thin, so ~19 recipe caches cost only the bytes they actually hold.
- Movers are already node-pinned to their source PVC via `sourceColocation: Auto`, and the WFC cache PVC binds on first run on that same node, so the pin stays self-consistent.

## Explicit schedule timezone

`scheduleDefaults.timezone: America/New_York` on the ClusterRepository. Consumers are the verification, replication, and maintenance crons (SnapshotSchedule has its own `schedule.timezone` and does not inherit this — but ours are hourly `H * * * *`, which is timezone-invariant).

The B2 replication cron moves `H 10 * * *` → `H 6 * * *` so its effective slot stays ~6 AM local; it also stops drifting an hour across DST like the UTC reading did.

## Operator security contexts

The 0.7.3 chart defaults are already fully hardened (nobody 65534, seccomp RuntimeDefault, read-only rootfs, drop ALL) and the live controller/webhook pods run exactly those values — this pins them explicitly in the HelmRelease (root keys for the controller, `webhook.*` for the webhook, which the chart deliberately keeps separate) so an upstream default change can't silently relax them.

## Validation

- `just test`: 168 passed.
- `flate build hr kopiur`: both rendered Deployments carry the pinned pod + container contexts.
- Post-merge checks: cache PVCs appear per recipe after the next hourly sweep (`kubectl get pvc -A -l app.kubernetes.io/managed-by=kopiur`); next B2 replication fires in the 6 AM EDT hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTkeWxttHJMeGPXqETzyzU