### PR TITLE
feat(external-secrets): add migration foundation

### DIFF
--- a/kubernetes/apps/ai/bifrost/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/bifrost/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: bifrost-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     BIFROST_ENCRYPTION_KEY: ENC[AES256_GCM,data:kCUKIjEux4JcQ4Cv46XLUGJyItEx7X7hTct9VHP0OSG6giwfJwfI3TuRB+zKw78IHVVzqecv8NC7zqxi1GG8qw==,iv:GbzGw6s7AteQZRmT0ZQ2eC03mCRedjtbkNjgNFlE7yA=,tag:Od/cUq4EfJYurBOmDHzRcg==,type:str]

--- a/kubernetes/apps/ai/litellm/proxy/keys-secret.sops.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/keys-secret.sops.yaml
@@ -3,6 +3,8 @@ kind: Secret
 type: Opaque
 metadata:
     name: litellm-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     LITELLM_MASTER_KEY: ENC[AES256_GCM,data:nUHKvxUDx9dNe7ooc/6+RvBEr8YeuqBqXV+4r5N/KROZcKyRutuoiBGdNdgKibwDpzcs,iv:Mkp05aKaffnIJtq/LdP6ATEW6XpMjSlOOSrKFJhUs7M=,tag:mkAln5/2/xZVUTmCS13HIA==,type:str]
     LITELLM_SALT_KEY: ENC[AES256_GCM,data:+2LJKryQEddhcI1MGEXigkW6Oq8nUt3PZtCf95zLep/8KMderK6mkUJhl6s7wqGkdtdk,iv:EdJcpus9yszJbypQTS7zlqlBwJDUN5fBCKcqlOtH9gw=,tag:vftok7G/Fn1qRiYVuwmM4A==,type:str]

--- a/kubernetes/apps/ai/litellm/proxy/secret.sops.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
     labels:
         cnpg.io/reload: "true"
     annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/kubernetes/apps/ai/llama-cpp/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/llama-cpp/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: llama-cpp-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     LLAMA_API_KEY: ENC[AES256_GCM,data:gfKFinEvmVaX7mTwunqn/a8+t1bfEttOSFpbC5E04xk8m4WGvqpCUYDH14tJSQqCwU4o3Hxrg28gSzt8xpeYgQ==,iv:1Bxb0UJ/Y94NmP52KpO42Eg+sFIjF+vx/P0sS6d5UUg=,tag:Pz78fEGH2ZGz/sGKHl0wcQ==,type:str]

--- a/kubernetes/apps/ai/memini/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/memini/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: memini-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     MEMINI_API_KEY: ENC[AES256_GCM,data:okB4DtwnYUXCdWfLNanHCjCnAP8M3zKcosS1Vn+bIXyuK09vu+uxVntaLkm/VaTu804uycLdDzkxZuJoeuExwg==,iv:jUtbdx1LK/qDzcGb2aieTAxhDP1wak/nbS6A5+/J1xU=,tag:DXy1WZ9yTScutCIUdL+Pkg==,type:str]

--- a/kubernetes/apps/ai/searxng/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/searxng/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: searxng-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     SEARXNG_SECRET: ENC[AES256_GCM,data:HYT0Np+b52tlmi6lG21N716mvB2qDnFlEDIl4i/LFkhWTWrlMipQYulayCJelBB6u/CJVmuPoy5TJnFJB1pJ8Q==,iv:fjCN2EAAB6vRhj7WQmmOQKBkyD/htqXQF4DBP7sijyQ=,tag:SeoAOFWZyTx6DiDRub5PXQ==,type:str]

