### PR TITLE
fix(coredns): disable autopath

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -36,25 +36,22 @@ spec:
             configBlock: |-
               pods verified
               fallthrough in-addr.arpa ip6.arpa
-          - name: autopath
-            parameters: "@kubernetes"
+          # Disabled: autopath's answer for the first search suffix is cached
+          # on whichever replica served it, so the two replicas disagree and
+          # Go's parallel A/AAAA queries can land on different ones — yielding
+          # a v6-only address, undialable on this IPv4-only pod network.
+          # todo: re-enable once the cluster is dual-stack — a v6-only answer
+          # dials fine there.
+          # - name: autopath
+          #   parameters: "@kubernetes"
           - name: forward
             parameters: ${SECRET_DOMAIN} 10.0.42.128
           - name: forward
             parameters: . /etc/resolv.conf
-          # `cache` runs before `autopath` in CoreDNS's plugin chain, so a
-          # transient autopath fallthrough gets its NXDOMAIN pinned in the
-          # denial cache (and kept alive by serve_stale) and served to every
-          # pod in the namespace. When that happens to only one of A/AAAA,
-          # Go resolvers stop at the first search suffix and return a
-          # single-family answer — fatal on this IPv4-only pod network.
-          # Not caching cluster.local denials costs nothing: they're answered
-          # from the kubernetes plugin's in-memory store, no upstream traffic.
           - name: cache
             configBlock: |-
               prefetch 20
               serve_stale
-              disable denial cluster.local
           - name: loop
           - name: reload
           - name: loadbalance


### PR DESCRIPTION
## Problem

The fix in #1496 didn't hold. konflate's renders still fail with:

```
OCIRepository network/towonel-agent resolve 1.5.3:
Head "https://codeberg.org/v2/towonel/charts/towonel-agent/manifests/1.5.3":
dial tcp [2a0a:4580:103f:c0de::1]:443: connect: network is unreachable
```

## What #1496 got wrong

It assumed the pinned entry was a **denial** — a stuck NXDOMAIN — and added `disable denial cluster.local`. The pinned entry is a **success**. Live on one replica, 13h after that fix reconciled:

```
pkg-containers.githubusercontent.com.flux-system.svc.cluster.local. 2192 IN CNAME pkg-containers.githubusercontent.com.
pkg-containers.githubusercontent.com. 2192 IN A 185.199.109.154  (+3 more)
```

That is autopath's answer shape, cached as a success, which `disable denial` never touches. `prefetch 20` re-fetches it through the plugin chain before expiry, so it is pinned indefinitely rather than for `serve_stale`'s hour.

## Root cause

autopath answers the first search suffix with a CNAME to the real name plus records. That answer is cached on whichever replica served it, so the two replicas diverge — one serves the records, the other NXDOMAIN. `kube-dns` has `sessionAffinity: None`, and Go sends A and AAAA on two separate UDP sockets to the ClusterIP, so the two families can land on different replicas. One gets an address, the other NXDOMAIN; Go stops the search walk at that suffix and returns a single-family list. A v6-only list has nothing to fall back to on the IPv4-only pod network, so the dial fails instantly.

Measured from a pod in `flux-system`, 150 lookups at 80-way concurrency:

| query | result |
|---|---|
| absolute FQDN | 150/150 dual-stack |
| search-path relative | **71/150 v6-only** |

Querying each suffix directly — only the pod's *own* namespace suffix is affected, which is exactly the one autopath handles:

| suffix | both | v4-only | v6-only | NXDOMAIN both |
|---|---|---|---|---|
| `<ns>.svc.cluster.local` | 14 | 54 | 42 | 40 |
| `svc.cluster.local` | 0 | 0 | 0 | 150 |
| `cluster.local` | 0 | 0 | 0 | 150 |

This needs concurrency *and* diverged replicas to show, which is why sequential `dig` loops look clean.

## Blast radius is wider than towonel-agent

`pkg-containers.githubusercontent.com`, the ghcr blob CDN, is dual-stack too. (`ghcr.io` itself has no AAAA — the redirect target does.) Running `flate test all` inside the cluster failed **42 of 180**: openebs, tuppr, grafana-operator, prometheus-operator-crds, snmp-exporter. towonel-agent is just the one konflate happened to surface.

## Fix

Disable `autopath`. It is a query-reduction optimization; nothing depends on it. Commented out rather than deleted, with a todo to restore it once the cluster is dual-stack — that is why the upstream chart author, running a functionally identical Corefile, never sees this.

`disable denial cluster.local` is reverted along with it. Without autopath every suffix NXDOMAINs consistently on both replicas, and negative caching becomes *more* useful, not less: each external lookup now walks three suffixes.

## Verification

- `just test` → 180 passed
- The rendered Corefile starts cleanly in a real CoreDNS 1.14.6 instance
- A/B against the live replicas, same moment, identical load (150 lookups, 80-way concurrency), a second CoreDNS running this config next to the current one:

| resolver | dual-stack | v6-only |
|---|---|---|
| current kube-dns (autopath on) | 80/150 | **70/150** |
| this config (autopath off) | **150/150** | **0** |

## Post-merge check

The rollout replaces both replicas, which flushes the pinned entry. After it reconciles, from any pod:

```
dig @<coredns-pod-ip> pkg-containers.githubusercontent.com.<ns>.svc.cluster.local A
```

should return NXDOMAIN on **both** replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
