### PR TITLE
feat(ai): sign in to the litellm admin UI with pocket-id

### DIFF
--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -38,11 +38,17 @@ spec:
   path: ./kubernetes/apps/ai/litellm/proxy
   components:
     - ../../../../components/database
+    - ../../../../components/oidc
   dependsOn:
     - name: litellm-operator
+    - name: pocket-id
+      namespace: security
   postBuild:
     substitute:
       APP: *app
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/litellm.svg"
+      OIDC_APP_NAME: LiteLLM
+      OIDC_CALLBACK_PATH: /sso/callback
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/ai/litellm/proxy/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./secret.sops.yaml
   - ./keys-secret.sops.yaml
   - ./proxy.yaml
+  - ./usergroup.yaml

--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -7,6 +7,11 @@ spec:
   image: ghcr.io/berriai/litellm:v1.97.0@sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834
   replicas: 1
 
+  # Pod template rather than the Deployment, which is the operator's — reloader
+  # falls back to template annotations when the workload carries none.
+  podAnnotations:
+    reloader.stakater.com/auto: "true"
+
   # Pushes model_list to the admin API instead of config.yaml, so the proxy does
   # not roll when the model set changes. qwen3-8-27b-mtp is gpu-preemptible and
   # its endpoint churns by design; in file mode each eviction would restart the
@@ -58,6 +63,49 @@ spec:
         secretKeyRef:
           name: litellm-postgres-secret
           key: password
+
+    # /ui SSO against pocket-id via litellm's "generic" OIDC provider, which has
+    # no discovery-document path — hence the endpoints wired individually out of
+    # the Secret the pocket-id operator writes. Who may log in is gated at
+    # pocket-id by the litellm-users group (usergroup.yaml), not here.
+    - name: PROXY_BASE_URL
+      value: "https://litellm.${SECRET_DOMAIN}"
+    - name: GENERIC_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: &oidcSecret litellm-oidc-credentials
+          key: OIDC_CLIENT_ID
+    - name: GENERIC_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: *oidcSecret
+          key: OIDC_CLIENT_SECRET
+    - name: GENERIC_AUTHORIZATION_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: *oidcSecret
+          key: OIDC_AUTHORIZATION_URL
+    - name: GENERIC_TOKEN_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: *oidcSecret
+          key: OIDC_TOKEN_URL
+    - name: GENERIC_USERINFO_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: *oidcSecret
+          key: OIDC_USERINFO_URL
+    # profile has to stay: pocket-id only returns preferred_username under it.
+    - name: GENERIC_SCOPE
+      value: openid email profile
+
+    # pocket-id emits no role claim, so logins land as internal_user except this
+    # id, which litellm promotes to proxy_admin on each callback. Username, not
+    # sub — sub is a UUID that does not exist until the user is created.
+    - name: GENERIC_USER_ID_ATTRIBUTE
+      value: preferred_username
+    - name: PROXY_ADMIN_ID
+      value: dsluo
 
   # The entrypoint runs `prisma migrate deploy` (~30 tables on a fresh DB)
   # before the server binds, which outlasts the operator's default liveness

--- a/kubernetes/apps/ai/litellm/proxy/usergroup.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/usergroup.yaml
@@ -1,0 +1,12 @@
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDUserGroup
+metadata:
+  name: litellm-users
+spec:
+  friendlyName: LiteLLM Users
+  allowedOIDCClients:
+    - name: litellm
+  users:
+    userRefs:
+      - name: david
+        namespace: security


### PR DESCRIPTION
Puts the litellm admin UI behind pocket-id, using litellm's "generic" OIDC provider.

## How it's wired

- **`ks.yaml`** picks up `components/oidc` with `OIDC_CALLBACK_PATH: /sso/callback`, and gains a `dependsOn` on `pocket-id`. That renders a `PocketIDOIDCClient` named `litellm`, whose operator-written Secret supplies the credentials and endpoints.
- **`proxy.yaml`** consumes that Secret. The generic provider has no discovery-document path, so authorize/token/userinfo are wired individually rather than from `OIDC_DISCOVERY_URL`. `PROXY_BASE_URL` is set so the redirect URI is deterministic instead of derived from the inbound `Host`.
- **`usergroup.yaml`** is the actual access gate: `litellm-users`, restricted to the `litellm` client. Someone outside it never receives an authorization code, so no `ui_access_mode` or `ALLOWED_EMAIL_DOMAINS` config is needed on the proxy side.

## Admin role

pocket-id emits no role claim, so every SSO login would otherwise land as `internal_user`. `PROXY_ADMIN_ID` pins the single identity litellm promotes to `proxy_admin` on each callback — anyone added to the group later still lands as `internal_user`.

It matches on `preferred_username`, not `sub`: `sub` is a pocket-id UUID that doesn't exist until the user is created. This is also why `profile` has to stay in `GENERIC_SCOPE` — `claims_service.go` only emits `preferred_username` under that scope. Note the litellm docs claim `GENERIC_SCOPE` defaults to `openid`; the code actually defaults to `openid email profile`. Set explicitly here since the user id depends on it.

## Reloader

`podAnnotations` carries `reloader.stakater.com/auto`, since the Deployment is the operator's and there's no object-level annotation to set. Reloader falls back to pod-template annotations when the workload carries none (`pkg/common/common.go`), and the CRD documents `podAnnotations` as being for exactly this.

Caveat: the operator does a full `deploy.Spec = desired.Spec` overwrite and `Owns` the Deployment, so it reverts Reloader's mutation quickly. The reload should still land — pods created during the flap read the Secret fresh — but it may look like a double rollout.

## Scope

Only `/ui` login is affected. `/v1` traffic and virtual keys authenticate as before, and the master key still works at `/fallback/login`.

## Verification

`just test` passes (173). Behaviour checked against source rather than docs — litellm `v1.97.0` `ui_sso.py`, pocket-id `v2.13.0` `claims_service.go`, Reloader `v1.4.21`, and litellm-operator `0.0.13`.

Not yet exercised against the live cluster. If the admin promotion doesn't take on first login, `/sso/debug/login` dumps the actual claims (needs `/sso/debug/callback` added to the client's callback URLs first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)