### PR TITLE
fix(external-secrets): reduce 1Password API calls

### DIFF
--- a/kubernetes/apps/ai/bifrost/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/bifrost/app/externalsecret.yaml
@@ -14,16 +14,12 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: BIFROST_ENCRYPTION_KEY
-      remoteRef:
-        key: k8s-ai-bifrost-secret/BIFROST_ENCRYPTION_KEY
-    - secretKey: BIFROST_SETUP_TOKEN
-      remoteRef:
-        key: k8s-ai-bifrost-secret/BIFROST_SETUP_TOKEN
-    - secretKey: BIFROST_ADMIN_USERNAME
-      remoteRef:
-        key: k8s-ai-bifrost-secret/BIFROST_ADMIN_USERNAME
-    - secretKey: BIFROST_ADMIN_PASSWORD
-      remoteRef:
-        key: k8s-ai-bifrost-secret/BIFROST_ADMIN_PASSWORD
+      mergePolicy: Replace
+      data:
+        BIFROST_ENCRYPTION_KEY: '{{ index . "BIFROST_ENCRYPTION_KEY" }}'
+        BIFROST_SETUP_TOKEN: '{{ index . "BIFROST_SETUP_TOKEN" }}'
+        BIFROST_ADMIN_USERNAME: '{{ index . "BIFROST_ADMIN_USERNAME" }}'
+        BIFROST_ADMIN_PASSWORD: '{{ index . "BIFROST_ADMIN_PASSWORD" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-bifrost-secret

--- a/kubernetes/apps/ai/litellm/proxy/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/externalsecret.yaml
@@ -21,10 +21,10 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-ai-litellm-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-ai-litellm-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-litellm-postgres-secret

--- a/kubernetes/apps/ai/litellm/proxy/keys-externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/keys-externalsecret.yaml
@@ -14,10 +14,10 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: LITELLM_MASTER_KEY
-      remoteRef:
-        key: k8s-ai-litellm-secret/LITELLM_MASTER_KEY
-    - secretKey: LITELLM_SALT_KEY
-      remoteRef:
-        key: k8s-ai-litellm-secret/LITELLM_SALT_KEY
+      mergePolicy: Replace
+      data:
+        LITELLM_MASTER_KEY: '{{ index . "LITELLM_MASTER_KEY" }}'
+        LITELLM_SALT_KEY: '{{ index . "LITELLM_SALT_KEY" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-litellm-secret

--- a/kubernetes/apps/ai/llama-cpp/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/llama-cpp/app/externalsecret.yaml
@@ -14,10 +14,10 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: LLAMA_API_KEY
-      remoteRef:
-        key: k8s-ai-llama-cpp-secret/LLAMA_API_KEY
-    - secretKey: HF_TOKEN
-      remoteRef:
-        key: k8s-ai-llama-cpp-secret/HF_TOKEN
+      mergePolicy: Replace
+      data:
+        LLAMA_API_KEY: '{{ index . "LLAMA_API_KEY" }}'
+        HF_TOKEN: '{{ index . "HF_TOKEN" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-llama-cpp-secret

--- a/kubernetes/apps/ai/memini/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/memini/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: MEMINI_API_KEY
-      remoteRef:
-        key: k8s-ai-memini-secret/MEMINI_API_KEY
+      mergePolicy: Replace
+      data:
+        MEMINI_API_KEY: '{{ index . "MEMINI_API_KEY" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-memini-secret

--- a/kubernetes/apps/ai/searxng/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/searxng/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: SEARXNG_SECRET
-      remoteRef:
-        key: k8s-ai-searxng-secret/SEARXNG_SECRET
+      mergePolicy: Replace
+      data:
+        SEARXNG_SECRET: '{{ index . "SEARXNG_SECRET" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-searxng-secret

--- a/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: api-token
-      remoteRef:
-        key: k8s-cert-manager-cert-manager-secret/api-token
+      mergePolicy: Replace
+      data:
+        api-token: '{{ index . "api-token" }}'
+  dataFrom:
+    - extract:
+        key: k8s-cert-manager-cert-manager-secret

