### PR TITLE
feat(litellm): add ChatGPT subscription models behind a device-login gate

### DIFF
--- a/kubernetes/apps/ai/litellm/chatgpt-login/job.yaml
+++ b/kubernetes/apps/ai/litellm/chatgpt-login/job.yaml
@@ -1,0 +1,61 @@
+---
+# The gate. litellm-chatgpt-models dependsOn this Kustomization with wait: true
+# (../ks.yaml), so Flux blocks on this Job completing before any chatgpt/* model
+# is ever registered — which is the whole point: registering one with no
+# auth.json blocks the proxy's startup event for 15 minutes per model until the
+# liveness probe crashloops it, and applyMode: api persists the models in
+# Postgres, so a revert cannot undo it.
+#
+# Idempotent: with a valid auth.json, get_access_token() returns the cached
+# token and this exits immediately. It blocks only when there is no usable
+# token, which is exactly when it should. The verification URL and device code
+# are printed to this pod's logs — that is where you complete the flow.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litellm-chatgpt-login
+spec:
+  # One attempt: a retry would silently start a second 15-minute flow, and
+  # litellm stores a cooldown that rate-limits repeat device-code requests.
+  # So a timed-out login stays Failed, and re-applying an unchanged Job will
+  # not restart it — delete the Job and let Flux recreate it.
+  backoffLimit: 0
+  activeDeadlineSeconds: 960
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        # Matches the proxy's -non_root image and ../ks.yaml's KOPIUR_UID/GID.
+        # _write_auth_file swallows OSError into a log line, so an auth.json
+        # written under any other uid makes token refreshes silently stop
+        # persisting instead of failing loudly.
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: login
+          # Must track ../proxy/proxy.yaml — this runs litellm's own
+          # Authenticator, so it needs the same litellm. Renovate bumps both.
+          image: ghcr.io/berriai/litellm-non_root:v1.98.0@sha256:157aaf0a519713663ec6abefe73fa48bf12f638b0e63fb2b209ba0eae68e6bd7
+          # litellm has no login CLI: the device flow only ever runs as a side
+          # effect of resolving a chatgpt model. Calling the Authenticator
+          # directly is what lets it happen here instead of inside the proxy.
+          command:
+            - python
+            - -c
+            - |
+              from litellm.llms.chatgpt.authenticator import Authenticator
+              Authenticator().get_access_token()
+              print("auth.json is valid", flush=True)
+          env:
+            # Same path as ../proxy/proxy.yaml, on the same PVC.
+            - name: CHATGPT_TOKEN_DIR
+              value: /var/lib/litellm/chatgpt
+          volumeMounts:
+            - name: chatgpt-auth
+              mountPath: /var/lib/litellm/chatgpt
+      volumes:
+        - name: chatgpt-auth
+          persistentVolumeClaim:
+            # Created by the kopiur component on the litellm Kustomization.
+            claimName: litellm

--- a/kubernetes/apps/ai/litellm/chatgpt-login/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/chatgpt-login/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./llmkube.yaml
+  - ./job.yaml

--- a/kubernetes/apps/ai/litellm/chatgpt-models/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/chatgpt-models/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./llmkube.yaml
+  - ./models.yaml

--- a/kubernetes/apps/ai/litellm/chatgpt-models/models.yaml
+++ b/kubernetes/apps/ai/litellm/chatgpt-models/models.yaml
@@ -6,9 +6,10 @@
 #   codex exec -m <model> --skip-git-repo-check "Reply with exactly: OK"
 # info is mandatory — the cost map cannot resolve chatgpt/* names, so litellm
 # errors without it. mode is responses (Responses-native backend).
-# Auth is a device-code login file (CHATGPT_TOKEN_DIR in ../proxy.yaml); do the
-# login before these take traffic, or the first request blocks on the device
-# flow for up to 15 minutes.
+# These live in their own Kustomization only so ../ks.yaml can gate them behind
+# ../chatgpt-login: registering one before the device-code login has written
+# auth.json crashloops the whole proxy, unrecoverably. Read that Job before
+# moving these back in with the llmkube models.
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -62,10 +62,17 @@ spec:
       # interactive device-code login, so a lost volume otherwise costs a
       # 15-minute blocked request and a trip to auth.openai.com.
       KOPIUR_CAPACITY: 1Gi
