### PR TITLE
feat(cilium): enable hubble

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -27,6 +27,7 @@ TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 "github:cloudnative-pg/cloudnative-pg" = "1.30.0"
 "github:home-operations/kopiur" = "0.10.3"
 "aqua:kopia/kopia" = "0.23.1"
+"aqua:cilium/hubble" = "1.19.4"
 # flux
 "aqua:FiloSottile/age" = "1.3.1"
 "aqua:fluxcd/flux2" = "2.9.4"

--- a/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
@@ -75,8 +75,8 @@ spec:
     # NOTE: `toServices` can't be paired with `toPorts`, so this allows whatever
     # ports the backends expose. qwen and the searxng proxy are 8080-only; memini
     # also exposes :9090 (metrics), which hermes can therefore reach. Acceptable
-    # for a sandbox allowlist. (Verifying enforcement needs Hubble, which is
-    # currently disabled cluster-wide — see kube-system/cilium.)
+    # for a sandbox allowlist. (Verify with `hubble observe --namespace
+    # ai-sandbox --verdict DROPPED`.)
     - toServices:
         # Qwen chat model (llmkube), reached at http://qwen3-8-27b-mtp.ai:8080/v1.
         - k8sService:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -40,9 +40,15 @@ spec:
         # *-namespace ones filter on source_namespace/destination_namespace and
         # group by source/destination, which only exist when labelsContext and
         # source/destinationContext are set. workload-name|reserved-identity
-        # keeps those two labels bounded — a workload name for in-cluster peers,
-        # otherwise a reserved identity (world, host, remote-node) rather than a
-        # per-IP series.
+        # keeps source/destination bounded — a workload name for in-cluster
+        # peers, otherwise a reserved identity (world, host, remote-node) rather
+        # than a per-IP series.
+        #
+        # `dns:query` is the exception: it labels every series with the resolved
+        # name, so its cardinality is whatever the cluster looks up. Kept anyway
+        # because it is what supplies the domain set for hermes' deferred
+        # toFQDNs allowlist (#1475). Drop it first if vmsingle starts shedding
+        # rows.
         #
         # No httpV2 here: L7 metrics are only emitted for pods with Layer 7
         # visibility, which needs envoy.enabled above (the next step of #1475).
@@ -55,16 +61,17 @@ spec:
           - "port-distribution:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
         dashboards:
           # ConfigMaps only; the GrafanaDashboard CRs that publish them live in
-          # ./grafanadashboard.yaml (grafana-operator reads the ConfigMap through
-          # a CR, it does not watch dashboard labels).
+          # ../hubble/grafanadashboard.yaml (grafana-operator reads a ConfigMap
+          # through a CR, it does not watch dashboard labels).
           enabled: true
         serviceMonitor:
           enabled: true
       relay:
         enabled: true
-        # hubble.tls.auto.method is helm: the CA is reused from the cilium-ca
-        # Secret, but the leaf certs are reminted on every chart/values change,
-        # so relay has to restart to pick up its new client cert.
+        # Rolls relay when its own ConfigMap changes (the annotation hashes
+        # hubble-relay/configmap.yaml, nothing else) — the relay counterpart of
+        # rollOutCiliumPods below. Certs are not the reason: the helm TLS method
+        # looks up hubble-relay-client-certs and reuses the existing leaf.
         rollOutPods: true
         prometheus:
           enabled: true

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -34,7 +34,44 @@ spec:
     gatewayAPI:
       enabled: false
     hubble:
-      enabled: false
+      enabled: true
+      metrics:
+        # The context options are load-bearing for the bundled dashboards: the
+        # *-namespace ones filter on source_namespace/destination_namespace and
+        # group by source/destination, which only exist when labelsContext and
+        # source/destinationContext are set. workload-name|reserved-identity
+        # keeps those two labels bounded — a workload name for in-cluster peers,
+        # otherwise a reserved identity (world, host, remote-node) rather than a
+        # per-IP series.
+        #
+        # No httpV2 here: L7 metrics are only emitted for pods with Layer 7
+        # visibility, which needs envoy.enabled above (the next step of #1475).
+        enabled:
+          - "dns:query;labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "drop:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "flow:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "tcp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "icmp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "port-distribution:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+        dashboards:
+          # ConfigMaps only; the GrafanaDashboard CRs that publish them live in
+          # ./grafanadashboard.yaml (grafana-operator reads the ConfigMap through
+          # a CR, it does not watch dashboard labels).
+          enabled: true
+        serviceMonitor:
+          enabled: true
+      relay:
+        enabled: true
+        # hubble.tls.auto.method is helm: the CA is reused from the cilium-ca
+        # Secret, but the leaf certs are reminted on every chart/values change,
+        # so relay has to restart to pick up its new client cert.
+        rollOutPods: true
+        prometheus:
+          enabled: true
+          serviceMonitor:
+            enabled: true
+      ui:
+        enabled: true
     ipam:
       mode: kubernetes
     ipv4NativeRoutingCIDR: 10.244.0.0/16

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -36,22 +36,13 @@ spec:
     hubble:
       enabled: true
       metrics:
