### PR TITLE
feat(oidc): default-deny ingress for forward-auth apps

### DIFF
--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -44,6 +44,10 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      # The workload this Kustomization fronts is hubble-ui, deployed by the
+      # cilium chart next door; ${APP} is `hubble` for the OIDC client's sake.
+      # components/oidc/envoy's default-deny needs the pod's real name label.
+      NETPOL_APP: hubble-ui
       OIDC_APP_NAME: Hubble
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/cilium.svg"
     substituteFrom:

--- a/kubernetes/apps/media/components/api-only/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/media/components/api-only/ciliumnetworkpolicy.yaml
@@ -1,21 +1,17 @@
 ---
-# Closes the in-cluster bypass (#1476): these apps set AUTH__REQUIRED to
-# DisabledForLocalAddresses and count all of 10.0.0.0/8 as local, so every pod
-# in the cluster reached their UI with no authentication at all. The Envoy OIDC
-# SecurityPolicy only ever sat on the LAN path.
-#
-# After this, the UI is reachable only through the gateway — where that
-# SecurityPolicy is — and direct pod-to-pod access is limited to /api, which
-# takes an API key. Requires ${APP} and ${APP_PORT}.
+# The in-cluster exception to components/oidc/envoy's default-deny (#1476):
+# sibling *arr apps integrate with each other pod-to-pod, and that traffic must
+# keep working without opening the UI back up. Cilium unions ingress across
+# policies selecting the same endpoint, so this only adds. Requires ${APP} and
+# ${APP_PORT}.
 #
 # ${APP_PORT} carries its own quotes (ks.yaml sets it to '"8989"' and so on).
 # The CRD types this port as a string, but kustomize re-emits a `"${APP_PORT}"`
 # scalar without the quotes, so substitution would otherwise yield a bare
 # number and the apply fails its dry-run.
 #
-# Local to this namespace rather than in kubernetes/components/: the sibling
-# rule below names `media` outright, so it isn't shared, and the *arr auth
-# behaviour it compensates for isn't either.
+# Local to this namespace rather than in kubernetes/components/: the rule below
+# names `media` outright, so it isn't shared.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -25,27 +21,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: ${APP}
   ingress:
-    # Kubelet probes. `host` covers the node the pod runs on; talos0 needs
-    # kube-apiserver too, because the control plane shares the node IP and
-    # Cilium resolves that address to the apiserver identity, not to host.
-    - fromEntities:
-        - host
-        - remote-node
-        - kube-apiserver
-        - health
-    # The LAN path. Deliberately L4 — no http rules — for two reasons: the
-    # OIDC SecurityPolicy on the catch-all HTTPRoute is already the gate here,
-    # and keeping Cilium's proxy out of this path leaves the UI's websocket and
-    # SSE streams alone.
-    - fromEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: network
-            gateway.envoyproxy.io/owning-gateway-namespace: network
-            gateway.envoyproxy.io/owning-gateway-name: envoy-internal
-      toPorts:
-        - ports:
-            - port: ${APP_PORT}
-              protocol: TCP
     # Sibling apps in this namespace: API only. This is the *arr integration
     # traffic — indexer sync, download-client calls, recyclarr — which is all
     # /api and all API-keyed. The UI is not reachable on this path.
@@ -66,6 +41,3 @@ spec:
               # Root-level health endpoint the *arr apps expose alongside the
               # API; connection tests between them use it. Returns status only.
               - path: "/ping"
-    # Anything else in the cluster is denied outright. A pod in another
-    # namespace that wants the API goes through the gateway's /api route like
-    # any other client; that route is exempt from OIDC by design.