-      # The berriai/litellm image runs the proxy as root; the movers have to
-      # write the restored auth.json as the uid that will refresh it in place.
-      KOPIUR_UID: "0"
-      KOPIUR_GID: "0"
+      # Match the -non_root image's runtime identity (../proxy/proxy.yaml), so
+      # the movers write the restored auth.json as the uid that refreshes it in
+      # place. These also carry the volume's permissions on their own: the proxy
+      # pod gets no fsGroup, because the CRD has no securityContext to put one
+      # in, so the mover's fsGroup is the only thing that makes a fresh volume
+      # writable — it leaves the root group-owned by KOPIUR_GID at 0775, and a
+      # bare zfspv volume is otherwise root:root 0755. Verified on the
+      # deploy-or-restore path too: the populator applies the fsGroup even when
+      # no snapshot exists yet.
+      KOPIUR_UID: "65534"
+      KOPIUR_GID: "65534"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -75,3 +75,63 @@ spec:
     namespace: flux-system
   targetNamespace: ai
   wait: false
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm-chatgpt-login
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/litellm/chatgpt-login
+  dependsOn:
+    # For the PVC the Job mounts, which the kopiur component above creates.
+    - name: litellm
+  # A Job's pod template is immutable, so without force a Renovate image bump
+  # would fail to apply forever. Recreating is safe: the Job is a no-op once
+  # auth.json is valid.
+  force: true
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  # Longer than the Job's own 15-minute device-code timeout, so Flux does not
+  # give up on a login someone is actively completing.
+  timeout: 20m
+  # The gate: litellm-chatgpt-models below blocks until this Job completes.
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm-chatgpt-models
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/litellm/chatgpt-models
+  dependsOn:
+    # Load-bearing, not just ordering. Registering a chatgpt model with no
+    # auth.json blocks the proxy's startup event for 15 minutes per model until
+    # the liveness probe crashloops it — and applyMode: api persists the models
+    # in Postgres, so reverting the commit cannot undo it. Waiting on the login
+    # Job makes that state unreachable.
+    - name: litellm-chatgpt-login
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -41,10 +41,13 @@ spec:
   path: ./kubernetes/apps/ai/litellm/proxy
   components:
     - ../../../../components/database
+    - ../../../../components/kopiur
     - ../../../../components/oidc
   dependsOn:
     - name: external-secrets-config
       namespace: external-secrets
+    - name: kopiur-repository
+      namespace: kopiur-system
     - name: litellm-operator
     - name: pocket-id
       namespace: security
@@ -54,6 +57,15 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/litellm.svg"
       OIDC_APP_NAME: LiteLLM
       OIDC_CALLBACK_PATH: /sso/callback
+      # The PVC holds one file: the ChatGPT OAuth auth.json (../proxy/proxy.yaml).
+      # Small, but backed up on purpose — the only way to recreate it is another
+      # interactive device-code login, so a lost volume otherwise costs a
+      # 15-minute blocked request and a trip to auth.openai.com.
+      KOPIUR_CAPACITY: 1Gi
+      # The berriai/litellm image runs the proxy as root; the movers have to
+      # write the restored auth.json as the uid that will refresh it in place.
+      KOPIUR_UID: "0"
+      KOPIUR_GID: "0"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -57,20 +57,12 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/litellm.svg"
       OIDC_APP_NAME: LiteLLM
       OIDC_CALLBACK_PATH: /sso/callback
-      # The PVC holds one file: the ChatGPT OAuth auth.json (../proxy/proxy.yaml).
-      # Small, but backed up on purpose — the only way to recreate it is another
-      # interactive device-code login, so a lost volume otherwise costs a
-      # 15-minute blocked request and a trip to auth.openai.com.
+      # Holds one file: the ChatGPT OAuth auth.json (../proxy/proxy.yaml) —
+      # backed up because recreating it needs an interactive device-code login.
       KOPIUR_CAPACITY: 1Gi
