### PR TITLE
fix(observability): stop VM dropping all kubelet/cAdvisor series

### DIFF
--- a/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
@@ -83,6 +83,23 @@ spec:
       enabled: true
     kubelet:
       enabled: true
+      vmScrape:
+        spec:
+          # The chart default labelmaps every node label onto every kubelet /
+          # cAdvisor series. Node Feature Discovery (pulled in by the GPU
+          # operator) puts 76-140 labels on each node, which blows past
+          # VictoriaMetrics' -maxLabelsPerTimeseries=30 and makes vmsingle
+          # discard the series outright at ingestion. Keep only the node labels
+          # that identify the node.
+          relabelConfigs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - action: labeldrop
+              regex: (feature_node_kubernetes_io_.*|nvidia_com_.*|extensions_talos_dev_.*|beta_kubernetes_io_.*|openebs_io_.*)
+            - sourceLabels: [__metrics_path__]
+              targetLabel: metrics_path
+            - targetLabel: job
+              replacement: kubelet
     kubeApiServer:
       enabled: true
     kubeControllerManager:

--- a/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
@@ -85,17 +85,18 @@ spec:
       enabled: true
       vmScrape:
         spec:
-          # The chart default labelmaps every node label onto every kubelet /
-          # cAdvisor series. Node Feature Discovery (pulled in by the GPU
-          # operator) puts 76-140 labels on each node, which blows past
-          # VictoriaMetrics' -maxLabelsPerTimeseries=30 and makes vmsingle
-          # discard the series outright at ingestion. Keep only the node labels
-          # that identify the node.
+          # Mirrors the chart 0.87.0 defaults minus the node-label labelmap —
+          # re-diff against the chart on upgrade.
+          #
+          # The default `labelmap __meta_kubernetes_node_label_(.+)` copies every
+          # node label onto every kubelet / cAdvisor series. Node Feature
+          # Discovery (pulled in by the GPU operator) puts 76-140 labels on each
+          # node, which blows past VictoriaMetrics' -maxLabelsPerTimeseries=30 and
+          # makes vmsingle discard the series outright at ingestion. Nothing here
+          # consumes the mapped labels and `instance` already carries the node
+          # name, so don't map them at all — an allowlist a future operator can't
+          # regress.
           relabelConfigs:
-            - action: labelmap
-              regex: __meta_kubernetes_node_label_(.+)
-            - action: labeldrop
-              regex: (feature_node_kubernetes_io_.*|nvidia_com_.*|extensions_talos_dev_.*|beta_kubernetes_io_.*|openebs_io_.*)
             - sourceLabels: [__metrics_path__]
               targetLabel: metrics_path
             - targetLabel: job

--- a/kubernetes/apps/observability/victoria/k8s-stack/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./vmrule.yaml
   - ./vmstaticscrape.yaml
   - ./vmuser.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/observability/victoria/k8s-stack/vmrule.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/vmrule.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/operator.victoriametrics.com/vmrule_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: victoria-metrics-ingestion