--- a/kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: cert-manager-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     api-token: ENC[AES256_GCM,data:VmgB/P7JkEMbsmg31UCgPwRLPQB5drr+X0XoT3FtqkPz0zdQDua2aA==,iv:Mzzax0C9D93+v+zr5ezfwCV42y8WnL8WjBjB61SjN5I=,tag:IqE8WweDG77YJpgassQI6g==,type:str]
 sops:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/secret.sops.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: garage-cnpg
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     ACCESS_KEY_ID: ENC[AES256_GCM,data:++yeMTlQBIkc8IArxBenzhi02rVsFeQun5U=,iv:UFqmFupZB1BFwh4hVTZRdDFIyesoFQA/56PyHg3e3JE=,tag:R23//1skWrDtnbvdQkoFjg==,type:str]
@@ -27,6 +29,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: b2-cnpg
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     ACCESS_KEY_ID: ENC[AES256_GCM,data:kKOjClOgWJ/dUT7JNBgXP7M1s6j4r1C7Nw==,iv:EUnmeEBh0A3tM7LE/TdFh8dFdBxLSrJyKnpePrHCZd4=,tag:3+bk+IvSSdYjo3JEmY3XSw==,type:str]

--- a/kubernetes/apps/documents/paperless/app/secret.sops.yaml
+++ b/kubernetes/apps/documents/paperless/app/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
     labels:
         cnpg.io/reload: "true"
     annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
@@ -33,6 +34,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: paperless-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:C/kFUg5Q4pYpmS/DiKKiM2AxZ9cwpD/e3C400PCbYbOiInEIXgMKZZSw0Hy8OciKxyzwXiRj7oXMDRtN+4TZ9w==,iv:2KIyvCJx2wHoXVl9aq8JJ75bcESSfYp6ftWmtiZ7mTE=,tag:WR2eBqtMwKVRISbmkaPomA==,type:str]
     PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:Mw5BRC0=,iv:lvnL9h/adVrH6kMMEA5CBDiK2mvxo1y3KO7ZHS+cMAQ=,tag:0iFQ9xa7VpBMGftigkOiQw==,type:str]

--- a/kubernetes/apps/external-secrets/external-secrets/config/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/clustersecretstore.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+spec:
+  conditions:
+    - namespaceSelector:
+        matchLabels:
+          external-secrets.io/managed: "true"
+  provider:
+    onepasswordSDK:
+      vault: homelab
+      auth:
+        serviceAccountSecretRef:
+          name: onepassword-service-account-token
+          namespace: external-secrets
+          key: token

--- a/kubernetes/apps/external-secrets/external-secrets/config/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clustersecretstore.yaml

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: external-secrets
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/external-secrets/external-secrets/operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: external-secrets
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets-config
+spec:
+  dependsOn:
+    - name: external-secrets
+  healthChecks:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterSecretStore
+      name: onepassword
+  healthCheckExprs:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterSecretStore
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  interval: 1h
+  path: ./kubernetes/apps/external-secrets/external-secrets/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: external-secrets
+  timeout: 5m

--- a/kubernetes/apps/external-secrets/external-secrets/operator/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/operator/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app external-secrets
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    fullnameOverride: external-secrets
+    installCRDs: true
+    crds:
+      createClusterExternalSecret: true
+      createClusterGenerator: false
+      createClusterPushSecret: false
+      createClusterSecretStore: true
+      createPushSecret: false
+      createSecretStore: false
+    processClusterExternalSecret: true
+    processClusterGenerator: false
+    processClusterPushSecret: false
+    processClusterStore: true
+    processPushSecret: false
+    processSecretStore: false
+    genericTargets:
+      enabled: false
+    rbac:
+      serviceAccountTokenCreate: false
+      servicebindings:
+        create: false
+    serviceMonitor:
+      enabled: true
+      renderMode: skipIfMissing

--- a/kubernetes/apps/external-secrets/external-secrets/operator/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/external-secrets/external-secrets/operator/ocirepository.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/operator/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: external-secrets
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.8.0
+  url: oci://ghcr.io/external-secrets/charts/external-secrets

--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets
+resources:
+  - ./namespace.yaml
+  - ./external-secrets/ks.yaml

--- a/kubernetes/apps/external-secrets/namespace.yaml
+++ b/kubernetes/apps/external-secrets/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    external-secrets.io/managed: "true"

--- a/kubernetes/apps/flux-system/flux-instance/app/secret.sops.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: github-webhook-token-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     token: ENC[AES256_GCM,data:q6T5CarZ30eyyOuK4fjQrKl+lt5SwAofA0d6WOYiCC8=,iv:1Y6WNBpfQJwy3230SOcdZNLIPB5kF7VNsptv59/0gOo=,tag:+kXcXOEyR7iLLxs1TT6QkA==,type:str]
 sops:

