### PR TITLE
fix(konflate): raise the memory limit to 2Gi

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -28,6 +28,12 @@ spec:
           sectionName: https
       hostnames:
         - konflate.${SECRET_DOMAIN}
+    resources:
+      limits:
+        memory: 2Gi
+      requests:
+        cpu: 50m
+        memory: 512Mi
     persistence:
       enabled: true
       storageClass: openebs-hostpath


### PR DESCRIPTION
konflate has been OOMKilled in a crashloop since the 0.4.3 → 0.5.0 upgrade landed on `main` today. It dies ~11s after every start, exit code 137, right after it begins rendering diffs for the open PRs:

```
{"msg":"refresh listed","prs":11,"new":0,"advanced":2}
lastState: terminated, exitCode: 137, reason: OOMKilled
```

The logs are otherwise clean — no error, it just stops.

**Cause:** the chart's default limit is 1Gi, and konflate's steady-state working set was already 540–750MiB (per VictoriaMetrics, over the past weeks, with 0 restarts). There was no headroom for the cold-start render fan-out — on restart the in-memory PR/diff state is gone, so it re-renders all 11 open PRs at diff concurrency 4 at once.

Chart values are byte-identical between 0.4.3 and 0.5.0 apart from the image digest, so this is app-side; 0.5.0 bumps `home-operations/flate` 0.4.12 → 0.4.14 plus a batch of Go deps.

**Change:** raise the limit to 2Gi and the request to 512Mi to match actual usage. talos1 is at 37% memory, so there's room. `config.maxDiffConcurrency` is left alone — it's the other lever if 2Gi proves tight.

`just test` passes for konflate. The `ai/llmkube-models` failure it reports is pre-existing on `main` (missing `models/qwen3-6-27b-mtp.yaml`) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)