### PR TITLE
fix(kopiur): avoid node-local mover cache conflicts

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -30,21 +30,6 @@ spec:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
-  moverDefaults:
-    # Warm kopia cache for every mover this repository spawns (backup,
-    # restore, maintenance, replication, bootstrap): a controller-owned
-    # per-recipe PVC reused across runs, so movers stop re-downloading the
-    # repository indexes from NFS on every hourly snapshot. Both `capacity`
-    # and `mode` are load-bearing — without a capacity the mode is ignored
-    # and the cache silently falls back to an emptyDir. Verification movers
-    # coerce Persistent to ephemeral themselves (RWO Multi-Attach safety).
-    # NFS classes can't back the cache (root-squash defeats fsGroup), hence
-    # the node-local zfs class; zvols are thin, so 5Gi per recipe costs only
-    # what the cache actually holds.
-    cache:
-      capacity: 5Gi
-      mode: Persistent
-      storageClassName: openebs-zfspv
   scheduleDefaults:
     # Every consuming cron (verification, replication, maintenance) reads in
     # local time instead of the implicit controller default (UTC). Snapshot


### PR DESCRIPTION
## Summary

- remove the repository-wide persistent mover cache backed by node-local ZFS
- restore Kopiur's ephemeral mover cache behavior
- keep the schedule timezone and operator security hardening unchanged

## Why

A mover can mount both a node-local snapshot clone and the persistent cache PVC. Kubernetes may bind those volumes to different nodes, leaving no valid placement for the mover.

Observed on the `seerr` backup:

- `kopiur-cache-seerr` was pinned to `talos0`
- `seerr-20260716043000-src` was pinned to `talos1`
- the mover remained Pending because neither node satisfied both PV affinities

## Validation

- `just test` (168 passed)
- `git diff --check`