### PR TITLE
fix(coredns): don't cache cluster.local denials

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -42,10 +42,19 @@ spec:
             parameters: ${SECRET_DOMAIN} 10.0.42.128
           - name: forward
             parameters: . /etc/resolv.conf
+          # `cache` runs before `autopath` in CoreDNS's plugin chain, so a
+          # transient autopath fallthrough gets its NXDOMAIN pinned in the
+          # denial cache (and kept alive by serve_stale) and served to every
+          # pod in the namespace. When that happens to only one of A/AAAA,
+          # Go resolvers stop at the first search suffix and return a
+          # single-family answer — fatal on this IPv4-only pod network.
+          # Not caching cluster.local denials costs nothing: they're answered
+          # from the kubernetes plugin's in-memory store, no upstream traffic.
           - name: cache
             configBlock: |-
               prefetch 20
               serve_stale
+              disable denial cluster.local
           - name: loop
           - name: reload
           - name: loadbalance


### PR DESCRIPTION
## Problem

konflate's renders of `network/towonel-agent` fail intermittently with:

```
OCIRepository network/towonel-agent resolve 1.5.3:
Head "https://codeberg.org/v2/towonel/charts/towonel-agent/manifests/1.5.3":
dial tcp [2a0a:4580:103f:c0de::1]:443: connect: network is unreachable
```

This is **not** a konflate bug and not a chart bug — it's cluster DNS.

## Root cause

`cache` runs before `autopath` in CoreDNS's fixed plugin chain (`plugin.cfg` order, not Corefile order). When autopath transiently falls through, the kubernetes plugin returns NXDOMAIN for the search-suffixed name, that NXDOMAIN lands in the **denial cache**, and every later query is answered from cache without autopath ever running again. `serve_stale` keeps it alive for up to an hour.

When the pinning hits only one of A/AAAA, a Go resolver stops at the first search suffix that yields *any* address and returns a single-family answer. Measured at the time of the failure, on `codeberg.org.flux-system.svc.cluster.local`:

| query | missing A | missing AAAA |
|---|---|---|
| search-suffixed | 35/60 | 23/60 |
| absolute (`codeberg.org.`) | 0/60 | 0/60 |

Pods have only `fe80::/64` on eth0 with no IPv6 default route, so an AAAA-only answer has nothing to fall back to and the dial fails instantly. Reproduced end-to-end with a 10-line Go program in `flux-system`: 16 of 30 `LookupIPAddr` calls returned v6-only, and the dial failed with the identical error string.

codeberg.org is the only dual-stack chart source in the repo (ghcr.io has no AAAA), which is why konflate is the only visible victim — but the bug is cluster-wide and affects any Go workload resolving a dual-stack external host.

For reference, the upstream chart author runs a functionally identical CoreDNS config, but on a dual-stack cluster (`podSubnets: [10.42.0.0/16, fd42::/56]`), where the same bug produces a v6-only answer that still dials fine and is therefore invisible.

## Fix

Add `disable denial cluster.local` to the `cache` block. A transient autopath miss now lasts exactly one query instead of up to an hour. `serve_stale` can stay — with no cluster.local denial entries to serve, it's no longer part of this failure mode.

Losing negative caching for `cluster.local` costs nothing measurable: those NXDOMAINs are answered from the kubernetes plugin's in-memory store with no upstream traffic, and autopath already suppresses most of the search-path walk that negative caching would otherwise absorb.

## Verification

- `just test` → 176 passed
- CoreDNS 1.14.6 has no `-validate` flag, so a real instance was started on port 1053 with the rendered Corefile — clean startup, `disable denial cluster.local` parses
- A/B against the live replicas while they were still serving a pinned entry for `github.com.flux-system.svc.cluster.local`, same query, same moment:

```
new  (disable denial) : NOERROR=15  NXDOMAIN=0
prod 10.244.1.104     : NOERROR=0   NXDOMAIN=15
prod 10.244.0.128     : NOERROR=0   NXDOMAIN=15

github.com.flux-system.svc.cluster.local. 5 IN CNAME github.com.
github.com.                               5 IN A     140.82.114.4
```

## Post-merge check

The two live replicas are still serving pinned entries until this reconciles. After it lands:

```
dig @<coredns-pod-ip> github.com.flux-system.svc.cluster.local A
```

should return NOERROR on both replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)