-        # The context options are load-bearing for the bundled dashboards: the
-        # *-namespace ones filter on source_namespace/destination_namespace and
-        # group by source/destination, which only exist when labelsContext and
-        # source/destinationContext are set. workload-name|reserved-identity
-        # keeps source/destination bounded — a workload name for in-cluster
-        # peers, otherwise a reserved identity (world, host, remote-node) rather
-        # than a per-IP series.
+        # The bundled *-namespace dashboards render empty without these
+        # contexts — they filter on the namespace labels and group by
+        # source/destination. httpV2 is absent: it needs envoy.enabled.
         #
-        # `dns:query` is the exception: it labels every series with the resolved
-        # name, so its cardinality is whatever the cluster looks up. Kept anyway
-        # because it is what supplies the domain set for hermes' deferred
-        # toFQDNs allowlist (#1475). Drop it first if vmsingle starts shedding
-        # rows.
-        #
-        # No httpV2 here: L7 metrics are only emitted for pods with Layer 7
-        # visibility, which needs envoy.enabled above (the next step of #1475).
+        # dns:query is the one unbounded label (a series per resolved name).
+        # It stays because it supplies the domain set for hermes' toFQDNs
+        # allowlist; drop it first if vmsingle sheds rows.
         enabled:
           - "dns:query;labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "drop:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
@@ -60,18 +51,15 @@ spec:
           - "icmp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "port-distribution:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
         dashboards:
-          # ConfigMaps only; the GrafanaDashboard CRs that publish them live in
-          # ../hubble/grafanadashboard.yaml (grafana-operator reads a ConfigMap
-          # through a CR, it does not watch dashboard labels).
+          # Writes ConfigMaps only. grafana-operator reads them through the
+          # CRs in ../hubble/grafanadashboard.yaml, not by watching labels.
           enabled: true
         serviceMonitor:
           enabled: true
       relay:
         enabled: true
-        # Rolls relay when its own ConfigMap changes (the annotation hashes
-        # hubble-relay/configmap.yaml, nothing else) — the relay counterpart of
-        # rollOutCiliumPods below. Certs are not the reason: the helm TLS method
-        # looks up hubble-relay-client-certs and reuses the existing leaf.
+        # Hashes hubble-relay/configmap.yaml only — not the TLS Secret, whose
+        # leaf the helm method reuses across upgrades.
         rollOutPods: true
         prometheus:
           enabled: true

--- a/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
@@ -1,14 +1,10 @@
 ---
-# The chart only writes the dashboards to ConfigMaps (labelled for the
-# kube-prometheus-stack sidecar we don't run); grafana-operator publishes them
-# only through these CRs. allowCrossNamespaceImport is required — the ConfigMaps
-# are here in kube-system, the Grafana instance is in observability.
+# allowCrossNamespaceImport is required: the ConfigMaps are in kube-system, the
+# Grafana instance is in observability.
 #
-# hubble-l7-http-metrics-by-workload is deliberately not published: it reads
-# hubble_http_*, which needs the httpV2 metric handler and therefore
-# envoy.enabled (see the HelmRelease). The `hubble` dashboard below carries an
-# HTTP row off the same metrics — expect it blank until then; the rest of that
-# dashboard is L3/L4 and populates now.
+# The chart's fourth dashboard, hubble-l7-http-metrics-by-workload, is left
+# unpublished — it is entirely hubble_http_*, which needs envoy.enabled. The
+# HTTP row on `hubble` below is blank for the same reason.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
@@ -5,8 +5,10 @@
 # are here in kube-system, the Grafana instance is in observability.
 #
 # hubble-l7-http-metrics-by-workload is deliberately not published: it reads