-      # Match the -non_root image's runtime identity (../proxy/proxy.yaml), so
-      # the movers write the restored auth.json as the uid that refreshes it in
-      # place. These also carry the volume's permissions on their own: the proxy
-      # pod gets no fsGroup, because the CRD has no securityContext to put one
-      # in, so the mover's fsGroup is the only thing that makes a fresh volume
-      # writable — it leaves the root group-owned by KOPIUR_GID at 0775, and a
-      # bare zfspv volume is otherwise root:root 0755. Verified on the
-      # deploy-or-restore path too: the populator applies the fsGroup even when
-      # no snapshot exists yet.
+      # Must match the -non_root image's 65534 identity. The mover's fsGroup is
+      # also what makes a fresh volume writable: the proxy CRD has no
+      # securityContext, so no fsGroup ever comes from the pod itself.
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"
     substituteFrom:

--- a/kubernetes/apps/ai/litellm/operator/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/operator/helmrelease.yaml
@@ -24,13 +24,13 @@ spec:
       # LiteLLMModel, but hardcodes ModelName to the InferenceService name
       # (internal/controller/llmkube_projection.go) with no chart value or flag
       # to change it, and hardcodes an openai/ provider prefix that litellm's
-      # rerank dispatch cannot route. ../proxy/models.yaml replaces the three
+      # rerank dispatch cannot route. ../proxy/models/llmkube.yaml replaces the three
       # generated models by hand to get llmkube/-namespaced client-facing IDs
       # and a working reranker.
       #
       # Turning this back on republishes the bare InferenceService names
       # alongside the hand-written ones — six models, not three. Delete
-      # ../proxy/models.yaml in the same change if you ever do.
+      # ../proxy/models/llmkube.yaml in the same change if you ever do.
       autoRegister: false
     resources:
       requests:

--- a/kubernetes/apps/ai/litellm/proxy/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - ./externalsecret.yaml
   - ./keys-externalsecret.yaml
   - ./proxy.yaml
-  - ./models.yaml
+  - ./models
   - ./usergroup.yaml

