### PR TITLE
feat(ai): bifrost

### DIFF
--- a/kubernetes/apps/ai/bifrost/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/bifrost/app/helmrelease.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bifrost
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    # Bifrost OSS does not sync config between processes, so a second replica
+    # would serve a stale view of anything created through the UI.
+    replicaCount: 1
+    image:
+      repository: docker.io/maximhq/bifrost
+      # Stay on the v1.6.x line; a v2.0.0-prerelease* line also publishes to
+      # this repository and Renovate will offer it if allowed to.
+      tag: v1.6.11@sha256:ef8e686b3588884066ec3d0e57f3fc15136b11047ad94678adefe5a9573539af
+    deploymentAnnotations:
+      # The chart already checksums the rendered config.json into the pod
+      # template; this covers bifrost-secret, which it does not.
+      reloader.stakater.com/auto: "true"
+
+    # Pin the chart's default runtime uid/gid so KOPIUR_UID/GID=1000 (ks.yaml)
+    # stays anchored to a real in-repo value and can't drift on a chart bump —
+    # the kopiur movers write restored files owned by that uid.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+
+    storage:
+      mode: sqlite
+      persistence:
+        enabled: true
+        # Setting existingClaim is also what makes the chart render a
+        # Deployment instead of a StatefulSet (templates/deployment.yaml:3),
+        # which is what we want: kopiur owns the PVC, not a volumeClaimTemplate.
+        existingClaim: *app
+      configStore:
+        enabled: true
+      logsStore:
+        enabled: true
+
+    bifrost:
+      appDir: /app/data
+      logStyle: json
+      # Everything the config store holds — including provider keys added
+      # through the UI — is encrypted with this. Never rotate it: a changed key
+      # makes stored secrets unreadable, kopiur restores included.
+      #
+      # Both settings are needed. encryptionKeySecret injects the env var, but
+      # despite what the chart's values.yaml claims, templates/_helpers.tpl
+      # writes config.json's encryption_key only from bifrost.encryptionKey —
+      # so the env.* reference has to be spelled out here too. It names an env
+      # var rather than carrying a value, so nothing secret lands in the
+      # ConfigMap the chart renders this into.
+      encryptionKey: env.BIFROST_ENCRYPTION_KEY
+      encryptionKeySecret:
+        name: bifrost-secret
+        key: BIFROST_ENCRYPTION_KEY
+      # Bootstraps the first admin account. Resolved from the env var of the
+      # same name, supplied by envFrom below.
+      setupToken: env.BIFROST_SETUP_TOKEN
+      authConfig:
+        # This is the only gate on the dashboard and /api/*. The HTTPRoute
+        # carries no OIDC SecurityPolicy, and any pod can reach
+        # bifrost.ai.svc:8080 directly regardless, so LAN and in-cluster
+        # callers face this and nothing else. Do not disable.
+        isEnabled: true
+        existingSecret: bifrost-secret
+        usernameKey: BIFROST_ADMIN_USERNAME
+        passwordKey: BIFROST_ADMIN_PASSWORD
+      client:
+        # Same reasoning: the only gate on /v1/*, which without this serves
+        # inference to anything that can open a socket. Chart default, kept
+        # explicit so a values cleanup can't drop it as redundant.
+        enforceAuthOnInference: true
+        allowedOrigins:
+          - "https://bifrost.${SECRET_DOMAIN}"
+
+      # Deliberately NOT setting sourceOfTruth. Its default ("split") lets
+      # file-declared and UI-created config coexist. Setting it to
+      # "config.json" prunes database-only rows for every section present in
+      # this file — which would delete each provider added through the UI on
+      # the next restart.
+      providers:
+        # The llmkube services, as custom OpenAI-compatible providers. External
+        # providers are added through the UI so their keys stay out of git —
+        # note the chart renders this whole block into a ConfigMap, not a
+        # Secret, so a real credential would have to arrive as env.* plus
+        # bifrost.providerSecrets.
+        #
+        # The served model name is llama.cpp's --alias, so a client-facing
+        # model string is the provider name plus that alias, e.g.
+        # "qwen/Qwen/Qwen3.8-27B" or "qwen-embedding/Qwen/Qwen3-Embedding-0.6B".
+        qwen:
+          custom_provider_config:
+            base_provider_type: openai
+            # llama.cpp runs without --api-key, so send no Authorization
+            # header. The chart's schema still requires keys[] (minItems 1),
+            # hence the valueless placeholder below.
+            is_key_less: true
+          network_config:
+            base_url: http://qwen3-8-27b-mtp.ai.svc.cluster.local:8080
+            # Required. Defaults to false, which blocks every RFC1918
+            # destination — i.e. every in-cluster Service.
+            allow_private_network: true
+          keys:
+            - name: local
+              weight: 1
+        qwen-embedding:
+          custom_provider_config:
+            base_provider_type: openai
+            is_key_less: true
+          network_config:
+            base_url: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080
+            allow_private_network: true
+          keys:
+            - name: local
+              weight: 1
+        # Best-effort: llama.cpp exposes rerank at /v1/rerank, which is not an
+        # OpenAI request type, so this may only ever show up in the model list.
+        # Drop it if it doesn't resolve.
+        qwen-reranker:
+          custom_provider_config:
+            base_provider_type: openai
+            is_key_less: true
+          network_config:
+            base_url: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080
+            allow_private_network: true
+          keys:
+            - name: local
+              weight: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        # Helm deep-merges maps, so the chart's default limits.cpu (2000m)
+        # survives unless explicitly nulled. Nothing else in this cluster
+        # throttles on CPU.
+        cpu: null
+        memory: 1Gi
+    extraEnv:
+      # Without a soft limit the Go runtime grows past the container limit and
+      # is OOM-killed rather than collecting. Keep just under limits.memory.
+      GOMEMLIMIT: 900MiB
+    envFrom:
+      # Supplies BIFROST_SETUP_TOKEN for the env.* reference above. The admin
+      # credentials and encryption key reach the pod through the explicit
+      # secretKeyRefs the chart renders from the values above.
+      - secretRef:
+          name: bifrost-secret