--- a/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
@@ -14,13 +14,13 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: ACCESS_KEY_ID
-      remoteRef:
-        key: k8s-database-garage-cnpg/ACCESS_KEY_ID
-    - secretKey: SECRET_ACCESS_KEY
-      remoteRef:
-        key: k8s-database-garage-cnpg/SECRET_ACCESS_KEY
+      mergePolicy: Replace
+      data:
+        ACCESS_KEY_ID: '{{ index . "ACCESS_KEY_ID" }}'
+        SECRET_ACCESS_KEY: '{{ index . "SECRET_ACCESS_KEY" }}'
+  dataFrom:
+    - extract:
+        key: k8s-database-garage-cnpg
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -38,10 +38,10 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: ACCESS_KEY_ID
-      remoteRef:
-        key: k8s-database-b2-cnpg/ACCESS_KEY_ID
-    - secretKey: SECRET_ACCESS_KEY
-      remoteRef:
-        key: k8s-database-b2-cnpg/SECRET_ACCESS_KEY
+      mergePolicy: Replace
+      data:
+        ACCESS_KEY_ID: '{{ index . "ACCESS_KEY_ID" }}'
+        SECRET_ACCESS_KEY: '{{ index . "SECRET_ACCESS_KEY" }}'
+  dataFrom:
+    - extract:
+        key: k8s-database-b2-cnpg

--- a/kubernetes/apps/documents/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/documents/paperless/app/externalsecret.yaml
@@ -21,13 +21,13 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-documents-paperless-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-documents-paperless-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-documents-paperless-postgres-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -45,13 +45,11 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: PAPERLESS_SECRET_KEY
-      remoteRef:
-        key: k8s-documents-paperless-secret/PAPERLESS_SECRET_KEY
-    - secretKey: PAPERLESS_ADMIN_USER
-      remoteRef:
-        key: k8s-documents-paperless-secret/PAPERLESS_ADMIN_USER
-    - secretKey: PAPERLESS_ADMIN_PASSWORD
-      remoteRef:
-        key: k8s-documents-paperless-secret/PAPERLESS_ADMIN_PASSWORD
+      mergePolicy: Replace
+      data:
+        PAPERLESS_SECRET_KEY: '{{ index . "PAPERLESS_SECRET_KEY" }}'
+        PAPERLESS_ADMIN_USER: '{{ index . "PAPERLESS_ADMIN_USER" }}'
+        PAPERLESS_ADMIN_PASSWORD: '{{ index . "PAPERLESS_ADMIN_PASSWORD" }}'
+  dataFrom:
+    - extract:
+        key: k8s-documents-paperless-secret

--- a/kubernetes/apps/external-secrets/external-secrets/config/clusterexternalsecret.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/clusterexternalsecret.yaml
@@ -15,16 +15,14 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: SECRET_DOMAIN
-      remoteRef:
-        key: k8s-cluster-secrets/SECRET_DOMAIN
-    - secretKey: CLOUDFLARE_TUNNEL_ID
-      remoteRef:
-        key: k8s-cluster-secrets/CLOUDFLARE_TUNNEL_ID
-    - secretKey: GARAGE_ENDPOINT_URL
-      remoteRef:
-        key: k8s-cluster-secrets/GARAGE_ENDPOINT_URL
+      mergePolicy: Replace
+      data:
+        SECRET_DOMAIN: '{{ index . "SECRET_DOMAIN" }}'
+        CLOUDFLARE_TUNNEL_ID: '{{ index . "CLOUDFLARE_TUNNEL_ID" }}'
+        GARAGE_ENDPOINT_URL: '{{ index . "GARAGE_ENDPOINT_URL" }}'
+  dataFrom:
+    - extract:
+        key: k8s-cluster-secrets
 ---
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret

--- a/kubernetes/apps/external-secrets/external-secrets/config/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/config/clustersecretstore.yaml
@@ -11,6 +11,9 @@ spec:
   provider:
     onepasswordSDK:
       vault: homelab
+      cache:
+        ttl: 6h
+        maxSize: 100
       auth:
         serviceAccountSecretRef:
           name: onepassword-service-account-token