--- a/kubernetes/apps/ai/litellm/proxy/models/chatgpt.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/chatgpt.yaml
@@ -1,0 +1,88 @@
+---
+# ChatGPT subscription models (https://docs.litellm.ai/docs/providers/chatgpt).
+# This is the ChatGPT plan's own Codex backend, not the OpenAI platform API: no
+# API key and no per-token bill, but plan rate limits apply and the quota is
+# shared with the Codex CLI.
+#
+# sol/luna/terra are the three gpt-5.6 variants the backend accepts; bare
+# gpt-5.6 is NOT one of them, nor are gpt-5.6-pro, -cyber or -codex. sol is the
+# Codex CLI's configured default here.
+#
+# This set is VERIFIED against the backend, not copied from a list. Neither
+# available list is authoritative: litellm's provider docs and its cost map both
+# top out at chatgpt/gpt-5.4, and of the six models that page advertises only
+# gpt-5.4 is still accepted — gpt-5.4-pro, gpt-5.3-codex, gpt-5.3-codex-spark,
+# gpt-5.3-instant and gpt-5.3-chat-latest all return 400 "model is not
+# supported". Conversely every model below appears in NO chatgpt/* cost map entry
+# yet routes fine. litellm has no allowlist for this provider (no model check in
+# llms/chatgpt/responses/transformation.py) — it forwards the string and the
+# backend decides, so the only way to know is to ask it:
+#
+#   codex exec -m <model> --skip-git-repo-check "Reply with exactly: OK"
+#
+# spec.params.model is the same string as modelName here, unlike ./llmkube.yaml
+# next door — "chatgpt" is a real entry in litellm.provider_list, so the prefix
+# both routes to the provider and namespaces the client-facing ID by backend.
+#
+# info is MANDATORY here, not documentation. litellm cannot infer it: the cost
+# map has no chatgpt/gpt-5.6-* key, and while it does have a bare gpt-5.6-sol,
+# that entry is tagged litellm_provider: openai, so _check_provider_match
+# (utils.py) rejects it for this provider — and its mere existence as an exact
+# key also short-circuits the capability-generalization fallback, which bails
+# whenever any candidate name is a known key. Net result without info:
+# get_model_info raises "This model isn't mapped yet". The numbers below are
+# those openai-provider entries, which are the same underlying models.
+#
+# mode is responses even though the map says chat: this backend is
+# Responses-native and /chat/completions is bridged onto it.
+# supportsPromptCaching is deliberately unset — the platform API supports it,
+# this backend is unverified.
+#
+# Auth is an OAuth device-code login in a file, NOT a Secret — see
+# CHATGPT_TOKEN_DIR in ../proxy.yaml. Do that login BEFORE these models take
+# traffic: resolving a chatgpt/* model calls get_llm_provider, which triggers the
+# device flow as a side effect and then blocks polling for up to 15 minutes.
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: chatgpt-gpt-5-6-sol
+spec:
+  modelName: chatgpt/gpt-5.6-sol
+  params:
+    model: chatgpt/gpt-5.6-sol
+  info:
+    mode: responses
+    maxInputTokens: 922000
+    maxOutputTokens: 128000
+    supportsFunctionCalling: true
+    supportsVision: true
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: chatgpt-gpt-5-6-luna
+spec:
+  modelName: chatgpt/gpt-5.6-luna
+  params:
+    model: chatgpt/gpt-5.6-luna
+  info:
+    mode: responses
+    maxInputTokens: 922000
+    maxOutputTokens: 128000
+    supportsFunctionCalling: true
+    supportsVision: true
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: chatgpt-gpt-5-6-terra
+spec:
+  modelName: chatgpt/gpt-5.6-terra
+  params:
+    model: chatgpt/gpt-5.6-terra
+  info:
+    mode: responses
+    maxInputTokens: 922000
+    maxOutputTokens: 128000
+    supportsFunctionCalling: true
+    supportsVision: true

--- a/kubernetes/apps/ai/litellm/proxy/models/chatgpt.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/chatgpt.yaml
@@ -1,47 +1,14 @@
 ---
-# ChatGPT subscription models (https://docs.litellm.ai/docs/providers/chatgpt).
-# This is the ChatGPT plan's own Codex backend, not the OpenAI platform API: no
-# API key and no per-token bill, but plan rate limits apply and the quota is
-# shared with the Codex CLI.
-#
-# sol/luna/terra are the three gpt-5.6 variants the backend accepts; bare
-# gpt-5.6 is NOT one of them, nor are gpt-5.6-pro, -cyber or -codex. sol is the
-# Codex CLI's configured default here.
-#
-# This set is VERIFIED against the backend, not copied from a list. Neither
-# available list is authoritative: litellm's provider docs and its cost map both
-# top out at chatgpt/gpt-5.4, and of the six models that page advertises only
-# gpt-5.4 is still accepted — gpt-5.4-pro, gpt-5.3-codex, gpt-5.3-codex-spark,
-# gpt-5.3-instant and gpt-5.3-chat-latest all return 400 "model is not
-# supported". Conversely every model below appears in NO chatgpt/* cost map entry
-# yet routes fine. litellm has no allowlist for this provider (no model check in
-# llms/chatgpt/responses/transformation.py) — it forwards the string and the
-# backend decides, so the only way to know is to ask it:
-#
+# ChatGPT subscription models (https://docs.litellm.ai/docs/providers/chatgpt):
+# the plan's Codex backend, not the platform API — no API key, but plan rate
+# limits shared with the Codex CLI. No published model list is accurate; litellm
+# forwards the string and the backend decides. Verify a candidate with:
 #   codex exec -m <model> --skip-git-repo-check "Reply with exactly: OK"
