### PR TITLE
fix(renovate): opt into home-operations apps/ presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -9,6 +9,11 @@
     ":disableRateLimiting",
     ":semanticCommits",
     "github>home-operations/renovate-presets",
+    "github>home-operations/renovate-presets//apps/cnpg.json5",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5",
+    "github>home-operations/renovate-presets//apps/llamacpp.json5",
+    "github>home-operations/renovate-presets//apps/searxng.json5",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5",
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: "Renovate Dashboard",
@@ -40,32 +45,6 @@
     ],
   },
   packageRules: [
-    {
-      description: "llama.cpp uses bNNNN build numbers with variant prefix",
-      matchPackageNames: [
-        "ghcr.io/ggml-org/llama.cpp"
-      ],
-      versioning: "regex:^(?<compatibility>server-[a-z]+)-b(?<patch>\\d+)$",
-    },
-    {
-      description: "SearXNG uses calver versioning (YYYY.M.patch-commit)",
-      matchPackageNames: [
-        "ghcr.io/searxng/searxng",
-        "searxng/searxng",
-        "docker.io/searxng/searxng"
-      ],
-      versioning: "regex:^(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<build>.+))?$",
-    },
-    {
-      description: "Override Helmfile Dependency Name",
-      matchDatasources: [
-        "docker"
-      ],
-      matchManagers: [
-        "helmfile"
-      ],
-      overrideDepName: "{{packageName}}",
-    },
     {
       description: "Flux Operator Group",
       groupName: "flux-operator",
@@ -253,6 +232,23 @@
       ],
       addLabels: [
         "renovate/github-release"
+      ],
+    },
+    {
+      description: "Grafana dashboard revisions are bare integers, so every bump reads as a major; restore the preset's chore framing that the generic major rule above overrides",
+      matchDatasources: [
+        "custom.grafana-dashboards"
+      ],
+      semanticCommitType: "chore",
+      semanticCommitScope: "grafana-dashboards",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}}):",
+      commitMessageTopic: "dashboard {{sourceDirectory}}",
+      commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
+      labels: [
+        "type/patch"
+      ],
+      addLabels: [
+        "renovate/grafana-dashboard"
       ],
     },
   ],


### PR DESCRIPTION
## Problem

Renovate started reporting:

> Failed to look up `custom.talos-factory` package `siderolabs/talos`: no-result

`home-operations/renovate-presets` moved app-specific presets out of `default.json` into an opt-in `apps/` directory (README: *"Application-specific presets live under `apps/` and are opt-in… not part of `default.json`"*). We only extended the bare reference, so `customDatasources["talos-factory"]` disappeared and the annotation in `tuppr/upgrades/talosupgrade.yaml` resolved to nothing.

Defining the datasource locally would fix the lookup but leave `talos/talconfig.yaml` unmanaged — 9ae62a82 deliberately deleted the `ghcr.io/siderolabs/installer` annotation and unified on `talos-factory`, relying on the preset's bundled custom manager to pick up `talosVersion:`.

## Change

Opt into the five `apps/` presets that apply here, and delete the local rules they replace.

| Preset | Rationale |
|---|---|
| `talosFactory` | Fixes the lookup. Supplies the custom datasource **and** the manager matching `talosVersion:` under `talos/` |
| `llamacpp` | Replaces the local rule — upstream captures `cuda` as compatibility rather than `server-cuda`; same stream isolation |
| `searxng` | Replaces the local rule — current tag `2026.8.5-1689cb1b5` matches. The local rule also listed `searxng/searxng` and `docker.io/searxng/searxng`, neither used here |
| `cnpg` | **New coverage** — `imageName: ghcr.io/cloudnative-pg/postgresql:18@sha256:…` in `cluster.yaml` was extracted by nothing before |
| `grafanaDashboards` | **New coverage** — the grafana.com revision pins in `victoria/logs/` and `nvidia-gpu/operator/` were untracked |

`phanpy` skipped — the image isn't used here.

Also drops the local **"Override Helmfile Dependency Name"** rule, now duplicated verbatim by upstream `default.json`.

### One rule added

`extends` resolve before the repo's own `packageRules`, so our generic `major → feat(...)!:` rule overrides the preset's `chore`. Dashboard revisions version as `regex:^(?<major>\d+)$`, so *every* revision bump is `updateType: "major"` — confirmed in a dry run against a forced 9→11 (`"updateType": "major", "isBreaking": true`). Without an override each dashboard bump lands as a breaking `feat(...)!:` labeled `type/major`. The trailing rule restores the preset's `chore(grafana-dashboards):` framing.

## Verification

`renovate --platform=local --dry-run=lookup` against the working tree. The only change to the resolved branch set is one addition:

```
> "branchName": "renovate/ghcr.io-cloudnative-pg-postgresql-18"
```

No regressions on talos, searxng, llama.cpp, or anything else. `siderolabs/talos` resolves again (`v1.13.7 → v1.13.8`) with `talconfig.yaml` and `talosupgrade.yaml` on the single branch `renovate/siderolabs-talos-1.x`. Dashboards resolve cleanly (`sourceDirectory: "VictoriaLogs - single-node"`, no warnings) and are already at latest. `renovate-config-validator` passes.

Two caveats worth stating plainly:

- The commit-message override reasoning can't be observed locally — `--platform=local` stops before the branch stage, so messages never render. The precedent is our existing `fix(mise):` commits, where the same override chain beats upstream's `chore`.
- **Pre-existing gap, untouched:** two llmkube models pin `llama.cpp:server-b9628` (no accelerator variant). That tag matches neither the old local regex nor the upstream one — both require `server-<variant>-b<N>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)