### PR TITLE
fix(media): keep APP_PORT a string through substitution

### DIFF
--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -20,7 +20,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      APP_PORT: "6767"
+      APP_PORT: '"6767"'
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/bazarr.svg"
       OIDC_APP_NAME: Bazarr
       KOPIUR_CAPACITY: 5Gi

--- a/kubernetes/apps/media/components/api-only/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/media/components/api-only/ciliumnetworkpolicy.yaml
@@ -8,6 +8,11 @@
 # SecurityPolicy is — and direct pod-to-pod access is limited to /api, which
 # takes an API key. Requires ${APP} and ${APP_PORT}.
 #
+# ${APP_PORT} carries its own quotes (ks.yaml sets it to '"8989"' and so on).
+# The CRD types this port as a string, but kustomize re-emits a `"${APP_PORT}"`
+# scalar without the quotes, so substitution would otherwise yield a bare
+# number and the apply fails its dry-run.
+#
 # Local to this namespace rather than in kubernetes/components/: the sibling
 # rule below names `media` outright, so it isn't shared, and the *arr auth
 # behaviour it compensates for isn't either.
@@ -39,7 +44,7 @@ spec:
             gateway.envoyproxy.io/owning-gateway-name: envoy-internal
       toPorts:
         - ports:
-            - port: "${APP_PORT}"
+            - port: ${APP_PORT}
               protocol: TCP
     # Sibling apps in this namespace: API only. This is the *arr integration
     # traffic — indexer sync, download-client calls, recyclarr — which is all
@@ -53,7 +58,7 @@ spec:
             io.kubernetes.pod.namespace: media
       toPorts:
         - ports:
-            - port: "${APP_PORT}"
+            - port: ${APP_PORT}
               protocol: TCP
           rules:
             http:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -18,7 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      APP_PORT: "9696"
+      APP_PORT: '"9696"'
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/prowlarr.svg"
       OIDC_APP_NAME: Prowlarr
     substituteFrom:

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -20,7 +20,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      APP_PORT: "8080"
+      APP_PORT: '"8080"'
       SUBDOMAIN: qb
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/qbittorrent.svg"
       OIDC_APP_NAME: qBittorrent

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -21,7 +21,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      APP_PORT: "7878"
+      APP_PORT: '"7878"'
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/radarr.svg"
       OIDC_APP_NAME: Radarr
       KOPIUR_CAPACITY: 5Gi

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -20,7 +20,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      APP_PORT: "8080"
+      APP_PORT: '"8080"'
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/sabnzbd.svg"
       OIDC_APP_NAME: SABnzbd
       KOPIUR_CAPACITY: 5Gi

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -21,7 +21,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      APP_PORT: "8989"
+      APP_PORT: '"8989"'
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/sonarr.svg"
       OIDC_APP_NAME: Sonarr
       KOPIUR_CAPACITY: 5Gi


### PR DESCRIPTION
#1532 does not apply. `flux get kustomizations -n media`:

```
prowlarr  False  CiliumNetworkPolicy/media/prowlarr-api-only dry-run failed:
  .spec.ingress[1].toPorts[0].ports[0].port: expected string, got 9696
```

Fail-closed, so nothing was applied and no traffic is affected — but the six
policies are not in force, and prowlarr's Kustomization is stuck.

## Cause

Cilium types this port as a string. Flux's substitution is textual, so
`port: "${APP_PORT}"` with `APP_PORT: "9696"` looks like it yields `port:
"9696"`. It doesn't: **kustomize re-emits the scalar without quotes**, because
`${APP_PORT}` needs none as YAML. What reaches substitution is `port:
${APP_PORT}`, and the result is a bare number.

Fix is to put the quotes in the value, so they survive the round-trip:

```yaml
# ks.yaml
APP_PORT: '"9696"'
```
```yaml
# component
- port: ${APP_PORT}
```

## On the check that missed it

`flate build` showed `port: 8989` unquoted before #1532 merged. I read that as a
serializer artifact and "confirmed" it with a server-side dry-run of a file I
substituted by hand with `sed` — which of course passed, because it was not what
the pipeline produces. The render was telling the truth.

Both checks now run against flate's own output:

```
sonarr: -port:"8989"   radarr: -port:"7878"   prowlarr: -port:"9696"
sabnzbd: -port:"8080"  bazarr: -port:"6767"   qbittorrent: -port:"8080"

$ for a in ...; do flate build ks $a | <extract CNP> | kubectl apply --dry-run=server -f -; done
ciliumnetworkpolicy.cilium.io/sonarr-api-only created (server dry run)
ciliumnetworkpolicy.cilium.io/radarr-api-only created (server dry run)
ciliumnetworkpolicy.cilium.io/prowlarr-api-only created (server dry run)
ciliumnetworkpolicy.cilium.io/sabnzbd-api-only created (server dry run)
ciliumnetworkpolicy.cilium.io/bazarr-api-only created (server dry run)
ciliumnetworkpolicy.cilium.io/qbittorrent-api-only created (server dry run)
```

`just test` — 183 passed.