--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: token
-      remoteRef:
-        key: k8s-flux-system-github-webhook-token-secret/token
+      mergePolicy: Replace
+      data:
+        token: '{{ index . "token" }}'
+  dataFrom:
+    - extract:
+        key: k8s-flux-system-github-webhook-token-secret

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -14,13 +14,11 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: KONFLATE_WEBHOOK_SECRET
-      remoteRef:
-        key: k8s-flux-system-konflate-secret/KONFLATE_WEBHOOK_SECRET
-    - secretKey: KONFLATE_APP_CLIENT_ID
-      remoteRef:
-        key: k8s-flux-system-konflate-secret/KONFLATE_APP_CLIENT_ID
-    - secretKey: KONFLATE_APP_PRIVATE_KEY
-      remoteRef:
-        key: k8s-flux-system-konflate-secret/KONFLATE_APP_PRIVATE_KEY
+      mergePolicy: Replace
+      data:
+        KONFLATE_WEBHOOK_SECRET: '{{ index . "KONFLATE_WEBHOOK_SECRET" }}'
+        KONFLATE_APP_CLIENT_ID: '{{ index . "KONFLATE_APP_CLIENT_ID" }}'
+        KONFLATE_APP_PRIVATE_KEY: '{{ index . "KONFLATE_APP_PRIVATE_KEY" }}'
+  dataFrom:
+    - extract:
+        key: k8s-flux-system-konflate-secret

--- a/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
@@ -14,19 +14,13 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: KOPIA_PASSWORD
-      remoteRef:
-        key: k8s-kopiur-system-kopiur-repository-secret/KOPIA_PASSWORD
-    - secretKey: B2_KEY_ID
-      remoteRef:
-        key: k8s-kopiur-system-kopiur-repository-secret/B2_KEY_ID
-    - secretKey: B2_KEY
-      remoteRef:
-        key: k8s-kopiur-system-kopiur-repository-secret/B2_KEY
-    - secretKey: AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: k8s-kopiur-system-kopiur-repository-secret/AWS_ACCESS_KEY_ID
-    - secretKey: AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: k8s-kopiur-system-kopiur-repository-secret/AWS_SECRET_ACCESS_KEY
+      mergePolicy: Replace
+      data:
+        KOPIA_PASSWORD: '{{ index . "KOPIA_PASSWORD" }}'
+        B2_KEY_ID: '{{ index . "B2_KEY_ID" }}'
+        B2_KEY: '{{ index . "B2_KEY" }}'
+        AWS_ACCESS_KEY_ID: '{{ index . "AWS_ACCESS_KEY_ID" }}'
+        AWS_SECRET_ACCESS_KEY: '{{ index . "AWS_SECRET_ACCESS_KEY" }}'
+  dataFrom:
+    - extract:
+        key: k8s-kopiur-system-kopiur-repository-secret

--- a/kubernetes/apps/media/bazarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/bazarr/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: password
-      remoteRef:
-        key: k8s-media-bazarr-secret/password
+      mergePolicy: Replace
+      data:
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-bazarr-secret

--- a/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
@@ -21,13 +21,13 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-media-prowlarr-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-media-prowlarr-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-prowlarr-postgres-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -45,7 +45,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: api_key
-      remoteRef:
-        key: k8s-media-prowlarr-secret/api_key
+      mergePolicy: Replace
+      data:
+        api_key: '{{ index . "api_key" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-prowlarr-secret

--- a/kubernetes/apps/media/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/externalsecret.yaml
@@ -14,13 +14,11 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: VPN_SERVICE_PROVIDER
-      remoteRef:
-        key: k8s-media-qbittorrent-secret/VPN_SERVICE_PROVIDER
-    - secretKey: WIREGUARD_PRIVATE_KEY
-      remoteRef:
-        key: k8s-media-qbittorrent-secret/WIREGUARD_PRIVATE_KEY
-    - secretKey: SERVER_COUNTRIES
-      remoteRef:
-        key: k8s-media-qbittorrent-secret/SERVER_COUNTRIES
+      mergePolicy: Replace
+      data:
+        VPN_SERVICE_PROVIDER: '{{ index . "VPN_SERVICE_PROVIDER" }}'
+        WIREGUARD_PRIVATE_KEY: '{{ index . "WIREGUARD_PRIVATE_KEY" }}'
+        SERVER_COUNTRIES: '{{ index . "SERVER_COUNTRIES" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-qbittorrent-secret