--- a/kubernetes/apps/flux-system/konflate/app/secret.sops.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: konflate-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     KONFLATE_WEBHOOK_SECRET: ENC[AES256_GCM,data:yZGFkI2jby+OawXgWdlenRDaaOcWKpMUC4RlRg3ATWOdJS0yiV2s8BrWF9PnhpHk+s8+Yveglr+ZUN35FsVFsQ==,iv:c11OxrX+sZB+249WXkY5lS3l4Z3jPQFVlSKgN8mqfZs=,tag:V3uU6sE2IH+D93sE6oDI8w==,type:str]
     KONFLATE_APP_CLIENT_ID: ENC[AES256_GCM,data:d4JWm/73sjiz8ZnRod5+VKdIvBY=,iv:J94hrHCDFonBE38ggoxq59sHIBUkI2lGAm6xOZUoHF4=,tag:vhWRA95lqi3Ozo71zJqT2Q==,type:str]

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kopiur-repository-secret
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
   #ENC[AES256_GCM,data:mNhie4tRMgz+vrG4FvdV9lSo9kn6E9SAvo79RScAiK+HAblUITGjPqogQqDChwP9NWEuzUrU+hGH8QH0zLbD,iv:KWHkVa5xPVs2Slh0gR2sC1At2rPZfR3+4L6BbqJryPE=,tag:Y/pp8f1NDqXCK+G4RzP1qA==,type:comment]
   #ENC[AES256_GCM,data:wFMfNv2jjpCBaBK/zjcgfP1saPOMHj6Uf776Wy/CJeXdUWjTv7dW9uszbhopONwdzRsMUZoELTUqicIWKKe2VV9cDQ==,iv:d8PUkgPstLqKt7dJYH+1cFm5QW3flqnt0LWqcPV6pzI=,tag:yd2Xh0C8W+pR/Wb1W3fYgQ==,type:comment]

--- a/kubernetes/apps/media/bazarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/bazarr/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: bazarr-secret
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
   password: ENC[AES256_GCM,data:K4mIyOlgPcVZUw==,iv:zvDFocfxr0XoIOeyOPJbh4kfcVRUA/67Apgq5lth6Is=,tag:ke1fyqkBjXCJVAUGsashbA==,type:str]

--- a/kubernetes/apps/media/prowlarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/prowlarr/app/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
     labels:
         cnpg.io/reload: "true"
     annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
@@ -33,6 +34,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: prowlarr-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     api_key: ENC[AES256_GCM,data:nz9HXOK8IVHWoXsw0WQI0UZtCH223T1d7FbKmo0iu3PBOqHo5Ti5TQKj9xJNQj04eElTIxLrb828MUBCjLeRqg==,iv:fD2lc4Lt5IYsYb78Hyhwx9dkSXBfZvjldzuJAT0uSl0=,tag:6YE8jojGdR/DnkgD+7cD4Q==,type:str]

--- a/kubernetes/apps/media/qbittorrent/app/secret.sops.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: qbittorrent-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     VPN_SERVICE_PROVIDER: ENC[AES256_GCM,data:gQiBT/C2syVa,iv:sUzN7vUDT3nTRK+P71wC+uw7Il6xqI+QWN7h52UW8vU=,tag:oQLlo4aRZHYrd10R0ezyWA==,type:str]

--- a/kubernetes/apps/media/radarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/radarr/app/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
     labels:
         cnpg.io/reload: "true"
     annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
@@ -33,6 +34,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: radarr-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     api_key: ENC[AES256_GCM,data:7Tq0tz/NVIeOFwZyxBP21soBEQSsMGrzD1opZ79C7MDNz48mlcmks7sNy5ZnVQ6q8BnI9wO1OHdIoO8EVvwZ,iv:+lnvzqT3MxmL9zikMSloDZ+I4WQzZmbIsRgXAg6DZPc=,tag:yUjjO0QQfHISeRcYdi8grw==,type:str]

--- a/kubernetes/apps/media/sabnzbd/app/secret.sops.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: sabnzbd-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     api_key: ENC[AES256_GCM,data:cn4JDeAkbfehz34N1OkBadAKbYgPVcwksHUrb4EoOQNJt+bsfgF+HXdsJEVVcTUcpF0QXhK0aburH9HaZKnOYg==,iv:XFMWq6/Ka2WZKWMiUpI0r+7dAjxxRtDSTrb2EqajohY=,tag:W1uu1QkwPCF8uhesZcCXtw==,type:str]

