### PR TITLE
feat(cilium): run envoy as a standalone daemonset

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -30,7 +30,16 @@ spec:
     endpointRoutes:
       enabled: true
     envoy:
-      enabled: false
+      # Run the L7 proxy as a standalone DaemonSet rather than as a process
+      # inside the agent pod, so an agent restart no longer takes the proxy
+      # down with it. Not a capability gate: L7 policy and the DNS proxy work
+      # either way, and Envoy is only inserted for the endpoints and ports an
+      # L7 rule selects.
+      enabled: true
+      rollOutPods: true
+      prometheus:
+        serviceMonitor:
+          enabled: true
     gatewayAPI:
       enabled: false
     hubble:
@@ -38,7 +47,9 @@ spec:
       metrics:
         # The bundled *-namespace dashboards render empty without these
         # contexts — they filter on the namespace labels and group by
-        # source/destination. httpV2 is absent: it needs envoy.enabled.
+        # source/destination. httpV2 is absent: it only reports flows an L7
+        # HTTP rule redirects through the proxy, so today it would cover
+        # media's /api component and nothing else.
         #
         # No `query` option on the dns handler: it labels every series with the
         # resolved name, which is unbounded. Re-add it temporarily when the

--- a/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
@@ -3,8 +3,9 @@
 # Grafana instance is in observability.
 #
 # The chart's fourth dashboard, hubble-l7-http-metrics-by-workload, is left
-# unpublished — it is entirely hubble_http_*, which needs envoy.enabled. The
-# HTTP row on `hubble` below is blank for the same reason.
+# unpublished — it is entirely hubble_http_*, which needs the httpV2 metric
+# handler the HelmRelease leaves off. The HTTP row on `hubble` below is blank
+# for the same reason.
 #
 # Expect one more blank panel: hubble-dns-namespace's "Top 10 DNS queries"
 # groups `by (query)`, a label the dns handler only emits with its `query`


### PR DESCRIPTION
Second checkbox of #1475.

`envoy.enabled` selects *where* the L7 proxy runs, not whether it exists — with
it off, the agent starts Envoy as a process inside its own pod. Flipping it on
is an availability change, not a capability one: an agent restart no longer
takes the proxy down with it.

## What changes

**`kubernetes/apps/kube-system/cilium/app/helmrelease.yaml`**
- `envoy.enabled: true`. Adds the `cilium-envoy` DaemonSet, Service,
  ServiceAccount and bootstrap ConfigMap; nothing else in the render moves.
- `envoy.rollOutPods: true`, matching `rollOutCiliumPods` / `operator.rollOutPods`
  / `relay.rollOutPods`. The DaemonSet gets a
  `cilium.io/cilium-envoy-configmap-checksum` pod annotation so a bootstrap
  change restarts it.
- `envoy.prometheus.serviceMonitor.enabled: true`. Envoy metrics have never been
  scraped: the agent exposed 9964 but only the `metrics` port had a
  ServiceMonitor. The new `cilium-envoy` ServiceMonitor carries no selector
  label, which is fine — VictoriaMetrics runs `selectAllByDefault: true`.
- The `httpV2` comment. It said the handler "needs `envoy.enabled`". It doesn't;
  it needs an L7 HTTP rule to redirect flows through the proxy, which today is
  only `media/components/api-only`.

**`kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml`**
- Same correction for `hubble-l7-http-metrics-by-workload`, still unpublished.

## Rendered diff (helm template, 1.20.1)

`cilium-config`:
- `external-envoy-proxy: "false"` → `"true"`
- `proxy-prometheus-port: "9964"` dropped — envoy now serves its own metrics

`cilium` DaemonSet:
- loses the `envoy-metrics` container port (9964, hostPort)
- gains a `/var/run/cilium/envoy/sockets` hostPath mount to reach the sidecar-
  less proxy

`cilium-agent` Service:
- loses the `envoy-metrics` port; `cilium-envoy` Service serves it instead

## Rollout notes

- 9964 is a `hostPort` on both the old agent pods and the new envoy pods, so an
  envoy pod cannot schedule on a node until that node's agent has rolled to the
  spec without it. Self-resolving; expect envoy to be Pending briefly.
- Existing L7 policy — the media `/api` rules and hermes' `rules.dns` — is
  reprogrammed onto the new proxy as the agents roll. Expect a short window
  where hermes' DNS proxy redirect is being re-established.
- The Kustomization is `wait: false`, so Flux will not block on any of this.

## Not in scope

`httpV2` is still off. It is now genuinely available (media has L7 HTTP rules),
and its labels are bounded — method/protocol/status/reporter, no path — but
adding a metric handler is the same call as #1534 and is left as its own
decision.