--- a/kubernetes/apps/media/radarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/radarr/app/externalsecret.yaml
@@ -21,13 +21,13 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-media-radarr-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-media-radarr-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-radarr-postgres-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -45,7 +45,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: api_key
-      remoteRef:
-        key: k8s-media-radarr-secret/api_key
+      mergePolicy: Replace
+      data:
+        api_key: '{{ index . "api_key" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-radarr-secret

--- a/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
@@ -14,10 +14,10 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: api_key
-      remoteRef:
-        key: k8s-media-sabnzbd-secret/api_key
-    - secretKey: nzb_key
-      remoteRef:
-        key: k8s-media-sabnzbd-secret/nzb_key
+      mergePolicy: Replace
+      data:
+        api_key: '{{ index . "api_key" }}'
+        nzb_key: '{{ index . "nzb_key" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-sabnzbd-secret

--- a/kubernetes/apps/media/seerr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/seerr/app/externalsecret.yaml
@@ -21,10 +21,10 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-media-seerr-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-media-seerr-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-seerr-postgres-secret

--- a/kubernetes/apps/media/sonarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sonarr/app/externalsecret.yaml
@@ -21,13 +21,13 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-media-sonarr-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-media-sonarr-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-sonarr-postgres-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -45,7 +45,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: api_key
-      remoteRef:
-        key: k8s-media-sonarr-secret/api_key
+      mergePolicy: Replace
+      data:
+        api_key: '{{ index . "api_key" }}'
+  dataFrom:
+    - extract:
+        key: k8s-media-sonarr-secret

--- a/kubernetes/apps/network/cloudflare-dns/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: api-token
-      remoteRef:
-        key: k8s-network-cloudflare-dns-secret/api-token
+      mergePolicy: Replace
+      data:
+        api-token: '{{ index . "api-token" }}'
+  dataFrom:
+    - extract:
+        key: k8s-network-cloudflare-dns-secret

--- a/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: TUNNEL_TOKEN
-      remoteRef:
-        key: k8s-network-cloudflare-tunnel-secret/TUNNEL_TOKEN
+      mergePolicy: Replace
+      data:
+        TUNNEL_TOKEN: '{{ index . "TUNNEL_TOKEN" }}'
+  dataFrom:
+    - extract:
+        key: k8s-network-cloudflare-tunnel-secret

--- a/kubernetes/apps/network/towonel-agent/app/externalsecret.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/externalsecret.yaml
@@ -14,7 +14,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: TOWONEL_INVITE_TOKEN
-      remoteRef:
-        key: k8s-network-towonel-agent-secret/TOWONEL_INVITE_TOKEN
+      mergePolicy: Replace
+      data:
+        TOWONEL_INVITE_TOKEN: '{{ index . "TOWONEL_INVITE_TOKEN" }}'
+  dataFrom:
+    - extract:
+        key: k8s-network-towonel-agent-secret

--- a/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
@@ -14,10 +14,10 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: GF_SECURITY_ADMIN_USER
-      remoteRef:
-        key: k8s-observability-grafana-credentials/GF_SECURITY_ADMIN_USER
-    - secretKey: GF_SECURITY_ADMIN_PASSWORD
-      remoteRef:
-        key: k8s-observability-grafana-credentials/GF_SECURITY_ADMIN_PASSWORD
+      mergePolicy: Replace
+      data:
+        GF_SECURITY_ADMIN_USER: '{{ index . "GF_SECURITY_ADMIN_USER" }}'
+        GF_SECURITY_ADMIN_PASSWORD: '{{ index . "GF_SECURITY_ADMIN_PASSWORD" }}'
+  dataFrom:
+    - extract:
+        key: k8s-observability-grafana-credentials

--- a/kubernetes/apps/observability/victoria/k8s-stack/externalsecret.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/externalsecret.yaml
@@ -15,7 +15,9 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: token
-      remoteRef:
-        key: k8s-observability-homeassistant-token/token
+      mergePolicy: Replace
+      data:
+        token: '{{ index . "token" }}'
+  dataFrom:
+    - extract:
+        key: k8s-observability-homeassistant-token

