### PR TITLE
feat(hermes): give DNS L7 visibility

### DIFF
--- a/kubernetes/apps/ai-sandbox/hermes/README.md
+++ b/kubernetes/apps/ai-sandbox/hermes/README.md
@@ -225,10 +225,12 @@ hermes pod, and run `hermes claw migrate --source <path>`.
   hourly (kopia dedupes them, so this is waste rather than breakage).
 - **Per-domain egress allowlist.** The policy still permits any public host on
   443/80. The tighter model is a `toFQDNs` allowlist of just the provider
-  domains the agent needs (`api.anthropic.com`, `*.openrouter.ai`, …). That
-  needs the CoreDNS egress rule upgraded to L7 (`rules: { dns: [{ matchPattern:
-  "*" }] }`) so Cilium's DNS proxy can learn the mappings — note that would be
-  the cluster's first L7 policy. Deferred until the needed domain set is known.
+  domains the agent needs (`api.anthropic.com`, `*.openrouter.ai`, …). The L7
+  DNS half of that is now in place — the CoreDNS rule carries `rules: { dns:
+  [{ matchPattern: "*" }] }`, the cluster's first L7 policy — so the proxy is
+  learning the mappings and hubble is recording them. What remains is reading
+  the domain set off `hubble_dns_queries_total` once it has run long enough to
+  be representative, then narrowing the `0.0.0.0/0` rule to it.
 - **Dedicated Gateway for pocket-id**, which would let the egress rule above
   name only the IdP's own Envoy pods instead of every route behind
   envoy-cloudflare. Out of scope here because it touches `security/pocket-id`

--- a/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
@@ -17,6 +17,11 @@ spec:
       app.kubernetes.io/name: hermes
   egress:
     # Cluster DNS (Helm-managed CoreDNS in kube-system).
+    #
+    # matchPattern "*" allows every name — this restricts nothing. It exists to
+    # put the agent's DNS proxy in the path, which is the only way hubble emits
+    # hubble_dns_* at all, so the toFQDNs allowlist (README, deferred) can be
+    # written from what hermes actually resolves rather than guessed.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -27,6 +32,9 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
     # Pocket-ID, reached through the envoy-cloudflare gateway that fronts it.
     #
     # This is new relative to openclaw and is the one real widening in this


### PR DESCRIPTION
Unblocks the `toFQDNs` item on #1475 by making the domain set observable. Also
the cluster's first L7 policy, deliberately on the smallest possible surface.

## Why

`hubble_dns_*` does not exist in VictoriaMetrics. Everything else the `#1522`
handlers emit is there — `hubble_flows_processed_total`, `drop_total`,
`tcp_flags_total`, `icmp_total`, `port_distribution_total` — but DNS metrics are
derived from *parsed L7 flows*, and those only exist where the agent's DNS proxy
sits in the path. Nothing gave it that, so `dns:query` has been recording
nothing.

The README's deferred item says the allowlist is blocked "until the needed
domain set is known". This is what makes it knowable.

## What

```yaml
          rules:
            dns:
              - matchPattern: "*"
```

on the existing kube-dns egress rule. `"*"` matches every name, so **no traffic
that resolves today stops resolving** — the change is that queries now traverse
the proxy and get recorded.

## Risk, stated honestly

This moves hermes' DNS from a pure L4 allow to a proxied path. The failure mode
if the proxy misbehaves is hermes losing name resolution — contained to one pod,
in the sandbox namespace, and revertible by deleting six lines. It is on the one
endpoint in the cluster whose egress policy was verified enforcing today:

```
hermes -> 10.0.42.3:6443 (kube-apiserver)  Policy denied DROPPED
hermes -> 10.0.42.1:443  (LAN/MikroTik)    Policy denied DROPPED
hermes -> api.anthropic.com                401 (reached)
hermes -> qwen3-8-27b-mtp.ai:8080          200
```

## After merge

Watch `sum by (query) (rate(hubble_dns_queries_total{source_namespace="ai-sandbox"}[1h]))`
for a few days. When it stops surfacing new names, that set becomes the
`toFQDNs` allowlist and the `0.0.0.0/0` egress rule narrows to it.

README's deferred entry updated to say what's now done and what's left.
`just test` — 183 passed.