### PR TITLE
refactor(ai): one llmkube provider for bifrost, not one per model

### DIFF
--- a/kubernetes/apps/ai/bifrost/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/bifrost/app/helmrelease.yaml
@@ -91,53 +91,64 @@ spec:
       # this file — which would delete each provider added through the UI on
       # the next restart.
       providers:
-        # The llmkube services, as custom OpenAI-compatible providers. External
-        # providers are added through the UI so their keys stay out of git —
+        # One provider for llmkube — it is the vendor, the Qwen models are its
+        # catalog — rather than one provider per InferenceService. External
+        # providers are added through the UI so their keys stay out of git;
         # note the chart renders this whole block into a ConfigMap, not a
         # Secret, so a real credential would have to arrive as env.* plus
         # bifrost.providerSecrets.
         #
-        # The served model name is llama.cpp's --alias, so a client-facing
-        # model string is the provider name plus that alias, e.g.
-        # "qwen/Qwen/Qwen3.8-27B" or "qwen-embedding/Qwen/Qwen3-Embedding-0.6B".
-        qwen:
+        # Client-facing model strings are the provider name plus llama.cpp's
+        # --alias, so: llmkube/Qwen/Qwen3.8-27B,
+        # llmkube/Qwen/Qwen3-Embedding-0.6B, llmkube/Qwen/Qwen3-Reranker-0.6B.
+        llmkube:
           custom_provider_config:
             base_provider_type: openai
             # llama.cpp runs without --api-key, so send no Authorization
             # header. The chart's schema still requires keys[] (minItems 1),
-            # hence the valueless placeholder below.
+            # hence the valueless entry below.
             is_key_less: true
+            # Each model is its own Service, but network_config carries exactly
+            # one base_url. These overrides are how the other two are reached:
+            # bifrost treats an override with scheme+host as a full URL and
+            # skips base_url entirely (core/providers/utils/utils.go).
+            #
+            # The catch: overrides key on REQUEST TYPE, not on model. That works
+            # here only because each Service happens to serve a different one —
+            # chat, embeddings, rerank. A second chat model on its own Service
+            # could not join this provider, since chat_completion is already
+            # bound to base_url; it would need its own provider entry.
+            #
+            # Consequence to know about: a request naming the chat model but
+            # sent to /v1/embeddings still lands on the embedding Service, and
+            # llama.cpp ignores the model field, so it embeds rather than
+            # erroring. Route by endpoint, not by trusting the model name.
+            request_path_overrides:
+              embedding: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1/embeddings
+              rerank: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080/v1/rerank
           network_config:
             base_url: http://qwen3-8-27b-mtp.ai.svc.cluster.local:8080
             # Required. Defaults to false, which blocks every RFC1918
-            # destination — i.e. every in-cluster Service.
+            # destination — i.e. every in-cluster Service. Enforced at dial
+            # time on this provider's client, so it covers the overridden hosts
+            # above too, not just base_url.
             allow_private_network: true
           keys:
-            - name: local
+            - name: llmkube
               weight: 1
-        qwen-embedding:
-          custom_provider_config:
-            base_provider_type: openai
-            is_key_less: true
-          network_config:
-            base_url: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080
-            allow_private_network: true
-          keys:
-            - name: local
-              weight: 1
-        # Best-effort: llama.cpp exposes rerank at /v1/rerank, which is not an
-        # OpenAI request type, so this may only ever show up in the model list.
-        # Drop it if it doesn't resolve.
-        qwen-reranker:
-          custom_provider_config:
-            base_provider_type: openai
-            is_key_less: true
-          network_config:
-            base_url: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080
-            allow_private_network: true
-          keys:
-            - name: local
-              weight: 1
+              # An explicit allowlist, and load-bearing for discovery: only the
+              # chat Service answers /v1/models, so the other two would be
+              # invisible without this. Bifrost backfills every allowlist entry
+              # the upstream did not return into its ListModels response
+              # (core/providers/utils/models.go, BackfillModels case A).
+              #
+              # It also restricts: a model not listed here is rejected. Keep in
+              # sync with the --alias values in
+              # kubernetes/apps/ai/llmkube/models/.
+              models:
+                - Qwen/Qwen3.8-27B
+                - Qwen/Qwen3-Embedding-0.6B
+                - Qwen/Qwen3-Reranker-0.6B
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
A bifrost provider is a *vendor* — anthropic, openrouter, openai — not a model
endpoint. #1477 shipped three providers (`qwen`, `qwen-embedding`,
`qwen-reranker`) because each llmkube `InferenceService` is a separate Service
with its own URL, but that puts three vendors in the dashboard where there is
really one. This collapses them into a single `llmkube` provider serving three
models.

```
before                          after
  qwen/Qwen/Qwen3.8-27B           llmkube/Qwen/Qwen3.8-27B
  qwen-embedding/Qwen/Qwen3-…     llmkube/Qwen/Qwen3-Embedding-0.6B
  qwen-reranker/Qwen/Qwen3-…      llmkube/Qwen/Qwen3-Reranker-0.6B
```

## How three Services fit behind one provider

`network_config` carries exactly one `base_url` — it is the only place in the
whole chart schema that field appears — so the other two are reached with
`request_path_overrides`. Bifrost treats an override with scheme+host as a full
URL and skips `base_url` entirely (`core/providers/utils/utils.go`):

```go
// Treat absolute URLs with scheme+host as full URLs.
if u, err := url.Parse(override); err == nil && u != nil && u.IsAbs() && u.Host != "" {
    return override, true
}
```

`allow_private_network` still covers all three: the RFC1918 guard runs at dial
time on the provider's client (`ConfigureDialer`), not against `base_url`, so the
overridden hosts inherit it.

Model discovery works because the key carries an explicit `models` allowlist.
Only the chat Service answers `/v1/models`, so the embedder and reranker would
otherwise be invisible — but `BackfillModels` (case A,
`core/providers/utils/models.go`) adds every allowlist entry the upstream did not
return into the ListModels response.

## Limits, recorded inline

- **Overrides key on request type, not model.** This works only because each
  Service happens to serve a different one. A second chat model on its own
  Service could not join this provider — `chat_completion` is already bound to
  `base_url` — and would need its own entry.
- **The allowlist restricts as well as declares.** A model not listed is
  rejected, so it has to stay in sync with the `--alias` values in
  `kubernetes/apps/ai/llmkube/models/`.
- **Routing follows the endpoint, not the model name.** A request naming the chat
  model but sent to `/v1/embeddings` still lands on the embedding Service, and
  llama.cpp ignores the model field, so it embeds rather than erroring.
- `network_config` (timeouts, retries, keep-alive) is now shared between the 27B
  chat model and the two 0.6B ones.

## Before merging: the old providers will linger

`sourceOfTruth` is deliberately unset, so it defaults to `split` — file-declared
and UI-created config coexist, and **database rows are never pruned**. If bifrost
has already reconciled #1477 and persisted `qwen`, `qwen-embedding` and
`qwen-reranker` to its config store, removing them from `config.json` here will
*not* delete them. Expect all four providers in the dashboard until the three old
ones are deleted by hand (dashboard, or `DELETE /api/providers/<name>`).

That is the same property that protects UI-added providers from being wiped on
restart, so it is working as intended — just worth knowing before wondering why
the old entries are still there.

## Verification

`just test` → 176 passed. Chart rendered with these values; the resulting
`config.json` `providers` block is a single `llmkube` entry with both path
overrides, the three-model allowlist, and `allow_private_network: true`.

Not yet exercised against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