+spec:
+  groups:
+    # Rows discarded at ingestion are invisible from the scrape side — vmagent
+    # reports its targets healthy while vmsingle drops the samples. That is how
+    # the -maxLabelsPerTimeseries=30 limit silently ate every kubelet/cAdvisor
+    # series for seven weeks. Alert on the whole class, not just that one limit.
+    - name: victoria-metrics-ingestion
+      rules:
+        - alert: VictoriaMetricsRowsIgnored
+          expr: sum by (reason) (increase(vm_rows_ignored_total[10m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: VictoriaMetrics is discarding rows at ingestion
+            description: >-
+              vmsingle has discarded {{ $value | humanize }} rows in the last
+              10m with reason "{{ $labels.reason }}". These samples are scraped
+              successfully but never stored, so scrape targets look healthy
+              while the series go missing.


### PR DESCRIPTION
## Problem

Most panels on the `Kubernetes / Compute Resources / Workload` dashboard (and its siblings) have been empty. The cause is not the dashboards — VictoriaMetrics has been **discarding every kubelet and cAdvisor series at ingestion** since 2026-06-14.

The chart's default `kubelet.vmScrape.spec.relabelConfigs` does:

```yaml
- action: labelmap
  regex: __meta_kubernetes_node_label_(.+)
```

which stamps every node label onto every series from all four kubelet VMNodeScrapes (cadvisor, kubelet, probes, resources). Node Feature Discovery, pulled in by the NVIDIA GPU operator in #1007, has loaded up the nodes:

| node | total labels | NFD / nvidia |
|---|---|---|
| talos0 | 90 | 76 |
| talos1 | 154 | 140 |

That puts each series far past VictoriaMetrics' default `-maxLabelsPerTimeseries=30`. Since [v1.108.0](https://docs.victoriametrics.com/victoriametrics/changelog/changelog_2024/) ([PR #7399](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7399)) VM drops over-limit series outright rather than truncating labels:

```
warn  ignoring series with 97 labels for {__name__="container_cpu_usage_seconds_total", ...}
```

## Why it hid for ~7 weeks

vmagent target health stayed green the entire time — all four node scrapes `up`, cAdvisor pulling ~22,845 samples per scrape. The loss is downstream, in vmsingle. Nothing in the shipped dashboards or alert rules surfaces `vm_rows_ignored_total`, which currently reads **1,282,244,114** for `reason="too_many_labels"` (every other reason is exactly 0).

Timeline:

| when | what |
|---|---|
| 2026-06-13 | `d9c02836 feat: nvidia gpu operator (#1007)` merged, bringing NFD |
| 2026-06-14 | last day `container_memory_working_set_bytes` has data |
| 2026-06-15 | `vm_rows_ignored_total{reason="too_many_labels"}` goes non-zero (107M rows that day) |

Affected metric families: `container_*`, `kubelet_*`, `node_cpu_usage_*`, plus the `node_namespace_pod_container:*` recording rules built on them. kube-state-metrics was never affected, which is why the handful of KSM-only panels still rendered.

## Fix

**Drop the node-label `labelmap` entirely.** Nothing in the chart's rules or dashboards, nor anywhere under `kubernetes/`, references a mapped node label, and `instance` already carries the node name (`talos0` / `talos1`). The override is otherwise byte-identical to the chart 0.87.0 default, and the shared spec means all four node scrapes pick it up (verified with `helm template`).

This started as a `labeldrop` denylist of the noisy families. Review caught that it was already leaky on day one: talos0 carries `intel.feature.node.kubernetes.io/gpu` → `intel_feature_node_kubernetes_io_gpu`, which the fully-anchored `feature_node_kubernetes_io_.*` never matched — and the Intel device plugin can expand that family (`sgx`, `dsa`, `qat`) exactly the way the nvidia one did. Removing the labelmap is an allowlist by construction rather than a denylist the next operator can regress.

**Plus a VMRule on `vm_rows_ignored_total`.** The relabel change fixes this instance; it does nothing about the detection gap that let it run for seven weeks. Rows discarded at ingestion are invisible from the scrape side, and a different limit (`-maxLabelValueLen`, per-metric-name limits) would fail the same silent way. The expression returns 855k rows/10m right now, so it doubles as verification — it should fall to zero once this reconciles.

## Notes

- Nothing in the vmks chart (0.80.0 → 0.88.x) or operator chart changelogs mentions this; the default has been unchanged across every version we've run. The override comment flags it as mirroring 0.87.0 so a future bump gets re-diffed.
- [VictoriaMetrics#10092](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10092) is the same symptom signature from another user, still open with no diagnosis upstream.
- Data recovery is not possible — the historical gap is permanent. Graphs populate going forward only.
- Series identity changes, so range queries spanning June will carry both the old (fat) and new labelsets. Cosmetic, given the gap already exists.

## Testing

- `just test` — 168 passed.
- `helm template` against vmks 0.87.0 — all four VMNodeScrapes render without the labelmap, `metricRelabelConfigs` and `job=kubelet` intact.
- `kubectl apply --dry-run=server` on the rendered VMRule — accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)