### PR TITLE
feat(cilium): export hubble L7 HTTP metrics

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -47,9 +47,14 @@ spec:
       metrics:
         # The bundled *-namespace dashboards render empty without these
         # contexts — they filter on the namespace labels and group by
-        # source/destination. httpV2 is absent: it only reports flows an L7
-        # HTTP rule redirects through the proxy, so today it would cover
-        # media's /api component and nothing else.
+        # source/destination.
+        #
+        # httpV2 carries a wider labelsContext than the rest on purpose: its
+        # dashboard groups by source_workload/destination_workload, and the
+        # `source`/`destination` labels sourceContext emits do not satisfy that
+        # despite holding the same value. It only sees flows an L7 HTTP rule
+        # puts through the proxy — today just the sibling-to-sibling half of
+        # media's api-only component.
         #
         # No `query` option on the dns handler: it labels every series with the
         # resolved name, which is unbounded. Re-add it temporarily when the
@@ -57,6 +62,7 @@ spec:
         # thing that needs it, and hermes is parked.
         enabled:
           - "dns:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+          - "httpV2:labelsContext=source_namespace,source_workload,destination_namespace,destination_workload;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "drop:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "flow:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
           - "tcp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"

--- a/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/grafanadashboard.yaml
@@ -2,10 +2,9 @@
 # allowCrossNamespaceImport is required: the ConfigMaps are in kube-system, the
 # Grafana instance is in observability.
 #
-# The chart's fourth dashboard, hubble-l7-http-metrics-by-workload, is left
-# unpublished — it is entirely hubble_http_*, which needs the httpV2 metric
-# handler the HelmRelease leaves off. The HTTP row on `hubble` below is blank
-# for the same reason.
+# The HTTP row on `hubble` stays blank even now that httpV2 is on: it reads
+# hubble_http_responses_total and groups by a bare `pod` label, and httpV2
+# emits neither — that row was written for the older `http` handler.
 #
 # Expect one more blank panel: hubble-dns-namespace's "Top 10 DNS queries"
 # groups `by (query)`, a label the dns handler only emits with its `query`
@@ -61,3 +60,20 @@ spec:
   configMapRef:
     name: hubble-dns-namespace
     key: hubble-dns-namespace.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hubble-l7-http-metrics-by-workload
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  allowCrossNamespaceImport: true
+  folder: Cilium
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: VictoriaMetrics
+  configMapRef:
+    name: hubble-l7-http-metrics-by-workload
+    key: hubble-l7-http-metrics-by-workload.json


### PR DESCRIPTION
Follows #1537, now rebased onto `main` as a single commit. It edits comments
that PR introduced, but is not a dependency of it: `httpV2` never needed
`envoy.enabled`, it needs an L7 HTTP rule — the same correction as the issue's.

## What changes

**`.../cilium/app/helmrelease.yaml`** — adds the `httpV2` metric handler.

**`.../cilium/hubble/grafanadashboard.yaml`** — publishes
`hubble-l7-http-metrics-by-workload`, the last of the chart's four dashboards
left unpublished.

## Why it's cheap

Envoy already writes L7 access logs to the agent (`envoy.log.accessLogEnabled`
defaults on). This only decides whether they become Prometheus series — there is
no new proxying and no new datapath cost.

Cardinality is the opposite of #1534's case. `dns:query` was one series per
resolved name, unbounded by construction. `httpV2` has **no path or URL label**:
method, protocol, status, reporter, and the workload pair. Six workloads and a
handful of statuses.

## What it actually measures

Only flows an L7 HTTP rule redirects through the proxy. Today that is the
sibling-to-sibling rule in `media/components/api-only` — \*arr integration
traffic (indexer sync, download-client calls, recyclarr) across bazarr,
prowlarr, qbittorrent, radarr, sabnzbd, sonarr.

The LAN/gateway rule in that same policy is deliberately L4, specifically to
keep the proxy off the websocket and SSE paths, so gateway traffic contributes
nothing here. The dashboard will look sparse. That is correct, not broken.

## Two label details

`httpV2` gets a wider `labelsContext` than the other six handlers —
`source_workload`/`destination_workload` on top of the namespaces. Its dashboard
groups by those names, and the `source`/`destination` labels `sourceContext`
emits hold the same value under a name the queries don't match. Mildly redundant,
but it's what makes the panels resolve.

The HTTP row on the `hubble` dashboard **stays blank regardless**. It reads
`hubble_http_responses_total` and groups by a bare `pod` label; `httpV2` emits
neither, and `pod` isn't an available context label at all (`source_pod` /
`destination_pod` are). That row targets the older `http` handler. The comment
now says that rather than blaming the missing handler.

## Verification

`just test` → 183 passed. Rendered against 1.20.1: the handler lands in
`cilium-config`'s `hubble-metrics`, and all four `GrafanaDashboard` CRs resolve
to ConfigMaps the chart actually emits.
