### PR TITLE
feat(llmkube): scrape controller metrics for the 0.9.14 operator dashboards

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -37,12 +37,27 @@ spec:
       accessMode: ReadWriteOnce
     priorityClasses:
       enabled: true
+    metrics:
+      # Plain HTTP on the controller's metrics port. With secure: true,
+      # controller-runtime puts its authn/authz filter in front of /metrics,
+      # and the chart's ServiceMonitor sets tlsConfig.insecureSkipVerify but
+      # sends no bearer token — vmagent would scrape it and get a 401. The
+      # port stays ClusterIP-only either way.
+      secure: false
     prometheus:
       # Discovers every pod carrying inference.llmkube.dev/service, so new
       # InferenceServices are scraped without edits, and relabels job to
       # llmkube-inference while promoting service/model/runtime onto each
       # series — which is what the recording rules and dashboards group by.
       inferencePodMonitor:
+        enabled: true
+        additionalLabels: null
+      # Scrapes the controller-manager's own llmkube_* metrics, which the
+      # Operator health row added to the llmkube-inference dashboard in 0.9.14
+      # reads (reconcile rate/duration, time-to-ready, fleet readiness, replica
+      # state, GPU queue depth). Relabels job to llmkube-controller, which is
+      # also what makes the ControllerDown alert below able to fire.
+      serviceMonitor:
         enabled: true
         additionalLabels: null
       prometheusRule:
@@ -61,9 +76,8 @@ spec:
           gpu:
             enabled: false
           # Gates the recording-rule group as well as the alerts.
-          # InferenceServiceDown is live off the PodMonitor's job relabel;
-          # ControllerDown is inert until serviceMonitor is enabled, since
-          # nothing emits job="llmkube-controller" to go 0.
+          # InferenceServiceDown is live off the PodMonitor's job relabel, and
+          # ControllerDown off the ServiceMonitor's.
           inference:
             enabled: true
     grafana:
@@ -75,9 +89,10 @@ spec:
         additionalLabels: null
         operator:
           enabled: true
-          # Defers the vLLM and SGLang dashboards to the operator, which
-          # publishes them only while an InferenceService on that runtime
-          # exists. Everything here is runtime: llamacpp, so they stay unfiled.
+          # Defers the runtime dashboards to the operator, which publishes each
+          # only while an InferenceService on that runtime exists. vLLM and
+          # SGLang stay unfiled; 0.9.14 added llamacpp to that set, so its
+          # dashboard is published here off the three llamacpp services.
           mode: auto
           instanceSelector:
             matchLabels:
@@ -85,7 +100,7 @@ spec:
           # The CRs land in ai; the Grafana instance lives in observability.
           allowCrossNamespaceImport: true
           folder: LLMKube
-          # Six of the seven dashboards template ${DS_PROMETHEUS}; the AMD one
+          # Seven of the eight dashboards template ${DS_PROMETHEUS}; the AMD one
           # uses a datasource variable and falls through to the default, which
           # is VictoriaMetrics either way.
           datasources:


### PR DESCRIPTION
## Problem

llmkube 0.9.14 added an **Operator health** row to the `llmkube-inference` dashboard — six panels: reconcile rate by result, reconcile duration p95, time-to-Ready p95, Services Ready vs total, fleet replicas ready vs desired, and GPU queue depth by namespace.

Every one of them reads a controller-manager metric (`llmkube_reconcile_total`, `llmkube_reconcile_duration_seconds_bucket`, `llmkube_inferenceservice_ready_duration_seconds_bucket`, `llmkube_inferenceservice_phase`, `llmkube_inferenceservice_replicas`, `llmkube_gpu_queue_depth`). Nothing scrapes the controller — `prometheus.serviceMonitor` has always been off here — so the chart bump silently published six blank panels into Grafana. Confirmed live: `uid: llmkube-inference` is already at 11 panels with row id 102, and no `llmkube_*` series exist in VictoriaMetrics.

## Change

Enable the chart's ServiceMonitor, and drop the controller's metrics endpoint to plain HTTP.

The second half is not optional. `metrics.secure` defaults to `true`, which puts controller-runtime's authn/authz filter in front of `/metrics`. The chart's ServiceMonitor template sets `tlsConfig.insecureSkipVerify` but sends **no bearer token**, so vmagent would scrape it and get a 401 — and the chart ships no metrics-reader ClusterRole to authorize vmagent's ServiceAccount for the `/metrics` nonResourceURL either. Keeping `secure: true` would mean bypassing the chart's ServiceMonitor entirely for a hand-written `VMServiceScrape` with `bearerTokenFile` plus that RBAC. The port is ClusterIP-only either way, so plain HTTP buys the same thing for two lines.

Side effect worth having: the ServiceMonitor relabels `job` to `llmkube-controller`, which is what `ControllerDown` matches. That alert has been inert since it was enabled — nothing emitted the job label for it to go 0 against.

Also refreshes three comments 0.9.14 made stale:
- llamacpp joined the deferred runtime-dashboard set, so the new `llamacpp-dashboard` is published off the three llamacpp InferenceServices rather than staying unfiled like vLLM/SGLang
- seven of *eight* dashboards now template `${DS_PROMETHEUS}` (was six of seven)
- `ControllerDown` is no longer inert

## Verification

`helm template` against the pinned 0.9.14 chart with these values — all three sides agree:

- Deployment: `--metrics-secure=false`
- metrics Service: port `8443` named `http`
- ServiceMonitor: endpoint `port: http`, `scheme: http`, no `tlsConfig`, no kube-prometheus-stack selector label (VM runs `selectAllByDefault`)

`just test` → 168 passed.

## Note on rollout

`talos1` is currently `NotReady,SchedulingDisabled`, so the llmkube controller and all three InferenceService pods are Pending and `llamacpp:*` / `DCGM_*` series stop at 2026-08-04 19:00Z. This won't produce data until that node is back — at which point the new `llamacpp-dashboard` should also appear on its own via the controller's auto-publish (it's already staged in `ai/llmkube-dashboard-candidates`; no config change needed for it).

## Not in this PR

- **`metrics.emitScrapeAnnotations`** (new in 0.9.14) stays off — it is an *alternative* to the inference PodMonitor, not a companion, and enabling both double-scrapes every target.
- **`rules.gpu`** stays disabled. 0.9.14 makes those expressions exporter-agnostic and adds a genuinely useful `GPUMetricsMissing`, but `gpu.enabled` gates the whole group, which would re-inherit `GPUHighUtilization` — still meaningless for a gpu-preemptible workload that is meant to sit at 100%. Worth revisiting as its own change, likely as a hand-written VMRule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)