### PR TITLE
fix(litellm): land on the admin UI instead of Swagger

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -70,6 +70,14 @@ spec:
     - name: CHATGPT_TOKEN_DIR
       value: /var/lib/litellm/chatgpt
 
+    # Swagger is served at / by default, and litellm only registers the root
+    # redirect when DOCS_URL is off "/" — so moving the docs is what makes
+    # ROOT_REDIRECT_URL take effect, not just an aesthetic choice.
+    - name: DOCS_URL
+      value: /docs
+    - name: ROOT_REDIRECT_URL
+      value: /ui
+
     # /ui SSO against pocket-id via litellm's "generic" OIDC provider, which has
     # no discovery-document path — hence the endpoints wired individually out of
     # the Secret the pocket-id operator writes. Who may log in is gated at


### PR DESCRIPTION
## Problem

`https://litellm.${SECRET_DOMAIN}` opens the Swagger API reference instead of the admin dashboard.

## Cause

litellm's `_get_docs_url()` (`litellm/proxy/utils.py`) defaults `DOCS_URL` to `"/"`, so FastAPI mounts Swagger at the root.

The root-redirect handler is guarded:

```python
docs_url: Final = _get_docs_url()
root_redirect_url: Final[str | None] = os.getenv("ROOT_REDIRECT_URL")
if docs_url != "/" and root_redirect_url is not None:

    @app.get("/", include_in_schema=False)
    async def root_redirect():
        return RedirectResponse(url=root_redirect_url)
```

So setting `ROOT_REDIRECT_URL` on its own is a silent no-op — moving the docs off `/` is what arms it.

## Change

Set both env vars on the `LiteLLMProxy`:

- `DOCS_URL: /docs`
- `ROOT_REDIRECT_URL: /ui`

`/` now redirects to the dashboard; Swagger stays reachable at `/docs`.

## Verification

- Source read from the running pod (`litellm-non_root:v1.98.0`) to confirm the guard and the `/ui` mount point.
- `just test` — 180 passed (the 2 warnings are the pre-existing offline `cluster-secrets` ones).

Inline env change, so the operator's Deployment update rolls the pod once Flux applies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)