--- a/kubernetes/apps/media/seerr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/seerr/app/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     cnpg.io/reload: "true"
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/kubernetes/apps/media/sonarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/sonarr/app/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
     labels:
         cnpg.io/reload: "true"
     annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
@@ -33,6 +34,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: sonarr-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     api_key: ENC[AES256_GCM,data:F7pqRGnFe75Ay3wLw0PF2vBOzoV0IFqTrnPjy0V/p+aKVWk/HBaHMaIExofdnlfAVDQ9ovJZ0X3U5coavPJY5g==,iv:iU+BOhkSBuoQH1blSH9Wtp3lX9II/Q/gPWnYbjEEPEs=,tag:PivDkUO402lRAgflIBLsYw==,type:str]

--- a/kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: cloudflare-dns-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     api-token: ENC[AES256_GCM,data:67yBsRO3gxgrtXIwXasyU1z2la5dGFEYGiGXExo6ZI06LDYytQRl2Q==,iv:ZZ4Ncl6BdukaeTwBCB5BOneJw9P2Z1jGLtCteiNzFZU=,tag:ADFipKO0i3RPsi+/I2Skfw==,type:str]
 sops:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/secret.sops.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: cloudflare-tunnel-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     TUNNEL_TOKEN: ENC[AES256_GCM,data:J7XdF6rBAJWbCJf+Sq2WxMUxitKX+/PyKjxLb7CfQoavDQK7+EbNrjaXk0IxcmA1GGFVxc/0kyt248brVoVBr1tsyEPajDakVLhmbIcev1cpzv1tQFUtyejlu+brWuoYAt+wQe8RxF5MIqW4YZcoaNx7oK/eHDqnOK40p45muoFrkGvwpdFd5AcebSdWM5ioh0VWPto8IRNjDxeHZedAbaAp16/pOLxuiDvR+FH8b59HoC/bFkXN1g==,iv:dtyqLlstbfC8ei5EdtgzQgs7p6d4MN01rpgAbXntv24=,tag:mzuJorDVl+zN2++g+v0Kpw==,type:str]
 sops:

--- a/kubernetes/apps/network/towonel-agent/app/secret.sops.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: towonel-agent-secret
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
   TOWONEL_INVITE_TOKEN: ENC[AES256_GCM,data:rm3ZUa/9/5i84y/TkPjvg0zBpZ+oEzo69ht+ZxIG33V79nMUy1uvYvXrvhQu9SFPyYRLxvHz3VByt1hCcuLwFAiehHTh41p+Xao4ReJGdwBwfeVvId68bA1xwbbtDNL8okYXpElaVWIvCUjdc2mZiwVQVYKI8GdXoi+AntSV65ShRSA7ZOMkOG3nYAIC4aNziZmHZvhQqw==,iv:XlzVCLkyT3WN9N8MQW/If/zuLJVdLyjYpqinoJ4iiVY=,tag:m0J5fTIJ6jUMBUDald7vfQ==,type:str]
 sops:

--- a/kubernetes/apps/observability/grafana/instance/secret.sops.yaml
+++ b/kubernetes/apps/observability/grafana/instance/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: grafana-credentials
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     GF_SECURITY_ADMIN_USER: ENC[AES256_GCM,data:q8gBYxI=,iv:heTDelZRmo0FxhQd0w8MX0n8HaWwu1j+9D1GkJMviv0=,tag:KfCIwVHycvLbrNWc869Pxw==,type:str]
     GF_SECURITY_ADMIN_PASSWORD: ENC[AES256_GCM,data:WNFMvR2BMfyZx/sNh+BNJei41tGCc6rL0e4=,iv:prPKx/MrtUYg2Vg2u9kCRZMnncwW5loDbCGZD9U6grA=,tag:Je3cRVuL8K3gGgZnH8cj9g==,type:str]

