### PR TITLE
fix(cilium): drop the unbounded dns query label

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -40,11 +40,12 @@ spec:
         # contexts — they filter on the namespace labels and group by
         # source/destination. httpV2 is absent: it needs envoy.enabled.
         #
-        # dns:query is the one unbounded label (a series per resolved name).
-        # It stays because it supplies the domain set for hermes' toFQDNs
-        # allowlist; drop it first if vmsingle sheds rows.
+        # No `query` option on the dns handler: it labels every series with the
+        # resolved name, which is unbounded. Re-add it temporarily when the
+        # hermes toFQDNs allowlist (#1475) is being written — that is the only
+        # thing that needs it, and hermes is parked.
         enabled:
-          - "dns:query;labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "dns:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "drop:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "flow:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "tcp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"

--- a/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
@@ -5,6 +5,11 @@
 # The chart's fourth dashboard, hubble-l7-http-metrics-by-workload, is left
 # unpublished — it is entirely hubble_http_*, which needs envoy.enabled. The
 # HTTP row on `hubble` below is blank for the same reason.
+#
+# Expect one more blank panel: hubble-dns-namespace's "Top 10 DNS queries"
+# groups `by (query)`, a label the dns handler only emits with its `query`
+# option, which the HelmRelease leaves off as unbounded. The rest of that
+# dashboard reads volume and rcodes and works.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:


### PR DESCRIPTION
`dns:query` labels every series with the resolved name — one series per name per
source workload, growing without limit. It went in with #1522 for one reason:
to supply the domain set for hermes' `toFQDNs` allowlist. That work is parked,
and likely permanently, since hermes may just be given open internet access
instead — so the label is now cost with no consumer.

```diff
-- "dns:query;labelsContext=…"
+- "dns:labelsContext=…"
```

The handler itself stays. Query volume, qtype and rcode per workload are all
bounded and useful; only the per-name breakdown goes.

## What this costs

`hubble-dns-namespace`'s **"Top 10 DNS queries"** panel groups `by (query)` and
will render empty. Noted in `grafanadashboard.yaml` so it reads as expected
rather than as a broken import — the same treatment the HTTP row already has.
The dashboard's other three panels (query rate, missing responses, DNS errors)
are unaffected.

Per-name detail is still available live — `hubble observe --protocol dns` shows
the query on each flow, as verified on hermes earlier today — just not retained.
If that history is ever wanted, `hubble.export.static` writing flow logs into
VictoriaLogs is the right home for it, not a metric label.

Re-add `query` temporarily if the allowlist is ever written.

`just test` — 183 passed.