-# hubble_http_* , which needs the httpV2 metric handler and therefore
-# envoy.enabled (see the HelmRelease).
+# hubble_http_*, which needs the httpV2 metric handler and therefore
+# envoy.enabled (see the HelmRelease). The `hubble` dashboard below carries an
+# HTTP row off the same metrics — expect it blank until then; the rest of that
+# dashboard is L3/L4 and populates now.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
@@ -1,0 +1,59 @@
+---
+# The chart only writes the dashboards to ConfigMaps (labelled for the
+# kube-prometheus-stack sidecar we don't run); grafana-operator publishes them
+# only through these CRs. allowCrossNamespaceImport is required — the ConfigMaps
+# are here in kube-system, the Grafana instance is in observability.
+#
+# hubble-l7-http-metrics-by-workload is deliberately not published: it reads
+# hubble_http_* , which needs the httpV2 metric handler and therefore
+# envoy.enabled (see the HelmRelease).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hubble
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  allowCrossNamespaceImport: true
+  folder: Cilium
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: VictoriaMetrics
+  configMapRef:
+    name: hubble-dashboard
+    key: hubble-dashboard.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hubble-network-overview-namespace
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  allowCrossNamespaceImport: true
+  folder: Cilium
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: VictoriaMetrics
+  configMapRef:
+    name: hubble-network-overview-namespace
+    key: hubble-network-overview-namespace.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hubble-dns-namespace
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  allowCrossNamespaceImport: true
+  folder: Cilium
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: VictoriaMetrics
+  configMapRef:
+    name: hubble-dns-namespace
+    key: hubble-dns-namespace.json

--- a/kubernetes/apps/kube-system/cilium/hubble/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/httproute.yaml
@@ -1,0 +1,20 @@
+---
+# hubble-ui ships no authentication of its own — the SecurityPolicy from
+# components/oidc/envoy (attached by name to this route) is the only gate, so
+# this route must stay the single entrypoint. The service is created by the
+# cilium chart; hubble.ui.ingress stays disabled since we front it with Envoy
+# Gateway like everything else.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble
+spec:
+  hostnames:
+    - "hubble.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: hubble-ui
+          port: 80

--- a/kubernetes/apps/kube-system/cilium/hubble/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/httproute.yaml
@@ -1,9 +1,6 @@
 ---
-# hubble-ui ships no authentication of its own — the SecurityPolicy from
-# components/oidc/envoy (attached by name to this route) is the only gate, so
-# this route must stay the single entrypoint. The service is created by the
-# cilium chart; hubble.ui.ingress stays disabled since we front it with Envoy
-# Gateway like everything else.
+# hubble-ui has no auth of its own; the SecurityPolicy from
+# components/oidc/envoy attaches to this route by name and is the only gate.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/kube-system/cilium/hubble/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./httproute.yaml
+  - ./usergroup.yaml
+  - ./grafanadashboard.yaml

--- a/kubernetes/apps/kube-system/cilium/hubble/usergroup.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/usergroup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDUserGroup
+metadata:
+  name: hubble-users
+spec:
+  friendlyName: Hubble Users
+  allowedOIDCClients:
+    - name: hubble
+  users:
+    userRefs:
+      - name: david
+        namespace: security

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -34,6 +34,10 @@ spec:
     - name: cilium
     - name: pocket-id
       namespace: security
+    # Both of these are wait: false, so this orders the apply rather than
+    # guaranteeing the CRDs are established first.
+    - name: grafana-operator
+      namespace: observability
   components:
     - ../../../../components/oidc/envoy
   interval: 1h

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -20,3 +20,36 @@ spec:
     namespace: flux-system
   targetNamespace: kube-system
   wait: false
+---
+# Hubble's UI route and dashboards live in their own Kustomization on purpose:
+# they need the Pocket-ID and grafana-operator CRDs, and Flux validates a
+# Kustomization's manifests as a set — a missing CRD or a not-yet-reconciled IdP
+# would then block the CNI's own Kustomization from applying.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hubble
+spec:
+  dependsOn:
+    - name: cilium
+    - name: pocket-id
+      namespace: security
+  components:
+    - ../../../../components/oidc/envoy
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/cilium/hubble
+  postBuild:
+    substitute:
+      APP: *app
+      OIDC_APP_NAME: Hubble
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/cilium.svg"
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -21,10 +21,9 @@ spec:
   targetNamespace: kube-system
   wait: false
 ---
-# Hubble's UI route and dashboards live in their own Kustomization on purpose:
-# they need the Pocket-ID and grafana-operator CRDs, and Flux validates a
-# Kustomization's manifests as a set — a missing CRD or a not-yet-reconciled IdP
-# would then block the CNI's own Kustomization from applying.
+# Split from the CNI's Kustomization because these need the Pocket-ID and
+# grafana-operator CRDs, and Flux applies a Kustomization as a set — a missing
+# CRD here would otherwise block cilium itself.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -34,8 +33,8 @@ spec:
     - name: cilium
     - name: pocket-id
       namespace: security
-    # Both of these are wait: false, so this orders the apply rather than
-    # guaranteeing the CRDs are established first.
+    # Both are wait: false, so this orders the apply, it doesn't guarantee
+    # the CRDs are established.
     - name: grafana-operator
       namespace: observability
   components:


### PR DESCRIPTION
First checkbox of #1475. Nothing else on that issue can be verified until flows
are observable, so this lands on its own.

## What changes

**`kubernetes/apps/kube-system/cilium/app/helmrelease.yaml`**
- `hubble.enabled: true`, `hubble.relay.enabled: true`, `hubble.ui.enabled: true`.
- Six L3/L4 metric handlers (`dns`, `drop`, `flow`, `tcp`, `icmp`,
  `port-distribution`), each with
  `labelsContext=source_namespace,destination_namespace` and
  `source/destinationContext=workload-name|reserved-identity`. The contexts are
  not decoration: the bundled `*-namespace` dashboards filter on the namespace
  labels and group by `source`/`destination`, which only exist when those
  options are set. `workload-name|reserved-identity` keeps the two labels
  bounded — a workload name for in-cluster peers, otherwise `world`/`host`/
  `remote-node` rather than a series per IP.
- `httpV2` is deliberately absent. L7 metrics are only emitted for pods with
  Layer 7 visibility, which needs `envoy.enabled` — the next item on the issue.
- `relay.rollOutPods: true`. `hubble.tls.auto.method` is `helm`: the CA is
  reused from the existing `cilium-ca` Secret, but the leaf certs are reminted
  on every chart/values change, so relay must restart to pick up its client cert.
- ServiceMonitors for the agent metrics endpoint and for relay.

**New `hubble` Flux Kustomization** (`cilium/hubble/`) — HTTPRoute for
`hubble.${SECRET_DOMAIN}` on `envoy-internal`, gated by `components/oidc/envoy`
(hubble-ui ships no auth of its own), a `PocketIDUserGroup`, and three
`GrafanaDashboard` CRs pointing at the chart-generated ConfigMaps.

It is a separate Kustomization on purpose: it needs the Pocket-ID and
grafana-operator CRDs, and Flux validates a Kustomization's manifests as a set —
folding these into the CNI's own Kustomization would let a missing CRD or an
unreconciled IdP block cilium itself from applying.

`hubble-l7-http-metrics-by-workload` is not published; it reads `hubble_http_*`
and stays empty until envoy lands.

**hermes** — the `networkpolicy.yaml` note saying enforcement is unverifiable
because hubble is disabled is now the `hubble observe` command that verifies it.

## Rollout notes

- The agent DaemonSet rolls (`rollOutCiliumPods` was already set) — one node at
  a time, brief per-node control-plane gap, BPF state stays loaded.
- Cardinality: `dns:query` adds one series per queried name per source workload.
  Bounded here, but it is the first handler to drop if VMSingle gets unhappy.
- Verify after reconcile: `cilium status`, then
  `hubble observe --namespace ai-sandbox --verdict DROPPED` against hermes,
  whose default-deny egress policy has never been observed enforcing.

## Testing

`just test` — 183 passed. `helm template` of the chart at 1.20.1 with these
values renders clean (relay/UI/metrics Services, both ServiceMonitors, the four
dashboard ConfigMaps), and `flate build ks hubble` renders the route,
SecurityPolicy, OIDC client and user group as expected.

Not applied to the cluster; Flux will reconcile it on merge.

---

## Note on the rest of #1475: L7 policy is not blocked on `envoy.enabled`

Checked while sizing the second checkbox. `envoy.enabled` picks *where* Envoy
runs, not *whether* it exists — the 1.20.1 chart describes it as "Enable Envoy
Proxy in standalone **DaemonSet**", and the 1.20 Envoy docs say that with the
DaemonSet off "the Cilium agent starts an Envoy proxy as separate process within
the Cilium agent pod", which it does "when Cilium L7 functionality (Ingress,
Gateway API, Network Policies with L7 functionality, L7 Protocol Visibility) is
enabled". So `toPorts[].rules.http[]` already works against the cluster as it
stands.

- Item 2 is optional and gates nothing below it: the DaemonSet buys upgrade
  resilience (an agent restart no longer takes the L7 proxy with it), not
  capability.
- The streaming cost is narrower than the issue assumes — Envoy is inserted only
  for the endpoints and ports an L7 rule selects, not wholesale. What needs
  testing is each L7 policy, not the values flip.
- Item 4 (hermes `toFQDNs`) needs no Envoy at all: `rules.dns` is served by the
  agent's own DNS proxy (`dnsProxy.*`; `standaloneDnsProxy` is a separate alpha
  opt-in, off). It was only ever blocked on not knowing the domain set — which
  the `dns:query` handler in this PR answers.
- Item 5 (bifrost `/api/*` vs `/v1/*`) is unblocked once verdicts are
  observable.

(Also posted on #1475.)