--- a/kubernetes/apps/observability/victoria/k8s-stack/secret.sops.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: homeassistant-token
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     token: ENC[AES256_GCM,data:k7ezZwhhtsT7jjSbjI7V3nhsdG+qpH+zlap22hgZ5Jd+MKBzd2oqMH43ezQfuDwVicTZFq4y4n0G2VZgL61BtgNAjJHjCcTWDloYcjsw799ZeyES0+M8AhDQ1zo1IicWJUw+5YE0HLXLX9dD9PPFOzT3Pju8Zr+iQztEYgAvJqdDalQmQPxZbJkfEJ3hH4atI8tji3n4mCn5AyPM6xuLGbMgjCzhfyqX3Y9ZbPnk/yYHsb24vwfk,iv:ilXryTyuyKWjJE7T42nRN1nNkWrJwsYnHq95YuLlAo0=,tag:C/uphZ+6Rf/axuAdKjednw==,type:str]
 sops:

--- a/kubernetes/apps/security/pocket-id/instance/secret.sops.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/secret.sops.yaml
@@ -6,6 +6,7 @@ metadata:
     labels:
         cnpg.io/reload: "true"
     annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: database
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
@@ -33,6 +34,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: pocket-id-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     ENCRYPTION_KEY: ENC[AES256_GCM,data:iSi86w+/9aRGG0M0RlZrM/r5NIDLRUWiVFFOdXYvG6UfGjc8mrZnHQzYuRI=,iv:9woDKkQBstSZZR/lfkKoY5VERbRXvtXDW6JdRq8Oa5E=,tag:sM4I6jWuHVODo4xDMRkySQ==,type:str]
     databaseUrl: ENC[AES256_GCM,data:YZOomqtgyVt4g1agclpPo8IdwUpJD+glVtRv3fENE9QyG0YUP8yoEzMtJyPH5jx2ORKa1iU6gaPZbVWDTWe0CHTNJlaKXqD+16jq4+TNlSniB55NRoY7YgdaJSbwajBJ9rIFz36zWEXNDJ5L/TczopVoRMLHg/KdKMVAPSZpju2lWQHQ,iv:RbiL9Ho3j+ARiYY8mAawwtawthrSSxHcA7+JANIPjUY=,tag:TLExzecgRHYQXLbTNLPLxw==,type:str]

--- a/kubernetes/apps/security/pocket-id/instance/user-info-secret.sops.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/user-info-secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: david-user-info
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     username: ENC[AES256_GCM,data:gcVY/MI=,iv:TTCG+sELceuajT6+W1q1iD1D4zNyPvcN/BVXmWA5DS0=,tag:3fYh5axDZsNfCFWpTkO5fA==,type:str]

--- a/kubernetes/apps/social/continuwuity/app/secret.sops.yaml
+++ b/kubernetes/apps/social/continuwuity/app/secret.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: continuwuity-secret
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 type: Opaque
 stringData:
     CONTINUWUITY_REGISTRATION_TOKEN: ENC[AES256_GCM,data:jBIUdDEshiCXhKC846Wcg7LYB7WZaQiw73ceCbjsas2nxPQqeQIsWrhe7zdC4UyH86bVzicUGiVW+1SspI+tVQ==,iv:ZQcLjK2fdRe2EGAGkynpAYEhQ9iazmddnXT+dUBXoQw=,tag:wuy21ER8uq5K+LgrdHD5sQ==,type:str]

--- a/kubernetes/components/sops/cluster-secrets.sops.yaml
+++ b/kubernetes/components/sops/cluster-secrets.sops.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: cluster-secrets
+    annotations:
+        kustomize.toolkit.fluxcd.io/prune: disabled
 stringData:
     SECRET_DOMAIN: ENC[AES256_GCM,data:wCHsWUsWY+P2vhc=,iv:LoC4VlkIHJRVUJLN+jftzaeExjIkyYwBbT4ioMdJ+aU=,tag:xJV0YHqxo+QtejKK/T23mQ==,type:str]
     CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:VSuEJJojtgQKq+33yCeD2puImzKgJY/oejfh9WNDPklAY4S3,iv:fSH+lXkRXDCSOancg4AfQGvKR0IYs/m75gXII1VIcv0=,tag:QmXgzRGNC1d/A0vhUgHwFg==,type:str]

--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -24,7 +24,7 @@ function wait_for_nodes() {
     done
 }
 