--- a/kubernetes/apps/security/pocket-id/instance/externalsecret.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/externalsecret.yaml
@@ -21,13 +21,13 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
           reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-security-pocketid-postgres-secret/username
-    - secretKey: password
-      remoteRef:
-        key: k8s-security-pocketid-postgres-secret/password
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-security-pocketid-postgres-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -45,13 +45,11 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: ENCRYPTION_KEY
-      remoteRef:
-        key: k8s-security-pocket-id-secret/ENCRYPTION_KEY
-    - secretKey: databaseUrl
-      remoteRef:
-        key: k8s-security-pocket-id-secret/databaseUrl
-    - secretKey: mailboxPassword
-      remoteRef:
-        key: k8s-security-pocket-id-secret/mailboxPassword
+      mergePolicy: Replace
+      data:
+        ENCRYPTION_KEY: '{{ index . "ENCRYPTION_KEY" }}'
+        databaseUrl: '{{ index . "databaseUrl" }}'
+        mailboxPassword: '{{ index . "mailboxPassword" }}'
+  dataFrom:
+    - extract:
+        key: k8s-security-pocket-id-secret

--- a/kubernetes/apps/security/pocket-id/instance/user-info-externalsecret.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/user-info-externalsecret.yaml
@@ -14,19 +14,13 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: username
-      remoteRef:
-        key: k8s-security-david-user-info/username
-    - secretKey: firstName
-      remoteRef:
-        key: k8s-security-david-user-info/firstName
-    - secretKey: lastName
-      remoteRef:
-        key: k8s-security-david-user-info/lastName
-    - secretKey: email
-      remoteRef:
-        key: k8s-security-david-user-info/email
-    - secretKey: displayName
-      remoteRef:
-        key: k8s-security-david-user-info/displayName
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        firstName: '{{ index . "firstName" }}'
+        lastName: '{{ index . "lastName" }}'
+        email: '{{ index . "email" }}'
+        displayName: '{{ index . "displayName" }}'
+  dataFrom:
+    - extract:
+        key: k8s-security-david-user-info

--- a/kubernetes/apps/social/continuwuity/app/externalsecret.yaml
+++ b/kubernetes/apps/social/continuwuity/app/externalsecret.yaml
@@ -14,10 +14,10 @@ spec:
     deletionPolicy: Retain
     template:
       type: Opaque
-  data:
-    - secretKey: CONTINUWUITY_REGISTRATION_TOKEN
-      remoteRef:
-        key: k8s-social-continuwuity-secret/CONTINUWUITY_REGISTRATION_TOKEN
-    - secretKey: CONTINUWUITY_TURN_SECRET
-      remoteRef:
-        key: k8s-social-continuwuity-secret/CONTINUWUITY_TURN_SECRET
+      mergePolicy: Replace
+      data:
+        CONTINUWUITY_REGISTRATION_TOKEN: '{{ index . "CONTINUWUITY_REGISTRATION_TOKEN" }}'
+        CONTINUWUITY_TURN_SECRET: '{{ index . "CONTINUWUITY_TURN_SECRET" }}'
+  dataFrom:
+    - extract:
+        key: k8s-social-continuwuity-secret

