### PR TITLE
fix(oidc): make the forward-auth netpol components compose safely

### DIFF
--- a/kubernetes/apps/media/components/api-only/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/media/components/api-only/ciliumnetworkpolicy.yaml
@@ -21,6 +21,16 @@ spec:
     matchLabels:
       app.kubernetes.io/name: ${APP}
   ingress:
+    # Duplicated from components/oidc/envoy so this component is safe on its
+    # own: any ingress rule flips the endpoint to default-deny, so without a
+    # probe allowance an app that dropped the oidc component would fail its
+    # kubelet probes and never go Ready — silently, since these Kustomizations
+    # are wait: false. Cilium unions the rules, so pairing them costs nothing.
+    - fromEntities:
+        - host
+        - remote-node
+        - kube-apiserver
+        - health
     # Sibling apps in this namespace: API only. This is the *arr integration
     # traffic — indexer sync, download-client calls, recyclarr — which is all
     # /api and all API-keyed. The UI is not reachable on this path.

--- a/kubernetes/components/oidc/variants/envoy/ciliumnetworkpolicy.yaml
+++ b/kubernetes/components/oidc/variants/envoy/ciliumnetworkpolicy.yaml
@@ -1,9 +1,11 @@
 ---
 # The SecurityPolicy next to this file is only a gate if the pod can't be
 # reached around it. Ingress here is default-deny except the gateway that
-# carries the OIDC filter, so forward auth cannot be bypassed from inside the
-# cluster (#1476). Apps needing an in-cluster exception add a second, additive
-# CNP — see kubernetes/apps/media/components/api-only.
+# carries the OIDC filter, so an ordinary pod can't bypass forward auth
+# (#1476). Node identities are still allowed unconditionally below, so a
+# hostNetwork pod would keep a way in — there are none today. Apps needing an
+# in-cluster exception add a second, additive CNP — see
+# kubernetes/apps/media/components/api-only.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -33,4 +35,8 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             gateway.envoyproxy.io/owning-gateway-namespace: network
+            # Every consumer is on envoy-internal today. An app routed via
+            # envoy-cloudflare or envoy-towonel must override this or the
+            # policy denies its only path in — it fails closed, so the symptom
+            # is an unreachable app rather than an open one.
             gateway.envoyproxy.io/owning-gateway-name: ${NETPOL_GATEWAY:=envoy-internal}


### PR DESCRIPTION
Review follow-ups from #1539. No behavior change for anything deployed today — all six media apps carry both components, so the restored rule is a no-op there. This is about the components being safe to use apart.

## The real one: `api-only` was left standalone-unsafe

#1539 moved the probe and gateway rules out of `media/components/api-only` and into `components/oidc/envoy`. That made `api-only` unsafe on its own, because **any** ingress rule flips the endpoint to default-deny — an app carrying `api-only` without the oidc component fails its kubelet probes and never goes Ready.

It fails *silently*: these Kustomizations are `wait: false`, so Flux reports success while the pod sits unready. Nothing enforces the pairing; the two are independent entries in each `ks.yaml`.

Restoring the `fromEntities` rule fixes it. Cilium unions ingress across policies selecting the same endpoint, so where both components are present this changes nothing.

## Two comment corrections

**The header overclaimed.** It said forward auth "cannot be bypassed from inside the cluster." `host` and `remote-node` grant unconditional all-port ingress to anything holding a node identity, which in Cilium includes any `hostNetwork: true` pod. There are none today and nothing prevents one, so the comment now says what the policy actually delivers.

**`NETPOL_GATEWAY` needed a warning.** The `envoy-internal` default is right for all eight current consumers, but the repo has three gateways. An app added to `components/oidc/envoy` while routed via `envoy-cloudflare` or `envoy-towonel` gets denied its only path in, and `just test` can't catch it — the CNP renders and applies fine. It fails closed, so the symptom is an unreachable app rather than an open one, but it's an easy trap for the next consumer.

## Deliberately not included

**Dropping `remote-node` from the probe allowance.** The argument is sound — kubelet probes are always node-local and cross-node liveness is covered by `health` — but that block is inherited verbatim from #1532 and has been enforcing in production since it merged. Tightening it is a separate change that deserves its own drop-watch, not a rider here.

**A guard against the fail-open selector.** `${NETPOL_APP:=${APP}}` fails open silently: typo the override and `just test`, the server-side dry-run, and Flux all stay green while the app is unauthenticated to every pod in the cluster. This is the sharpest remaining edge on the design. The fix is a static check asserting each rendered `-envoy-only` selector matches a pod template in the same output, in the style of `scripts/check-external-secrets.sh` — a new script, and better as its own PR.

## Verification

`just test` passes 180/180, and the revised policies clear a server-side dry-run against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)