### PR TITLE
fix(k8s-gateway): serve DNS over TCP

### DIFF
--- a/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
@@ -18,4 +18,9 @@ spec:
       annotations:
         lbipam.cilium.io/ips: 10.0.42.128
       externalTrafficPolicy: Cluster
+      # Without this the Service publishes UDP only, so every TCP query to the
+      # VIP is dropped SERVICE_BACKEND_NOT_FOUND — including CoreDNS' fallback
+      # when a `forward crayon.club` response comes back truncated. The pod
+      # already serves TCP on 1053; only the port declarations were missing.
+      useTcp: true
     watchedResources: ["HTTPRoute", "Service"]


### PR DESCRIPTION
First thing Hubble caught, about an hour after #1522 landed.

## Symptom

~40 dropped SYNs per minute, continuously, for as long as the metrics go back:

```
10.0.42.4:45166 (remote-node) <> network/k8s-gateway:53 (ID:16777219) Service backend not found DROPPED (TCP Flags: SYN)
```

`sum(rate(hubble_drop_total{reason="SERVICE_BACKEND_NOT_FOUND"}[2m]))` sits at
0.5–0.9/s with no periodicity — a steady trickle, not a cron.

## Cause

`svc/k8s-gateway` published UDP only:

```
NAME          TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)
k8s-gateway   LoadBalancer   10.104.148.165   10.0.42.128   53:30366/UDP
```

CoreDNS forwards the domain at that VIP (`forward crayon.club 10.0.42.128`), and
DNS retries over TCP whenever a response comes back truncated. A TCP packet to a
Service with no TCP port has nowhere to go, so Cilium drops it —
`SERVICE_BACKEND_NOT_FOUND` is exactly that, and it fails silently: the resolver
just times out.

The pod was never the problem. Its CoreDNS listens on `.:1053`, which serves
both protocols; only the Service port and the containerPort declaration were
missing.

## Fix

`service.useTcp: true`. Rendered result — the Service gains a second port and
the container gains the matching declaration:

```yaml
ports:
- {name: dns-udp, port: 53, protocol: UDP, targetPort: dns-udp}
- {name: dns-tcp, port: 53, protocol: TCP, targetPort: dns-tcp}
```

## Verifying after merge

```
hubble observe --verdict DROPPED -f | grep k8s-gateway
```

should go quiet, and `hubble_drop_total{reason="SERVICE_BACKEND_NOT_FOUND"}`
should flatten.

## Follow-up worth considering, not done here

CoreDNS forwards to the **LoadBalancer** VIP rather than the ClusterIP, so
in-cluster queries for the domain leave through the node, get masqueraded, and
come back — which is also why the drop shows a `remote-node` source rather than
the CoreDNS pod. Pointing that `forward` at the ClusterIP or the in-cluster name
would keep it on the pod network. Separate change, separate blast radius.

`just test` — 183 passed.