--- a/kubernetes/components/oidc/variants/envoy/ciliumnetworkpolicy.yaml
+++ b/kubernetes/components/oidc/variants/envoy/ciliumnetworkpolicy.yaml
@@ -1,0 +1,36 @@
+---
+# The SecurityPolicy next to this file is only a gate if the pod can't be
+# reached around it. Ingress here is default-deny except the gateway that
+# carries the OIDC filter, so forward auth cannot be bypassed from inside the
+# cluster (#1476). Apps needing an in-cluster exception add a second, additive
+# CNP — see kubernetes/apps/media/components/api-only.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ${APP}-envoy-only
+spec:
+  endpointSelector:
+    matchLabels:
+      # ${NETPOL_APP} exists for pods whose name label isn't ${APP} — hubble-ui
+      # is served by the `hubble` Kustomization. A selector that matches
+      # nothing is a silently inert policy, not an error.
+      app.kubernetes.io/name: ${NETPOL_APP:=${APP}}
+  ingress:
+    # Kubelet probes. `host` covers the node the pod runs on; talos0 needs
+    # kube-apiserver too, because the control plane shares the node IP and
+    # Cilium resolves that address to the apiserver identity, not to host.
+    - fromEntities:
+        - host
+        - remote-node
+        - kube-apiserver
+        - health
+    # Deliberately L4 with no port constraint: Envoy only forwards to ports an
+    # HTTPRoute backendRef names, so narrowing here buys nothing and would
+    # force every consumer to declare one. No http rules either — the
+    # SecurityPolicy is already the gate, and keeping Cilium's proxy off this
+    # path leaves websocket and SSE streams alone.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            gateway.envoyproxy.io/owning-gateway-namespace: network
+            gateway.envoyproxy.io/owning-gateway-name: ${NETPOL_GATEWAY:=envoy-internal}

--- a/kubernetes/components/oidc/variants/envoy/kustomization.yaml
+++ b/kubernetes/components/oidc/variants/envoy/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - securitypolicy.yaml
+  - ciliumnetworkpolicy.yaml


### PR DESCRIPTION
Extends #1532 from the six media apps to **every** app behind `components/oidc/envoy`, and moves the control into the component itself so it arrives with the gate instead of being opted into per app.

Newly covered: **orcaslicer** and **hubble**. orcaslicer is the pod that demonstrated the original bypass in #1476.

## What changed

- **`components/oidc/envoy` gains a CiliumNetworkPolicy** — default-deny ingress, allowing kubelet probes and the gateway pods that carry the OIDC filter, nothing else.
- **`media/components/api-only` slims to its exception** — the sibling `/api` + `/ping` rule. Cilium unions ingress across policies selecting the same endpoint, so the shared policy supplies probes + envoy and this one adds the media path.
- **`NETPOL_APP: hubble-ui`** on the hubble Kustomization.

## Two decisions worth review

**The shared envoy rule is portless.** Envoy only forwards to ports an HTTPRoute `backendRef` names, so a port constraint narrows nothing real, and requiring one would force every consumer to declare it — orcaslicer sets no `containerPort` at all. This is a technical widening for the media six, which previously pinned the gateway to `${APP_PORT}`. That variable and its quoting workaround (#1533) survive only in `api-only`, where the L7 rule genuinely needs them.

**hubble needed a selector override.** Its pod label is `app.kubernetes.io/name=hubble-ui` while `${APP}` is `hubble` for the OIDC client's sake. A CNP whose `endpointSelector` matches nothing is *inert, not an error* — without `NETPOL_APP` this would have looked applied and enforced nothing.

## Verification

- 7 days of Hubble data (`hubble_tcp_flags_total{flag="SYN"}`) for the two new targets. **hubble-ui**: `reserved:host` (6007) and namespace `network` (51). **orcaslicer**: `reserved:kube-apiserver` (6014) — the talos0 case where the control plane shares the node IP and Cilium resolves it to the apiserver identity rather than `host`. Nothing else in the cluster reaches either.
- `just test` — 180 pass; the 2 warnings are pre-existing (offline `cluster-secrets`).
- All 14 rendered policies accepted by a server-side dry-run against the live cluster.

## Residual risk

orcaslicer logged **zero** gateway-sourced flows in 7 days, so its envoy path is correct by construction but unexercised in the data — worth loading it in a browser after this reconciles. Any surprise shows up as `hubble observe --namespace maker --verdict DROPPED`. Rollback is one line in the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)