-#
-# spec.params.model is the same string as modelName here, unlike ./llmkube.yaml
-# next door — "chatgpt" is a real entry in litellm.provider_list, so the prefix
-# both routes to the provider and namespaces the client-facing ID by backend.
-#
-# info is MANDATORY here, not documentation. litellm cannot infer it: the cost
-# map has no chatgpt/gpt-5.6-* key, and while it does have a bare gpt-5.6-sol,
-# that entry is tagged litellm_provider: openai, so _check_provider_match
-# (utils.py) rejects it for this provider — and its mere existence as an exact
-# key also short-circuits the capability-generalization fallback, which bails
-# whenever any candidate name is a known key. Net result without info:
-# get_model_info raises "This model isn't mapped yet". The numbers below are
-# those openai-provider entries, which are the same underlying models.
-#
-# mode is responses even though the map says chat: this backend is
-# Responses-native and /chat/completions is bridged onto it.
-# supportsPromptCaching is deliberately unset — the platform API supports it,
-# this backend is unverified.
-#
-# Auth is an OAuth device-code login in a file, NOT a Secret — see
-# CHATGPT_TOKEN_DIR in ../proxy.yaml. Do that login BEFORE these models take
-# traffic: resolving a chatgpt/* model calls get_llm_provider, which triggers the
-# device flow as a side effect and then blocks polling for up to 15 minutes.
+# info is mandatory — the cost map cannot resolve chatgpt/* names, so litellm
+# errors without it. mode is responses (Responses-native backend).
+# Auth is a device-code login file (CHATGPT_TOKEN_DIR in ../proxy.yaml); do the
+# login before these take traffic, or the first request blocks on the device
+# flow for up to 15 minutes.
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:

--- a/kubernetes/apps/ai/litellm/proxy/models/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./llmkube.yaml
+  - ./chatgpt.yaml

--- a/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
@@ -1,6 +1,6 @@
 ---
-# Hand-written replacements for what ../operator's llmkube auto-registration
-# used to generate (now off — see ../operator/helmrelease.yaml). Written out
+# Hand-written replacements for what ../../operator's llmkube auto-registration
+# used to generate (now off — see ../../operator/helmrelease.yaml). Written out
 # because the operator hardcodes ModelName to the InferenceService name
 # (internal/controller/llmkube_projection.go) with no knob, and we want the
 # client-facing IDs namespaced by backend the way bifrost's llmkube provider
@@ -37,7 +37,7 @@ spec:
     # (Repeated per document — YAML anchors do not cross a --- boundary.)
     apiKey: sk-llmkube-noauth
   info:
-    # ../../llmkube/models/qwen3-8-27b-mtp.yaml contextSize, which is also what
+    # ../../../llmkube/models/qwen3-8-27b-mtp.yaml contextSize, which is also what
     # the GGUF reports and what the projection read out of Model.status.
     maxInputTokens: 262144
 ---

--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -4,7 +4,15 @@ kind: LiteLLMProxy
 metadata:
   name: litellm
 spec:
-  image: ghcr.io/berriai/litellm:v1.98.0@sha256:20b5044b619055374061a6d5b7b08754cad75aeabbf82ddf4f69cc0cf80ddaf4
+  # -non_root, not the default image, which runs as uid 0. The operator's CRD
+  # exposes no securityContext (checked through chart 0.0.16) — no runAsUser, no
+  # fsGroup — so the runtime user can only come from the image's own USER, and
+  # this variant additionally owns /app as that user. Forcing the default image
+  # to a non-root uid is not an equivalent fix even once the CRD grows the knob:
+  # there /app stays root:root 0755 and HOME resolves to an unwritable /.
+  # Runtime identity is 65534:65534, which ../ks.yaml's KOPIUR_UID/GID must keep
+  # matching — do not swap this image back without revisiting them.
+  image: ghcr.io/berriai/litellm-non_root:v1.98.0@sha256:157aaf0a519713663ec6abefe73fa48bf12f638b0e63fb2b209ba0eae68e6bd7
   replicas: 1
 
   # Pod template rather than the Deployment, which is the operator's — reloader

--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -25,10 +25,12 @@ spec:
       name: litellm-secret
       key: LITELLM_MASTER_KEY
 