--- a/scripts/check-external-secrets.sh
+++ b/scripts/check-external-secrets.sh
@@ -36,9 +36,9 @@ function main() {
             || fail "${file} is not included by ${kustomization_file}"
 
         secret_count=$((secret_count + $(jq 'length' <<<"${documents}")))
-        field_count=$((field_count + $(jq '[.[].spec.data | length] | add // 0' <<<"${documents}")))
+        field_count=$((field_count + $(jq '[.[].spec.target.template.data | length] | add // 0' <<<"${documents}")))
 
-        invalid="$(jq -r '
+        invalid="$(jq -r --arg namespace "${namespace}" '
             .[]
             | select(
                 .apiVersion != "external-secrets.io/v1"
@@ -49,7 +49,12 @@ function main() {
                 or .spec.target.creationPolicy != "Owner"
                 or .spec.target.deletionPolicy != "Retain"
                 or (.spec.target.template.type | type) != "string"
-                or (.spec.dataFrom != null)
+                or .spec.target.template.mergePolicy != "Replace"
+                or (.spec.target.template.data | type) != "object"
+                or (.spec.data != null)
+                or (.spec.dataFrom | length) != 1
+                or (.spec.dataFrom[0] | keys) != ["extract"]
+                or .spec.dataFrom[0].extract.key != ("k8s-" + $namespace + "-" + .spec.target.name)
                 or .metadata.name != .spec.target.name
             )
             | .metadata.name
@@ -63,16 +68,18 @@ function main() {
                 type: .spec.target.template.type,
                 labels: (.spec.target.template.metadata.labels // {}),
                 annotations: (.spec.target.template.metadata.annotations // {}),
-                keys: ([.spec.data[].secretKey] | sort)
+                keys: (.spec.target.template.data | keys)
             }
         ' <<<"${documents}")"$'\n'
 
-        while IFS=$'\t' read -r target secret_key remote_key; do
+        while IFS=$'\t' read -r target remote_key secret_key template_value; do
             [[ -n "${target}" ]] || continue
-            [[ "${remote_key}" == "k8s-${namespace}-${target}/${secret_key}" ]] \
-                || fail "mapping mismatch in ${file}: ${secret_key} -> ${remote_key}"
-        done < <(jq -r '.[] as $secret | $secret.spec.data[]
-            | [$secret.spec.target.name, .secretKey, .remoteRef.key]
+            [[ "${remote_key}" == "k8s-${namespace}-${target}" ]] \
+                || fail "item mapping mismatch in ${file}: ${target} -> ${remote_key}"
+            [[ "${template_value}" == "{{ index . \"${secret_key}\" }}" ]] \
+                || fail "template mapping mismatch in ${file}: ${secret_key}"
+        done < <(jq -r '.[] as $secret | $secret.spec.target.template.data | to_entries[]
+            | [$secret.spec.target.name, $secret.spec.dataFrom[0].extract.key, .key, .value]
             | @tsv' <<<"${documents}")
     done < <(find "${ROOT_DIR}/kubernetes/apps" -type f -name '*externalsecret.yaml' \
         ! -path '*/external-secrets/*' -print0)
@@ -93,7 +100,7 @@ function main() {
     source="$(yq eval-all --output-format=json --indent=0 \
         'select(.kind == "ExternalSecret" and .metadata.name == "cluster-secrets-source")' \
         "${source_file}" | jq --slurp '.[0]')"
-    [[ "$(jq '.spec.data | length' <<<"${source}")" -eq 3 ]] \
+    [[ "$(jq '.spec.target.template.data | length' <<<"${source}")" -eq 3 ]] \
         || fail "cluster-secrets-source must contain exactly three fields"
     invalid="$(jq -r '
         select(
@@ -103,7 +110,14 @@ function main() {
             or .spec.target.name != "cluster-secrets-source"
             or .spec.target.creationPolicy != "Owner"
             or .spec.target.deletionPolicy != "Retain"
-            or any(.spec.data[]; .remoteRef.key != ("k8s-cluster-secrets/" + .secretKey))
+            or .spec.target.template.mergePolicy != "Replace"
+            or (.spec.target.template.data | keys) != ["CLOUDFLARE_TUNNEL_ID", "GARAGE_ENDPOINT_URL", "SECRET_DOMAIN"]
+            or any(.spec.target.template.data | to_entries[];
+                .value != ("{{ index . \"" + .key + "\" }}"))
+            or (.spec.data != null)
+            or (.spec.dataFrom | length) != 1
+            or (.spec.dataFrom[0] | keys) != ["extract"]
+            or .spec.dataFrom[0].extract.key != "k8s-cluster-secrets"
         )
         | .metadata.name
     ' <<<"${source}")"


### PR DESCRIPTION
## Summary

- enable the 1Password SDK client cache with a six-hour TTL
- fetch each 1Password item once with `dataFrom.extract`
- retain the existing Kubernetes Secret key allowlists with `mergePolicy: Replace`
- update the external-secret contract check for item-level extraction

## Why

ESO was resolving each field separately and exhausting the 1Password request quota. Failed reconciles then retried repeatedly and amplified the request volume.

## Validation

- `just test` (180 passed)
- `git diff --check`