### PR TITLE
feat(external-secrets): fan out cluster secrets

### DIFF
--- a/kubernetes/apps/ai-sandbox/hermes/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/ks.yaml
@@ -19,6 +19,8 @@ spec:
     - ../../../../components/oidc
     - ../../../../components/kopiur
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: pocket-id
       namespace: security
     - name: kopiur-repository

--- a/kubernetes/apps/ai-sandbox/namespace.yaml
+++ b/kubernetes/apps/ai-sandbox/namespace.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     resource.kubernetes.io/admin-access: "true"
     # Isolated home for hermes, which runs untrusted agent code. Kept separate
     # from the shared `ai` namespace to contain blast radius. The hermes pod

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -7,6 +7,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/ai/litellm/operator
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     # Kept after autoRegister was turned off, where it used to be load-bearing
     # (the flag resolves once at operator startup, so racing the llmkube CRDs
     # disabled it for the life of the pod). Now it only orders the backing

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: &app llmkube
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/ai/llmkube/app
   postBuild:
@@ -36,6 +39,8 @@ spec:
       - name: cluster-secrets
         kind: Secret
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: llmkube
   prune: true
   sourceRef:

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -7,4 +7,5 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: &app toolhive-crds
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/ai/toolhive/crds
   postBuild:
@@ -34,6 +37,8 @@ spec:
       - name: cluster-secrets
         kind: Secret
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: toolhive-crds
   prune: true
   sourceRef:
@@ -55,6 +60,8 @@ spec:
       - name: cluster-secrets
         kind: Secret
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: toolhive-crds
   prune: true
   sourceRef:

--- a/kubernetes/apps/cert-manager/namespace.yaml
+++ b/kubernetes/apps/cert-manager/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: cnpg-operator
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: openebs
       namespace: openebs-system
   interval: 1h
@@ -51,6 +53,8 @@ metadata:
   name: plugin-barman-cloud
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: cnpg-operator
   interval: 1h
   path: ./kubernetes/apps/database/cloudnative-pg/plugin-barman-cloud

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/default/echo/ks.yaml
+++ b/kubernetes/apps/default/echo/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: echo
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/default/echo/app
   postBuild:

--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: default
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/documents/namespace.yaml
+++ b/kubernetes/apps/documents/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/external-secrets/external-secrets/config/clusterexternalsecret.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/clusterexternalsecret.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cluster-secrets-source
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cluster-secrets-source
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+  data:
+    - secretKey: SECRET_DOMAIN
+      remoteRef:
+        key: k8s-cluster-secrets/SECRET_DOMAIN
+    - secretKey: CLOUDFLARE_TUNNEL_ID
+      remoteRef:
+        key: k8s-cluster-secrets/CLOUDFLARE_TUNNEL_ID
+    - secretKey: GARAGE_ENDPOINT_URL
+      remoteRef:
+        key: k8s-cluster-secrets/GARAGE_ENDPOINT_URL
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: cluster-secrets
+spec:
+  externalSecretName: cluster-secrets
+  namespaceSelectors:
+    - matchLabels:
+        external-secrets.io/cluster-secrets: "true"
+  refreshTime: 1m
+  externalSecretSpec:
+    refreshInterval: 1h
+    refreshPolicy: Periodic
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: cluster-secrets-fanout
+    target:
+      name: cluster-secrets
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        type: Opaque
+    data:
+      - secretKey: SECRET_DOMAIN
+        remoteRef:
+          key: cluster-secrets-source
+          property: SECRET_DOMAIN
+      - secretKey: CLOUDFLARE_TUNNEL_ID
+        remoteRef:
+          key: cluster-secrets-source
+          property: CLOUDFLARE_TUNNEL_ID
+      - secretKey: GARAGE_ENDPOINT_URL
+        remoteRef:
+          key: cluster-secrets-source
+          property: GARAGE_ENDPOINT_URL