-  # No modelSelector: adopts every LiteLLMModel in ai, all of them now written
-  # by hand in ./models/llmkube.yaml. The operator's llmkube auto-registration is off
-  # (../operator/helmrelease.yaml) because it hardcodes both the client-facing
-  # model name and an openai/ provider prefix the rerank path cannot route.
+  # No modelSelector: adopts every LiteLLMModel in ai, wherever it is applied
+  # from — ./models/llmkube.yaml here, plus ../chatgpt-models, which is a
+  # separate Kustomization only so it can be gated behind the device login.
+  # The operator's llmkube auto-registration is off (../operator/helmrelease.yaml)
+  # because it hardcodes both the client-facing model name and an openai/
+  # provider prefix the rerank path cannot route.
 
   env:
     - name: LITELLM_MASTER_KEY
@@ -62,7 +64,7 @@ spec:
           name: litellm-postgres-secret
           key: password
 
-    # The chatgpt provider (./models/chatgpt.yaml) reads AND rewrites its
+    # The chatgpt provider (../chatgpt-models/models.yaml) reads AND rewrites its
     # auth.json on token refresh, so it lives on the kopiur PVC below rather
     # than in a read-only Secret mount.
     - name: CHATGPT_TOKEN_DIR

--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -4,14 +4,9 @@ kind: LiteLLMProxy
 metadata:
   name: litellm
 spec:
-  # -non_root, not the default image, which runs as uid 0. The operator's CRD
-  # exposes no securityContext (checked through chart 0.0.16) — no runAsUser, no
-  # fsGroup — so the runtime user can only come from the image's own USER, and
-  # this variant additionally owns /app as that user. Forcing the default image
-  # to a non-root uid is not an equivalent fix even once the CRD grows the knob:
-  # there /app stays root:root 0755 and HOME resolves to an unwritable /.
-  # Runtime identity is 65534:65534, which ../ks.yaml's KOPIUR_UID/GID must keep
-  # matching — do not swap this image back without revisiting them.
+  # -non_root, not the default image (uid 0): the CRD has no securityContext,
+  # so identity must come from the image. Runs as 65534:65534 — keep
+  # ../ks.yaml's KOPIUR_UID/GID matching.
   image: ghcr.io/berriai/litellm-non_root:v1.98.0@sha256:157aaf0a519713663ec6abefe73fa48bf12f638b0e63fb2b209ba0eae68e6bd7
   replicas: 1
 
@@ -67,13 +62,9 @@ spec:
           name: litellm-postgres-secret
           key: password
 
-    # The chatgpt provider (models in ./models/chatgpt.yaml) authenticates out of
-    # an auth.json it both reads and rewrites: every request reads the file, and
-    # an expired access_token is refreshed against auth.openai.com and written
-    # back. Default location is $HOME/.config/litellm/chatgpt, which is
-    # container-local — pointed at the kopiur PVC below so one device-code login
-    # survives restarts. A read-only mount (a Secret) would "work" but re-refresh
-    # on every single request, and OpenAI rotates the refresh_token on each one.
+    # The chatgpt provider (./models/chatgpt.yaml) reads AND rewrites its
+    # auth.json on token refresh, so it lives on the kopiur PVC below rather
+    # than in a read-only Secret mount.
     - name: CHATGPT_TOKEN_DIR
       value: /var/lib/litellm/chatgpt
 

--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -23,7 +23,7 @@ spec:
       key: LITELLM_MASTER_KEY
 
   # No modelSelector: adopts every LiteLLMModel in ai, all of them now written
-  # by hand in ./models.yaml. The operator's llmkube auto-registration is off
+  # by hand in ./models/llmkube.yaml. The operator's llmkube auto-registration is off
   # (../operator/helmrelease.yaml) because it hardcodes both the client-facing
   # model name and an openai/ provider prefix the rerank path cannot route.
 
@@ -58,6 +58,16 @@ spec:
         secretKeyRef:
           name: litellm-postgres-secret
           key: password
