### PR TITLE
fix(memini): pull the chart from the ghcr.io mirror

### DIFF
--- a/kubernetes/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/app/ocirepository.yaml
@@ -10,4 +10,4 @@ spec:
     operation: copy
   ref:
     tag: v0.7.17
-  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini
+  url: oci://ghcr.io/eleboucher/charts/memini


### PR DESCRIPTION
Renovate has been failing to look up `registry.erwanleboucher.dev/eleboucher/charts/memini` (`no-result`), so the memini OCIRepository gets no update PRs. The registry's `/v2/` root answers 401 with no anonymous token flow, so Renovate's docker datasource bails before it ever reaches the tags endpoint.

The chart is mirrored to `ghcr.io/eleboucher/charts/memini`, which Renovate reads fine.

## Why this is a safe swap

- Same tag set on both registries — ghcr is actually ahead, it already carries `v0.7.18`.
- The pinned `v0.7.17` resolves to an **identical manifest digest** on both: `sha256:94712c018f91f5c8bf8c87d75346cb0923a5146780862438885ca153a56da4ae`.
- Same media types (`application/vnd.cncf.helm.config.v1+json` config, `application/vnd.cncf.helm.chart.content.v1.tar+gzip` layer), so the existing `layerSelector` still matches.

Pure source swap; no chart change, no values change.

## Validation

`flate` pulls the chart from the new URL cleanly:

```
✓  OCIRepository  ai/memini
```

Note that `just test` currently fails on `main` for an unrelated reason — `kubernetes/apps/ai/llmkube/models/kustomization.yaml` still references `qwen3-6-27b-mtp.yaml`, which 6b821d96 renamed to `qwen3-8-27b-mtp.yaml` (the matching kustomization fix lives on the unmerged `feat/qwen3.8` branch). That blocks `ai/llmkube-models`, and memini `dependsOn` it, so memini shows as `⊘ blocked` rather than passing. Not caused by this PR.

The remaining Renovate warning — `custom.talos-factory` / `siderolabs/talos` in `tuppr/upgrades/talosupgrade.yaml` — is a separate issue and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)