-# Namespaces to be applied before the SOPS secrets are installed
+# Namespaces to be applied before the bootstrap secrets are installed
 function apply_namespaces() {
     log debug "Applying namespaces"
 
@@ -138,6 +138,7 @@ function main() {
     # Apply resources and Helm releases
     wait_for_nodes
     apply_namespaces
+    "${ROOT_DIR}/scripts/bootstrap-external-secrets.sh"
     apply_sops_secrets
     apply_crds
     sync_helm_releases

--- a/scripts/bootstrap-external-secrets.sh
+++ b/scripts/bootstrap-external-secrets.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+source "$(dirname "${0}")/lib/common.sh"
+
+export LOG_LEVEL="${LOG_LEVEL:-info}"
+
+readonly NAMESPACE="external-secrets"
+readonly SECRET_NAME="onepassword-service-account-token"
+readonly TOKEN_REFERENCE="op://homelab/Service Account Auth Token - external-secrets/credential"
+
+function main() {
+    check_env KUBECONFIG
+    check_cli kubectl op
+
+    if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+        log error "Namespace must exist before bootstrapping ESO" "namespace=${NAMESPACE}"
+    fi
+
+    local token
+    token="$(op read "${TOKEN_REFERENCE}")"
+    if [[ -z "${token}" ]]; then
+        log error "1Password service-account token is empty" "reference=${TOKEN_REFERENCE}"
+    fi
+
+    if ! printf '%s' "${token}" \
+        | kubectl --namespace "${NAMESPACE}" create secret generic "${SECRET_NAME}" \
+            --from-file=token=/dev/stdin --dry-run=client --output=yaml \
+        | kubectl apply --server-side --filename - &>/dev/null; then
+        unset token
+        log error "Failed to apply the ESO bootstrap Secret" "resource=${SECRET_NAME}"
+    fi
+    unset token
+
+    log info "ESO bootstrap Secret applied" "resource=${SECRET_NAME}"
+}
+
+main "$@"

--- a/scripts/import-sops-to-onepassword.sh
+++ b/scripts/import-sops-to-onepassword.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+source "$(dirname "${0}")/lib/common.sh"
+
+export LOG_LEVEL="${LOG_LEVEL:-info}"
+
+readonly ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly VAULT="homelab"
+readonly EXPECTED_ITEMS=34
+readonly EXPECTED_FIELDS=69
+
+apply=false
+overwrite_conflicts=false
+items="[]"
+processed_items=0
+processed_fields=0
+
+function usage() {
+    printf 'Usage: %s [--apply] [--overwrite-conflicts]\n' "$(basename "$0")"
+}
+
+function sha256() {
+    shasum -a 256 | awk '{print $1}'
+}
+
+function item_title() {
+    local -r file="$1"
+    local -r secret_name="$2"
+    local relative namespace
+
+    relative="${file#${ROOT_DIR}/}"
+    if [[ "${relative}" == "kubernetes/components/sops/cluster-secrets.sops.yaml" ]] \
+        && [[ "${secret_name}" == "cluster-secrets" ]]; then
+        printf 'k8s-cluster-secrets'
+        return
+    fi
+
+    if [[ "${relative}" != kubernetes/apps/* ]]; then
+        log error "Unsupported Kubernetes SOPS Secret location" "file=${relative}"
+    fi
+    namespace="${relative#kubernetes/apps/}"
+    namespace="${namespace%%/*}"
+    printf 'k8s-%s-%s' "${namespace}" "${secret_name}"
+}
+
+function verify_item() {
+    local -r desired="$1"
+    local -r existing="$2"
+    local desired_labels existing_labels key desired_hash existing_hash existing_type
+
+    desired_labels="$(jq --compact-output '.values | keys | sort' <<<"${desired}")"
+    existing_labels="$(jq --compact-output '[
+        .fields[]
+        | select((.purpose // "") == "" and .id != "notesPlain")
+        | .label
+    ] | sort' <<<"${existing}")"
+    [[ "${desired_labels}" == "${existing_labels}" ]] || return 1
+
+    while IFS= read -r key; do
+        existing_type="$(jq --raw-output --arg key "${key}" '
+            [.fields[] | select(.label == $key)][0].type // ""
+        ' <<<"${existing}")"
+        [[ "${existing_type}" == "CONCEALED" ]] || return 1
+
+        desired_hash="$(jq --join-output --arg key "${key}" '.values[$key]' \
+            <<<"${desired}" | sha256)"
+        existing_hash="$(jq --join-output --arg key "${key}" '
+            [.fields[] | select(.label == $key)][0].value
+        ' <<<"${existing}" | sha256)"
+        [[ "${desired_hash}" == "${existing_hash}" ]] || return 1
+    done < <(jq --raw-output '.values | keys[]' <<<"${desired}")
+}
+
+function create_item() {
+    local -r desired="$1"
+
+    printf '%s' "${desired}" | jq '
+        (.values | to_entries) as $entries
+        | {
+            title: .title,
+            category: "SECURE_NOTE",
+            fields: (
+                [{
+                    id: "notesPlain",
+                    type: "STRING",
+                    purpose: "NOTES",
+                    label: "notesPlain",
+                    value: "Managed by scripts/import-sops-to-onepassword.sh"
+                }]
+                + [range(0; $entries | length) as $index | {
+                    id: ("eso-" + ($index | tostring)),
+                    type: "CONCEALED",
+                    label: $entries[$index].key,
+                    value: $entries[$index].value
+                }]
+            )
+        }
+    ' | op item create --vault "${VAULT}" - &>/dev/null
+}
+
+function overwrite_item() {
+    local -r desired="$1"
+    local -r existing="$2"
+    local -r item_id="$(jq --raw-output '.id' <<<"${existing}")"
+
+    printf '%s\n%s\n' "${existing}" "${desired}" | jq --slurp '
+        .[0] as $item
+        | (.[1].values | to_entries) as $entries
+        | $item
+        | .fields = (
+            [.fields[] | select(.purpose != null or .id == "notesPlain")]
+            + [range(0; $entries | length) as $index | {
+                id: ("eso-" + ($index | tostring)),
+                type: "CONCEALED",
+                label: $entries[$index].key,
+                value: $entries[$index].value
+            }]
+        )
+    ' | op item edit "${item_id}" --vault "${VAULT}" &>/dev/null
+}
+
+function preflight_inventory() {
+    local item_count=0
+    local field_count=0
+    local file document_count document_fields
+
+    while IFS= read -r -d '' file; do
+        document_count="$(yq eval-all 'select(.kind == "Secret") | 1' "${file}" \
+            | awk '{total += $1} END {print total + 0}')"
+        document_fields="$(yq eval-all 'select(.kind == "Secret")
+            | ((.data // {}) | length) + ((.stringData // {}) | length)' \
+            "${file}" | awk '{total += $1} END {print total + 0}')"
+        item_count=$((item_count + document_count))
+        field_count=$((field_count + document_fields))
+    done < <(find "${ROOT_DIR}/kubernetes" -type f -name '*.sops.yaml' -print0)
+
+    [[ "${item_count}" -eq "${EXPECTED_ITEMS}" ]] \
+        || log error "Unexpected Secret inventory" "expected=${EXPECTED_ITEMS}" "actual=${item_count}"
+    [[ "${field_count}" -eq "${EXPECTED_FIELDS}" ]] \
+        || log error "Unexpected field inventory" "expected=${EXPECTED_FIELDS}" "actual=${field_count}"
+
+    log info "SOPS inventory validated" "items=${item_count}" "fields=${field_count}"
+}
+
+function process_secret() {
+    local -r file="$1"
+    local -r source_secret="$2"
+    local secret_name title field_count item_matches item_id existing verified desired
+
+    secret_name="$(jq --raw-output '.name' <<<"${source_secret}")"
+    title="$(item_title "${file}" "${secret_name}")"
+    field_count="$(jq '.values | length' <<<"${source_secret}")"
+    desired="$(jq --arg title "${title}" '. + {title: $title}' <<<"${source_secret}")"
+    processed_items=$((processed_items + 1))
+    processed_fields=$((processed_fields + field_count))
+
+    item_matches="$(jq --arg title "${title}" '[.[] | select(.title == $title)] | length' \
+        <<<"${items}")"
+    if [[ "${item_matches}" -gt 1 ]]; then
+        log error "Multiple 1Password items have the required title" "item=${title}"
+    fi
+
+    if [[ "${item_matches}" -eq 0 ]]; then
+        if [[ "${apply}" == false ]]; then
+            log info "Would create 1Password item" "item=${title}" "fields=${field_count}"
+            return
+        fi
+
+        create_item "${desired}"
+        existing="$(op item get "${title}" --vault "${VAULT}" --format json)"
+        if ! verify_item "${desired}" "${existing}"; then
+            log error "Created item failed hash verification" "item=${title}"
+        fi
+        log info "Created and verified 1Password item" "item=${title}" "fields=${field_count}"
+        return
+    fi
+
+    item_id="$(jq --raw-output --arg title "${title}" \
+        '.[] | select(.title == $title) | .id' <<<"${items}")"
+    existing="$(op item get "${item_id}" --vault "${VAULT}" --format json)"
+    if verify_item "${desired}" "${existing}"; then
+        log info "Verified existing 1Password item" "item=${title}" "fields=${field_count}"
+        return
+    fi
+
+    if [[ "${apply}" == false || "${overwrite_conflicts}" == false ]]; then
+        log error "Existing 1Password item conflicts with the SOPS source" \
+            "item=${title}" "hint=use --apply --overwrite-conflicts"
+    fi
+
+    overwrite_item "${desired}" "${existing}"
+    verified="$(op item get "${item_id}" --vault "${VAULT}" --format json)"
+    if ! verify_item "${desired}" "${verified}"; then
+        log error "Overwritten item failed hash verification" "item=${title}"
+    fi
+    log info "Overwrote and verified 1Password item" "item=${title}" "fields=${field_count}"
+}
+
+function main() {
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --apply) apply=true ;;
+            --overwrite-conflicts) overwrite_conflicts=true ;;
+            -h | --help)
+                usage
+                exit 0
+                ;;
+            *)
+                usage >&2
+                log error "Unknown argument" "argument=$1"
+                ;;
+        esac
+        shift
+    done
+
+    if [[ "${overwrite_conflicts}" == true && "${apply}" == false ]]; then
+        log error "--overwrite-conflicts requires --apply"
+    fi
+
+    check_cli jq op shasum sops yq
+    op whoami &>/dev/null || log error "1Password CLI is not signed in"
+    op vault get "${VAULT}" &>/dev/null || log error "1Password vault is unavailable" "vault=${VAULT}"
+
+    preflight_inventory
+
+    # Item listings contain identifiers and titles only, never field values.
+    items="$(op item list --vault "${VAULT}" --format json)"
+
+    local file secret
+    while IFS= read -r -d '' file; do
+        while IFS= read -r secret; do
+            [[ -n "${secret}" ]] || continue
+            process_secret "${file}" "${secret}"
+        done < <(
+            sops decrypt --output-type yaml "${file}" \
+                | yq eval-all --output-format=json --indent=0 '
+                    select(.kind == "Secret")
+                    | {
+                        "name": .metadata.name,
+                        "values": (
+                            ((.data // {}) | with_entries(.value |= @base64d))
+                            * (.stringData // {})
+                        )
+                    }
+                ' -
+        )
+    done < <(find "${ROOT_DIR}/kubernetes" -type f -name '*.sops.yaml' -print0)
+
+    [[ "${processed_items}" -eq "${EXPECTED_ITEMS}" ]] \
+        || log error "Decrypted item count did not match preflight" \
+            "expected=${EXPECTED_ITEMS}" "actual=${processed_items}"
+    [[ "${processed_fields}" -eq "${EXPECTED_FIELDS}" ]] \
+        || log error "Decrypted field count did not match preflight" \
+            "expected=${EXPECTED_FIELDS}" "actual=${processed_fields}"
+
+    if [[ "${apply}" == false ]]; then
+        log info "Dry run complete; no 1Password items were changed"
+    else
+        log info "Import complete" "items=${EXPECTED_ITEMS}" "fields=${EXPECTED_FIELDS}"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- deploy External Secrets Operator 2.8.0 and the read-only 1Password SDK ClusterSecretStore
- add an idempotent bootstrap helper for the ESO service-account token
- add a temporary dry-run-by-default SOPS-to-1Password importer
- protect all 34 existing Kubernetes Secrets from Flux pruning before adoption

## Migration checkpoint

- imported and hash-verified 34 1Password Secure Notes containing 69 fields
- verified a second importer run is idempotent
- applied the ESO bootstrap token twice and verified it matches the 1Password source
- no application Secret consumers are cut over in this PR

## Validation

- `bash -n` on changed scripts
- all encrypted manifests differ only by the prune annotation
- `just test`: 180 resources passed