--- a/kubernetes/apps/external-secrets/external-secrets/config/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/clustersecretstore.yaml
@@ -16,3 +16,26 @@ spec:
           name: onepassword-service-account-token
           namespace: external-secrets
           key: token
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: cluster-secrets-fanout
+spec:
+  conditions:
+    - namespaceSelector:
+        matchLabels:
+          external-secrets.io/cluster-secrets: "true"
+  provider:
+    kubernetes:
+      remoteNamespace: external-secrets
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: external-secrets
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: cluster-secrets-reader
+          namespace: external-secrets

--- a/kubernetes/apps/external-secrets/external-secrets/config/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/kustomization.yaml
@@ -2,4 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./clusterexternalsecret.yaml
   - ./clustersecretstore.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/external-secrets/external-secrets/config/rbac.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/rbac.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-secrets-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-secrets-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["cluster-secrets-source"]
+    verbs: ["get"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["selfsubjectrulesreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-secrets-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-secrets-reader
+subjects:
+  - kind: ServiceAccount
+    name: cluster-secrets-reader
+    namespace: external-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-secrets-token-request
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    resourceNames: ["cluster-secrets-reader"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: external-secrets-token-request
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-secrets-token-request
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -30,9 +30,103 @@ spec:
     - apiVersion: external-secrets.io/v1
       kind: ClusterSecretStore
       name: onepassword
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      name: cluster-secrets-source
+      namespace: external-secrets
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterSecretStore
+      name: cluster-secrets-fanout
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterExternalSecret
+      name: cluster-secrets
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: ai
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: ai-sandbox
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: cert-manager
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: database
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: default
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: documents
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: finance
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: flux-system
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: games
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: kopiur-system
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: kube-system
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: maker
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: media
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: network
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: observability
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: openebs-system
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: security
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: social
+    - apiVersion: v1
+      kind: Secret
+      name: cluster-secrets
+      namespace: system-upgrade
   healthCheckExprs:
     - apiVersion: external-secrets.io/v1
       kind: ClusterSecretStore
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterExternalSecret
       failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h

--- a/kubernetes/apps/finance/actual/ks.yaml
+++ b/kubernetes/apps/finance/actual/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app actual
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: kopiur-repository
       namespace: kopiur-system
   components:

--- a/kubernetes/apps/finance/namespace.yaml
+++ b/kubernetes/apps/finance/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: finance
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -39,6 +39,7 @@ spec:
                 name: flux-system
                 labels:
                   external-secrets.io/managed: "true"
+                  external-secrets.io/cluster-secrets: "true"
             target:
               kind: Namespace
               name: flux-system

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: flux-operator
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   components:
     - ../../../../components/oidc
   interval: 1h

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/games/games-on-whales/ks.yaml
+++ b/kubernetes/apps/games/games-on-whales/ks.yaml
@@ -38,6 +38,8 @@ spec:
   wait: false
   targetNamespace: games
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: fenrir-crds
   postBuild:
     substitute:

--- a/kubernetes/apps/games/namespace.yaml
+++ b/kubernetes/apps/games/namespace.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     # Wolf session pods need NET_ADMIN (fake-udev) + run as root, which the
     # cluster-default baseline PSS rejects. Match media/openebs-system.
     pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: cilium
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
   postBuild:

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: coredns
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/coredns/app
   postBuild:

--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: intel-gpu-resource-driver
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/intel-gpu-resource-driver/app
   postBuild:

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: metrics-server
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/metrics-server/app
   postBuild:

--- a/kubernetes/apps/kube-system/namespace.yaml
+++ b/kubernetes/apps/kube-system/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: kube-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/kube-system/reflector/ks.yaml
+++ b/kubernetes/apps/kube-system/reflector/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: reflector
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/reflector/app
   postBuild:

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: reloader
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/reloader/app
   postBuild:

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: snapshot-controller
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kube-system/snapshot-controller/app
   postBuild:

--- a/kubernetes/apps/maker/namespace.yaml
+++ b/kubernetes/apps/maker/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/maker/orcaslicer/ks.yaml
+++ b/kubernetes/apps/maker/orcaslicer/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app orcaslicer
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: kopiur-repository
       namespace: kopiur-system
     - name: intel-gpu-resource-driver

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -29,6 +29,8 @@ spec:
   targetNamespace: media
   wait: false
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: kopiur-repository
       namespace: kopiur-system
     - name: intel-gpu-resource-driver

--- a/kubernetes/apps/media/namespace.yaml
+++ b/kubernetes/apps/media/namespace.yaml
@@ -7,5 +7,6 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     pod-security.kubernetes.io/enforce: privileged
     resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app recyclarr
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: kopiur-repository
       namespace: kopiur-system
   components:

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: envoy-gateway
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
   postBuild:

--- a/kubernetes/apps/network/k8s-gateway/ks.yaml
+++ b/kubernetes/apps/network/k8s-gateway/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: k8s-gateway
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/network/k8s-gateway/app
   postBuild:

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: grafana-operator
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/operator
   postBuild:

--- a/kubernetes/apps/observability/namespace.yaml
+++ b/kubernetes/apps/observability/namespace.yaml
@@ -7,4 +7,5 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/observability/snmp-exporter/ks.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/ks.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 metadata:
   name: snmp-exporter
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/observability/snmp-exporter/app
   postBuild:

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: victoria-metrics-operator
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     # the VM operator watches prometheus-operator CRs (ServiceMonitor,
     # PodMonitor, PrometheusRule, ...) and converts them to VM equivalents
     - name: prometheus-operator-crds
@@ -33,10 +35,10 @@ metadata:
   name: &app vmks
 spec:
   dependsOn:
-    - name: victoria-metrics-operator
-    - name: grafana-instance
     - name: external-secrets-config
       namespace: external-secrets
+    - name: victoria-metrics-operator
+    - name: grafana-instance
     - name: kopiur-repository
       namespace: kopiur-system
   interval: 1h
@@ -69,6 +71,8 @@ metadata:
   name: &app victoria-logs
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: victoria-metrics-operator
     - name: kopiur-repository
       namespace: kopiur-system

--- a/kubernetes/apps/openebs-system/namespace.yaml
+++ b/kubernetes/apps/openebs-system/namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"
     pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: openebs
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: snapshot-controller
       namespace: kube-system
   interval: 1h

--- a/kubernetes/apps/security/namespace.yaml
+++ b/kubernetes/apps/security/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/social/namespace.yaml
+++ b/kubernetes/apps/social/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/social/sable/ks.yaml
+++ b/kubernetes/apps/social/sable/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: &app sable
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   
   interval: 1h
   path: ./kubernetes/apps/social/sable/app

--- a/kubernetes/apps/system-upgrade/namespace.yaml
+++ b/kubernetes/apps/system-upgrade/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: system-upgrade
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    external-secrets.io/managed: "true"
+    external-secrets.io/cluster-secrets: "true"

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: &app tuppr
 spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/app
   postBuild:
@@ -26,6 +29,8 @@ metadata:
   name: &app tuppr-upgrades
 spec:
   dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
     - name: tuppr
   interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/upgrades


### PR DESCRIPTION
## Summary

- fetch `k8s-cluster-secrets` once into `external-secrets/cluster-secrets-source`
- fan out the unchanged three-key `cluster-secrets` Secret to the existing 19 consumer namespaces
- add a namespace-scoped Kubernetes provider store with a dedicated ServiceAccount
- restrict reader RBAC to `get` only `cluster-secrets-source`; retain narrow TokenRequest permission
- health-check the source, both stores, ClusterExternalSecret, and all 19 target Secrets
- gate every shared-secret consumer on `external-secrets-config`
- preserve both ESO labels on the Flux Operator-owned namespace

## Validation

- all 19 namespace selectors and all consumer dependencies statically verified
- both source and fan-out mappings explicitly contain exactly three fields
- reader RBAC statically verified as source-name-restricted
- `git diff --check`
- `mise exec -- just test` (180 passed)
- captured UID/type/metadata/SHA-256 baselines for all 19 live target Secrets

This is Stage 4 of #764; final SOPS cleanup remains.