--- a/kubernetes/apps/ai/bifrost/app/httproute.yaml
+++ b/kubernetes/apps/ai/bifrost/app/httproute.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bifrost
+spec:
+  hostnames:
+    - "bifrost.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  # One unmatched rule: the dashboard, /api/* (admin), /v1/* and the SDK-compat
+  # prefixes all share port 8080, and bifrost authenticates each of them itself
+  # (see helmrelease.yaml). No SecurityPolicy targets this route — an OIDC
+  # forward-auth here would 302 API clients into a login redirect, and splitting
+  # the hostname to avoid that would only protect the LAN path while every pod
+  # still reaches the Service directly. Revisit once L7 CiliumNetworkPolicy is
+  # available, and note the inversion when doing so: unlike the *arr apps,
+  # /api/* here is the admin surface, not the machine one.
+  rules:
+    - backendRefs:
+        - name: bifrost
+          port: 8080

--- a/kubernetes/apps/ai/bifrost/app/kustomization.yaml
+++ b/kubernetes/apps/ai/bifrost/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/ai/bifrost/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/bifrost/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bifrost
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.1.36
+  url: oci://ghcr.io/maximhq/helm-charts/bifrost

--- a/kubernetes/apps/ai/bifrost/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/bifrost/app/secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: bifrost-secret
+type: Opaque
+stringData:
+    BIFROST_ENCRYPTION_KEY: ENC[AES256_GCM,data:kCUKIjEux4JcQ4Cv46XLUGJyItEx7X7hTct9VHP0OSG6giwfJwfI3TuRB+zKw78IHVVzqecv8NC7zqxi1GG8qw==,iv:GbzGw6s7AteQZRmT0ZQ2eC03mCRedjtbkNjgNFlE7yA=,tag:Od/cUq4EfJYurBOmDHzRcg==,type:str]
+    BIFROST_SETUP_TOKEN: ENC[AES256_GCM,data:72q2MtxQWVMIxmNVKrXDThgzFb3pdHGO87qoqvsipYuC27mSYMmSCj+GFSE+yxmvjGNHE+CIhp7SU+YkRkK4OA==,iv:lClgH4j8hH6KqwyGr+YrMmCk7OHMIJdGbPTCDMQiK44=,tag:omaOUaXvxtXedYieDjzCMg==,type:str]
+    BIFROST_ADMIN_USERNAME: ENC[AES256_GCM,data:WXDS/6A=,iv:CXBxTQ6PutXEbYjN3p4+/fFffBhJYnEqPNNHmAFpd5E=,tag:QD7kydjgPbFQ0dJup52ZWg==,type:str]
+    BIFROST_ADMIN_PASSWORD: ENC[AES256_GCM,data:zBLkDbWNE4uw1xJGWZn78tHJvsSNFPMQNHF97Guz0c/GcKyIQFEdezKPI1/LRZtIXUNf2Gpr7LI8Lp0U/x1g/g==,iv:199YmMa7bVwANxIYOp+GJp22yNknnqcFre15d9WPaLE=,tag:TRqsWNwmtLEMH4aXJkiK1Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqNXRxa2RQSVd5Szc0SE9U
+            a0xmUnY0ZTJ1eFFGVkJVOTQrb3RTeFB6RXhZCjZvV2VNOUwxUHcxTlo5SVJLS0Nu
+            Nml5TFl4bU5MVktSanJNa1Fyb2RjRHMKLS0tIHVlcUxmNVlZT2dWcnJsV01Bc0Jw
+            eXYyQlhZNnVwMHFiNzJ6OWhPMDJVS1kKoGmAogSFTRm2i4iYJKhVeLmF5baP0neL
+            BdxuwDv90jPMY3JnHjVfz1Bzar/9TJ57Xcc+s7cj7i65+Im8lY9eeQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pw3ushyk74yquev7sc7wu0sw6sfku0nfswpqua8ljm0e8vmpxsjslmgv75
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-22T02:06:37Z"
+    mac: ENC[AES256_GCM,data:Pn52KruMjJsRmCGuTbAFNfnBDAbIRubaPdxv0htvqdVtSrAsV0gXyeUe1HolfQfc0y/mnGWw4kIZ3mtqB5CDJc/tOgxvdt8bcqMzcbsiF0ablkVd+RNq7zwhJ6HkEtKLTzFBRBLwmaaV3qOeN2aeFG5L0v1OflmEUkKYFYq2/+4=,iv:IXdSr7wpg+1Ow1r/PpwWrpl72/YYxv0xY7bgWoEGCsg=,tag:im2kANW04SbaQkDq0E6ZFQ==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.3

--- a/kubernetes/apps/ai/bifrost/ks.yaml
+++ b/kubernetes/apps/ai/bifrost/ks.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bifrost
+spec:
+  dependsOn:
+    - name: kopiur-repository
+      namespace: kopiur-system
+  components:
+    - ../../../../components/kopiur
+  interval: 1h
+  path: ./kubernetes/apps/ai/bifrost/app
+  postBuild:
+    substitute:
+      APP: *app
+      KOPIUR_CAPACITY: 10Gi
+      KOPIUR_UID: "1000"
+      KOPIUR_GID: "1000"
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../components/sops
 resources:
   - ./namespace.yaml
+  - ./bifrost/ks.yaml
   # - ./llama-cpp/ks.yaml
   - ./litellm/ks.yaml
   - ./llmkube/ks.yaml


### PR DESCRIPTION
Deploys [bifrost](https://github.com/maximhq/bifrost) — an OpenAI-compatible LLM
gateway — to the `ai` namespace for evaluation **alongside** LiteLLM, not as a
replacement. Nothing under `kubernetes/apps/ai/litellm/` changes, and this can be
removed by dropping one line from `kubernetes/apps/ai/kustomization.yaml`.

## Shape

- **Upstream chart via OCI** — `oci://ghcr.io/maximhq/helm-charts/bifrost:2.1.36`,
  so this fits the repo's `OCIRepository` convention rather than needing a
  `HelmRepository`. Image pinned to `v1.6.11@sha256:ef8e686b…` (the `v2.0.0-prerelease*`
  line is deliberately avoided).
- **SQLite on a kopiur PVC.** Bifrost OSS is single-replica regardless — it does not
  sync config between processes — so Postgres would buy no availability, only a
  coupling to the CNPG cluster whose every WAL is PITR-archived to B2. Request logs
  are the high-volume table and don't belong there. Moving to config-in-Postgres
  later is a values-only change.
- **Local llmkube models declared in git; external providers added through the UI.**
  No provider API keys in the repo — which matters here because the chart renders
  the providers block into a **ConfigMap, not a Secret**.

## Why there is no pocket-id, and no NetworkPolicy

Bifrost serves the dashboard, `/api/*` (admin) and `/v1/*` (inference) on one
listener, port 8080. That single port drives everything below.

The first draft of this split the hostname into two HTTPRoutes — a gated catch-all
carrying `components/oidc/envoy`, and an exempt route on `/v1` plus the SDK-compat
prefixes — because Envoy's SecurityPolicy attaches per-HTTPRoute with no path
granularity, so one gated route would 302 API clients into a login redirect.

That split isn't worth its cost while the cluster has no L7 network policy. Envoy
sits on the LAN path only; any pod already reaches `bifrost.ai.svc:8080/api/*`
directly, bypassing it. So the split bought path separation for one of two ingress
paths while carrying a real footgun: `/api` is **inverted** relative to the
sonarr-style precedent it copied. For sonarr, `/api` is the machine surface and is
deliberately exempt; for bifrost, `/api/*` is the admin API and must stay gated.
Getting that backwards publishes the admin API.

Network policy can't close the in-cluster path either — an L4 policy can only allow
or deny port 8080 wholesale, and L7 path filtering needs `envoy.enabled: true` in
Cilium (currently false, with `hubble` also off, so drops would be unobservable).

**So bifrost's own auth is the only control, and it is the same control on both
paths**: admin password for the dashboard and `/api/*`, `enforceAuthOnInference` +
a virtual key for `/v1/*`. Nothing is protected by where the caller happens to sit
— which is precisely the assumption that left the \*arr apps reachable
unauthenticated from inside the cluster (#1476).

This costs the convention that everything on `envoy-internal` sits behind pocket-id.
Accepted knowingly: pocket-id in front of an app that already has a login means two
logins, and here it would have gated only the half of the traffic that was never the
exposure. Re-adding it is a `components/oidc/envoy` line plus a `usergroup.yaml`, and
becomes worth doing once L7 policy exists — tracked as the last item of #1475, with
the inversion warning attached.

## Verification

`just test` → 176 passed. Beyond that, the chart was rendered with these exact values
and the output read, which caught two things:

- **`encryption_key` was missing from config.json.** The chart's values.yaml claims
  `encryptionKeySecret` writes `encryption_key: "env.BIFROST_ENCRYPTION_KEY"`, but
  `_helpers.tpl:208` only writes it from `bifrost.encryptionKey` — it injected the env
  var and nothing else. Both are now set; the file explains why.
- **`limits.cpu: 2000m` survived.** Helm deep-merges maps, so specifying only
  `limits.memory` kept the chart's CPU limit. Explicitly nulled, per the repo's
  no-CPU-limit convention.

Confirmed in the render: Deployment (not StatefulSet, because `existingClaim` is set),
kopiur PVC mounted, `auth_config.is_enabled: true`, `enforce_auth_on_inference: true`,
and all three providers carrying `allow_private_network: true` — required, since it
defaults to false and blocks every RFC1918 destination, i.e. every in-cluster Service.

## Still to do on a live cluster

`just flux-branch`, then **before logging in**:

```
curl -so /dev/null -w '%{http_code}\n' https://bifrost.${SECRET_DOMAIN}/api/providers
```

must return 401/403, **not** 200 — with no SSO in front, `authConfig` is the whole
gate. Repeat from inside the cluster against `bifrost.ai.svc.cluster.local:8080`;
both paths returning the same thing is the design. Then mint a virtual key and check
`/v1/chat/completions` works with `x-bf-vk` and is rejected without it.

## Notes

- `BIFROST_ENCRYPTION_KEY` must **never** be rotated — everything the config store
  holds is encrypted with it, so a change makes stored provider keys unreadable,
  kopiur restores included.
- `sourceOfTruth` is deliberately unset. Its default (`split`) lets file-declared and
  UI-created config coexist; `config.json` would prune database-only rows and delete
  every provider added through the UI on the next restart.
- The `qwen-reranker` provider is best-effort — llama.cpp exposes rerank at
  `/v1/rerank`, which is not an OpenAI request type, so it may only ever appear in the
  model list. Flagged in a comment; easy to drop.

Follow-ups: #1475, #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
