### PR TITLE
fix(ai): raise litellm-operator memory above chart default

### DIFF
--- a/kubernetes/apps/ai/litellm/operator/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/operator/helmrelease.yaml
@@ -31,6 +31,6 @@ spec:
     resources:
       requests:
         cpu: 10m
-        memory: 64Mi
-      limits:
         memory: 128Mi
+      limits:
+        memory: 512Mi


### PR DESCRIPTION
## Problem

`litellm-operator` has been in `CrashLoopBackOff` since #1445 landed, OOMKilled (exit 137) roughly every 20s.

The chart default of `64Mi` request / `128Mi` limit is too small for this cluster. The `LiteLLMVirtualKey` controller watches Secrets cluster-wide with no namespace or label scope, so the informer caches all ~380 of ours. The logs show a clean startup — cert rotation, webhook registration, all four validating webhooks served — and then the kill lands the instant leader election is won and the caches fill. Nothing is logged as an error, which is what makes it look like a healthy operator that just dies.

The knock-on effect is the visible failure: the pod never reaches `0/1` → ready, so `litellm-operator-webhook` has no endpoints, and the `litellm` Kustomization fails its dry-run:

```
LiteLLMProxy/ai/litellm dry-run failed (InternalError): failed calling webhook
"vlitellmproxy.kb.io": ... dial tcp 10.107.21.157:443: connect: no route to host
```

## Fix

Raise to `128Mi` request / `512Mi` limit. Chart 0.0.13 exposes no watch-scope knob (no `watchNamespace`, no cache selector), so headroom is the only lever available. For reference, `llmkube-controller-manager` next door runs `256Mi`/`1Gi` and idles at 34Mi.

Note the `resources:` block being replaced was byte-identical to the chart default — it was a restatement, not an override, so nothing intentional is being undone here.

## Testing

- `just test` — 173 passed
- Rollout verification pending merge; the proxy Kustomization should reconcile on its own once the webhook has endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)