### PR TITLE
fix(external-secrets): preserve Flux namespace label

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -30,6 +30,18 @@ spec:
           app.kubernetes.io/name: flux
       kustomize:
         patches:
+          - # The Flux Operator owns this namespace and otherwise removes labels
+            # added by the cluster-apps Kustomization.
+            patch: |
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: flux-system
+                labels:
+                  external-secrets.io/managed: "true"
+            target:
+              kind: Namespace
+              name: flux-system
           - # Increase the number of workers
             patch: |
               - op: add


### PR DESCRIPTION
## Summary

- patch the Flux Operator-rendered `flux-system` Namespace with `external-secrets.io/managed: "true"`
- preserve the restricted ClusterSecretStore condition while allowing the Flux webhook and Konflate ExternalSecrets

Flux Operator owns the Namespace and removed the label applied by the separate cluster-apps Namespace manifest. Existing Kubernetes Secrets remained intact while ESO reported the denial.

## Validation

- `git diff --check`
- `mise exec -- just test` (180 passed)

Follow-up to Stage 3C of #764; does not close the issue.