+
+    # The chatgpt provider (models in ./models/chatgpt.yaml) authenticates out of
+    # an auth.json it both reads and rewrites: every request reads the file, and
+    # an expired access_token is refreshed against auth.openai.com and written
+    # back. Default location is $HOME/.config/litellm/chatgpt, which is
+    # container-local — pointed at the kopiur PVC below so one device-code login
+    # survives restarts. A read-only mount (a Secret) would "work" but re-refresh
+    # on every single request, and OpenAI rotates the refresh_token on each one.
+    - name: CHATGPT_TOKEN_DIR
+      value: /var/lib/litellm/chatgpt
 
     # /ui SSO against pocket-id via litellm's "generic" OIDC provider, which has
     # no discovery-document path — hence the endpoints wired individually out of
@@ -114,6 +124,14 @@ spec:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 30
+
+  volumes:
+    - name: chatgpt-auth
+      persistentVolumeClaim:
+        claimName: litellm
+  volumeMounts:
+    - name: chatgpt-auth
+      mountPath: /var/lib/litellm/chatgpt
 
   route:
     hostnames:


### PR DESCRIPTION
Publishes the gpt-5.6 family through litellm's `chatgpt` provider — the ChatGPT plan's own Codex backend rather than the OpenAI platform API. No API key and no per-token bill, but plan rate limits apply and the quota is shared with the Codex CLI.

## Models

The set is verified against the backend, not copied from a list. Neither available list is authoritative:

- litellm's provider docs and its cost map both top out at `chatgpt/gpt-5.4`, and **five of the six models that docs page advertises now return 400 "model is not supported"** (`gpt-5.4-pro`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.3-instant`, `gpt-5.3-chat-latest`).
- Conversely every model added here has **no** `chatgpt/*` cost map entry yet routes fine.

There is no allowlist in the provider, so the backend is the only oracle — probed with `codex exec -m <model>`. `sol`, `luna` and `terra` are the gpt-5.6 variants it accepts; bare `gpt-5.6`, `-pro`, `-cyber` and `-codex` are not.

Each model carries an explicit `info` block because litellm cannot infer one. The cost map's bare `gpt-5.6-sol` key is tagged `litellm_provider: openai`, so `_check_provider_match` rejects it for this provider — and its existence as an exact key also short-circuits the capability-generalization fallback. Without `info`, `get_model_info` raises.

## Auth

An OAuth device-code login stored in a file, not a Secret. The provider reads *and rewrites* that file — an expired access token is refreshed and written back — so a read-only Secret mount would re-refresh on every request against a rotating refresh token. It gets the kopiur PVC instead, backed up because the only way to recreate it is another interactive login.

## Gating the login

The device flow is not merely slow on first use — it is load-bearing on the proxy's availability, and getting the order wrong is not recoverable by reverting.

Registering a `chatgpt/*` model resolves the provider, which starts the device flow as a side effect and then blocks polling for `DEVICE_CODE_TIMEOUT_SECONDS` (15 minutes), per model. That is not the first *request*: `add_deployment` runs in the proxy's FastAPI startup event, so on any restart with the models already in the database the port never binds, the liveness probe's ~330s budget expires, and the whole proxy crashloops — taking the llmkube models with it. And because `applyMode: api` persists models in Postgres, reverting this PR would not clear them: `syncModels` deletes through the admin API of a proxy that is by then crashlooping, leaving hand-deleting rows as the only way out.

So the ordering is enforced rather than documented. The chatgpt models move into their own Kustomization, gated behind one holding a login Job:

```
litellm                        wait=false
  └─ litellm-chatgpt-login     wait=true   ← Flux blocks on the Job completing
       └─ litellm-chatgpt-models           ← models apply only after that
```

The Job calls litellm's `Authenticator` directly, which is the only way to run the flow deliberately — there is no login CLI; it otherwise happens only as a side effect of resolving a model. It prints the verification URL and device code to its pod logs, and Flux waits (`timeout: 20m`, comfortably past the Job's own 15-minute window) while a human completes it.

Three details that are deliberate:

- **Idempotent.** With a valid `auth.json`, `get_access_token()` returns the cached token and the Job exits immediately, so re-running it costs nothing.
- **`force: true`.** A Job's pod template is immutable, so a Renovate image bump would otherwise fail to apply forever. Recreating is safe precisely because of the above.
- **`backoffLimit: 0`.** A retry would start a second flow and trip litellm's stored device-code cooldown, so a timed-out login stays `Failed` and is cleared by deleting the Job and letting Flux recreate it.

The Job also runs as 65534:65534 rather than inheriting a default. `_write_auth_file` swallows `OSError` into a log line, so an `auth.json` written under any other uid would make later token refreshes silently stop persisting instead of failing loudly.

An initContainer would be the more natural home for this, but `LiteLLMProxy` exposes no `initContainers`, no `securityContext`, and no pod-template override of any kind — confirmed against upstream `main`, not just the pinned chart. Only `volumes`, `volumeMounts`, `env`, `envFrom`, `service`, `resources`, probes and pod metadata pass through.

## Non-root

Swaps the proxy to the `-non_root` image (65534:65534, owns `/app`). The image is the only lever: `LiteLLMProxy` exposes no `securityContext`, `podSecurityContext` or `serviceAccountName` — confirmed against chart 0.0.16, not just the pinned 0.0.15. The operator hardens its own pod but renders the proxy with an empty pod securityContext and no container one. Sibling `LiteLLMMCPServer` got those fields in upstream PR #27; the proxy never did.

Setting a securityContext on the default image would not be equivalent even once that lands — there `/app` stays `root:root 0755` and HOME resolves to an unwritable `/`.

`KOPIUR_UID`/`GID` follow to 65534/65534. The gid is not the image's numeric `USER` taken literally; the runtime resolves a passwd entry for `nobody` and takes its primary group. Those values also carry the volume's permissions outright: with no fsGroup available on the proxy pod, the kopiur mover's fsGroup is the only thing making a fresh volume writable, leaving the root group-owned at 0775 where a bare zfspv volume would be `root:root 0755`. Verified that this holds on the deploy-or-restore path too — the populator applies the fsGroup before any snapshot exists.

## Also

Model manifests move out of a single `models.yaml`: the llmkube ones to `proxy/models/llmkube.yaml`, the chatgpt ones to `chatgpt-models/models.yaml`. The proxy sets no `modelSelector`, so it still adopts every `LiteLLMModel` in `ai` regardless of which Kustomization applied it.

## Verification

- `just test` passes (182, up from 180 for the two new Kustomizations).
- Both new Kustomizations render offline; the proxy Kustomization now emits only the three `llmkube/*` models.
- `kubectl apply --dry-run=server` accepted by the operator's admission webhook.
- Volume permission chain probed end to end in-cluster with the real image on a real populator-provisioned PVC (`makedirs` + write succeeded). All probe resources removed.
- `crane config` on the pinned digest confirms `User=65534` and a `PATH` led by `/app/.venv/bin`, so the Job's `python -c` resolves to the interpreter that has litellm.

Not verified: whether `prod_entrypoint.sh`'s `prisma migrate deploy` completes cleanly as 65534 — only filesystem writability was probed, not a full startup. The gate has not been exercised against a live device flow.

## Known gaps

Two findings from review are left open rather than fixed here:

- **Refresh-token race.** litellm constructs a new `Authenticator` per call with no cross-request caching, and `_refresh_tokens` rotates the token. Concurrent requests arriving after expiry each refresh with the same token; losers get `RefreshAccessTokenError` and fall into the 15-minute device flow. The operator sets no Deployment `strategy`, so the default maxSurge=1 overlaps two pods on the RWO PVC during every rollout, widening it. The gate does not help here — a completed Job will not re-run.
- **`model_info` edits do not propagate.** Under `applyMode: api`, `syncModels` skips when `subsetEqual(params, cur.LiteLLMParams)` and never compares `model_info`. Since `params` is just the model string, later `maxInputTokens`/`mode` tuning needs the CR renamed to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
