### PR TITLE
feat(oidc): reach pocket-id at its Service instead of through the gateway

### DIFF
--- a/kubernetes/apps/ai-sandbox/hermes/README.md
+++ b/kubernetes/apps/ai-sandbox/hermes/README.md
@@ -37,12 +37,19 @@ for what actually changed.
   See [Authentication](#authentication).
 - **Pinned to `talos1`** (worker, has the gVisor extension); never the
   control-plane / GPU host `talos0`.
-- **Egress is default-deny** (`app/networkpolicy.yaml`): cluster DNS, the
-  envoy-cloudflare gateway pods (for Pocket-ID — see below), a short allowlist
-  of named in-cluster services (the Qwen model, memini, and the SearXNG MCP
-  proxy — via Cilium `toServices`), and the *public* internet (private /
-  link-local CIDRs excluded). kube-apiserver, the rest of the LAN, and every
-  other namespace/service are unreachable.
+- **Egress is default-deny** (`app/networkpolicy.yaml`): cluster DNS, two named
+  in-cluster services via Cilium `toServices` (`svc/litellm` in `ai`, and
+  `svc/pocket-id` in `security` for the dashboard's own OIDC — see below), and
+  the *public* internet (private / link-local CIDRs excluded). kube-apiserver,
+  the rest of the LAN, and every other namespace/service are unreachable — the
+  models, memini, and the MCP servers included. Anything in-cluster the agent
+  gets, it gets through the LiteLLM proxy.
+
+  Note the IdP is reached at its *Service*, not through the gateway that fronts
+  it. That depends on the cluster-wide CoreDNS rewrite of
+  `pocket-id.${SECRET_DOMAIN}` (`apps/kube-system/coredns`) plus Pocket-ID
+  terminating TLS in-pod; without both, this rule resolves to the shared
+  envoy-cloudflare VIP and login fails.
 
 ### The uid is not a free choice
 
@@ -165,23 +172,31 @@ kubectl -n ai-sandbox exec -it deploy/hermes -- hermes setup
 ```
 
 The dashboard is at `https://hermes.${SECRET_DOMAIN}/`, behind a Pocket-ID
-login. To point the agent at the in-cluster Qwen model instead of an external
-provider (reachable per the egress policy):
+login. To point the agent at an in-cluster model instead of an external
+provider, go through LiteLLM — the model services themselves are not reachable
+from the sandbox:
 
 ```sh
 kubectl -n ai-sandbox exec -it deploy/hermes -- sh -c '
   hermes config set model.provider custom
   hermes config set model.default qwen3-8-27b-mtp
-  hermes config set model.base_url http://qwen3-8-27b-mtp.ai:8080/v1
+  hermes config set model.base_url http://litellm.ai.svc.cluster.local:4000/v1
+  hermes config set model.api_key sk-...
   hermes config set model.context_length 262144
 '
 ```
 
-`api_key` needs to be any non-empty string — llama.cpp requires the header but
-doesn't validate it. Note this is a one-shot exec against the PVC rather than
-openclaw's every-boot config-patch script: Hermes persists config properly and
-doesn't rewrite it out from under us, so the self-healing patch loop openclaw
-needed isn't warranted here.
+Use the **fully qualified** name. `http://litellm.ai:4000/v1` — the short form
+used elsewhere in this repo — is a trap here: the pod runs `ndots: 1`, so a
+name containing a dot resolves as absolute first, and `litellm.ai` is a real
+public domain. The egress policy drops it (public egress is 443/80 only), so it
+fails rather than leaks, but confusingly.
+
+Unlike llama.cpp, LiteLLM validates `api_key`, so it needs a real virtual key.
+Note this is a one-shot exec against the PVC rather than openclaw's every-boot
+config-patch script: Hermes persists config properly and doesn't rewrite it out
+from under us, so the self-healing patch loop openclaw needed isn't warranted
+here.
 
 > **Unattended gateways should enable tool-loop hard stops.**
 > `tool_loop_guardrails.hard_stop_enabled` defaults to `false`, which only makes

--- a/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
@@ -1,7 +1,7 @@
 ---
 # Default-deny egress for hermes. The pod runs untrusted / prompt-injected
 # agent code (gVisor-sandboxed), so this is the control that contains a
-# breakout: the pod may reach DNS, Pocket-ID, the in-cluster LLMs, and the
+# breakout: the pod may reach DNS, Pocket-ID, the LiteLLM proxy, and the
 # public internet, but NOT the Kubernetes API, the rest of the LAN, or other
 # in-cluster services.
 #
@@ -35,85 +35,49 @@ spec:
           rules:
             dns:
               - matchPattern: "*"
-    # Pocket-ID, reached through the envoy-cloudflare gateway that fronts it.
+    # The in-cluster services hermes may reach, named directly — NOT the whole
+    # `ai` or `security` namespace. `toServices` resolves each Service to its
+    # current backend pods (with kube-proxy replacement Cilium handles the
+    # ClusterIP->pod translation), so this follows the Service's own endpoint
+    # selector and self-heals if a chart bump relabels pods.
     #
-    # This is new relative to openclaw and is the one real widening in this
-    # policy. openclaw never spoke to the IdP itself — the Envoy forward-auth
-    # filter did, out in the network namespace. Hermes authenticates its own
-    # dashboard, so the POD has to reach the issuer server-side for OIDC
-    # discovery, the token exchange, and the JWKS fetch.
-    #
-    # This selects the gateway PODS, not the hostname, and that is deliberate:
-    # `pocket-id.${SECRET_DOMAIN}` resolves (via k8s-gateway) to the
-    # envoy-cloudflare LoadBalancer VIP, and with kube-proxy replacement Cilium
+    # Matching an ingress hostname instead would be worse on two counts: it
+    # resolves to a SHARED gateway VIP that fronts every route, and Cilium
     # DNATs a service VIP to its backend pod BEFORE resolving the destination
-    # identity for policy. So the policy engine only ever sees the gateway pod's
-    # identity — a `toFQDNs` or `toCIDR` rule on the VIP would never match. Same
-    # reason the `toServices` rule below is written the way it is.
+    # identity, so a `toFQDNs` or `toCIDR` rule on that VIP never matches.
     #
-    # SCOPE, honestly stated: Envoy routes by Host header, so allowing the
-    # gateway pod transitively allows every route behind envoy-cloudflare, not
-    # just Pocket-ID. There is no way to narrow this at L3/L4 while the IdP
-    # shares a gateway — tightening it means giving pocket-id its own Gateway.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: network
-            gateway.envoyproxy.io/owning-gateway-namespace: network
-            gateway.envoyproxy.io/owning-gateway-name: envoy-cloudflare
-      toPorts:
-        - ports:
-            # 10443, NOT 443. Envoy Gateway shifts privileged listener ports by
-            # +10000 (svc/envoy-cloudflare is `443 -> targetPort 10443`), and the
-            # DNAT described above happens BEFORE the policy verdict — so what
-            # this rule sees is the backend port, not the service port. A "443"
-            # here matches nothing and silently drops every server-side OIDC
-            # call. (The kube-dns rule above gets to say 53 only because that
-            # Service is genuinely 53 -> 53.)
-            - port: "10443"
-              protocol: TCP
-    # In-cluster services hermes is allowed to reach, named directly — NOT the
-    # whole `ai` namespace, which also runs the embedding/reranker models and the
-    # other MCP servers that hermes must not reach. `toServices` resolves each
-    # Service to its current backend pods (with kube-proxy replacement Cilium
-    # handles the ClusterIP->pod translation), so this follows the Service's own
-    # endpoint selector and self-heals if llmkube/ToolHive relabel pods on a chart
-    # bump. (Matching the `qwen.${SECRET_DOMAIN}` ingress hostname would be worse —
-    # it resolves to the SHARED envoy-internal gateway IP that fronts every route.)
-    #
-    # NOTE: `toServices` can't be paired with `toPorts`, so this allows whatever
-    # ports the backends expose. qwen and the searxng proxy are 8080-only; memini
-    # also exposes :9090 (metrics), which hermes can therefore reach. Acceptable
-    # for a sandbox allowlist. (Verify with `hubble observe --namespace
-    # ai-sandbox --verdict DROPPED`.)
+    # NOTE: `toServices` can't be paired with `toPorts`, so this allows every
+    # port the backends expose — svc/litellm is 4000-only, but pocket-id also
+    # carries :9464 (metrics). Acceptable for a sandbox allowlist. (Verify with
+    # `hubble observe --namespace ai-sandbox --verdict DROPPED`.)
     - toServices:
-        # Qwen chat model (llmkube), reached at http://qwen3-8-27b-mtp.ai:8080/v1.
+        # LiteLLM proxy. Everything the agent calls goes through it, so LiteLLM
+        # is the enforcement point for which models it gets, not this policy.
         - k8sService:
-            serviceName: qwen3-8-27b-mtp
+            serviceName: litellm
             namespace: ai
-        # memini memory API.
+        # Pocket-ID. Hermes authenticates its own dashboard, so the POD reaches
+        # the issuer server-side for OIDC discovery, the token exchange, and
+        # the JWKS fetch. This is a direct hit on the IdP Service rather than
+        # on the gateway that fronts it: CoreDNS rewrites
+        # `pocket-id.${SECRET_DOMAIN}` to this Service cluster-wide, and the
+        # pod terminates TLS itself. Going via envoy-cloudflare instead would
+        # transitively allow every route behind that gateway.
         - k8sService:
-            serviceName: memini
-            namespace: ai
-        # SearXNG MCP server — the proxy is the endpoint clients connect to
-        # (the HTTPRoute backs mcp-mcp-searxng-proxy, not mcp-mcp-searxng).
-        - k8sService:
-            serviceName: mcp-mcp-searxng-proxy
-            namespace: ai
+            serviceName: pocket-id
+            namespace: security
     # Public internet only. NOTE: Cilium's `world` entity also covers RFC1918
     # LAN hosts (the MikroTik at 10.0.42.1, other homelab devices), so we use a
     # CIDR allow that explicitly excludes private + link-local ranges. This
     # keeps kube-apiserver, the pod/service CIDRs, other namespaces, and the LAN
     # unreachable while still permitting external egress (e.g. Anthropic API,
-    # agent web access). The one deliberate hole in the private ranges is the
-    # envoy-cloudflare rule above.
+    # agent web access). The only holes in the private ranges are the
+    # `toServices` entries above.
     #
     # FUTURE HARDENING (see README "Deferred follow-ups"): replace this broad
-    # 0.0.0.0/0 rule with a `toFQDNs` allowlist of only the provider domains the
-    # agent actually needs. That additionally requires upgrading the CoreDNS rule
-    # above to L7 (add `rules: { dns: [{ matchPattern: "*" }] }` under its
-    # toPorts) so Cilium's DNS proxy can learn the name->IP mappings. Note this
-    # would be the cluster's first L7 policy. Deferred until the needed domain
-    # set is known.
+    # 0.0.0.0/0 rule with a `toFQDNs` allowlist of only the domains the agent
+    # actually needs. The L7 DNS rule above is already in place to feed it;
+    # deferred until the needed domain set is known.
     - toCIDRSet:
         - cidr: 0.0.0.0/0
           except:

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -44,6 +44,21 @@ spec:
           # dials fine there.
           # - name: autopath
           #   parameters: "@kubernetes"
+          # Split-horizon for the IdP. Without this, in-cluster OIDC clients
+          # resolve pocket-id via k8s-gateway to the envoy-cloudflare VIP, so
+          # every one of them needs an egress rule allowing those gateway pods
+          # — which transitively grants it every route behind that gateway.
+          # Sending the name straight at the Service makes `toServices` on
+          # pocket-id the whole allowance. External resolution is unaffected:
+          # it never passes through here.
+          #
+          # Placement is cosmetic — CoreDNS orders plugins by its own build,
+          # and rewrite always runs before kubernetes/forward.
+          - name: rewrite
+            parameters: stop
+            configBlock: |-
+              name exact pocket-id.${SECRET_DOMAIN} pocket-id.security.svc.cluster.local
+              answer auto
           - name: forward
             parameters: ${SECRET_DOMAIN} 10.0.42.128
           - name: forward

--- a/kubernetes/apps/security/pocket-id/instance/backendtlspolicy.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/backendtlspolicy.yaml
@@ -1,0 +1,20 @@
+---
+# The pod terminates TLS itself (spec.tls on the instance), so the gateway's
+# hop to the backend is HTTPS, not plaintext. Without this the external route
+# breaks: Envoy would speak cleartext to a TLS listener.
+#
+# `hostname` is the SNI Envoy sends and the name it validates — it must match
+# the cert's dnsName, not the Service name.
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: pocket-id
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: pocket-id
+      sectionName: http
+  validation:
+    hostname: "pocket-id.${SECRET_DOMAIN}"
+    wellKnownCACertificates: System

--- a/kubernetes/apps/security/pocket-id/instance/certificate.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/certificate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pocket-id
+spec:
+  secretName: pocket-id-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "pocket-id.${SECRET_DOMAIN}"
+  dnsNames: ["pocket-id.${SECRET_DOMAIN}"]

--- a/kubernetes/apps/security/pocket-id/instance/instance.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/instance.yaml
@@ -40,6 +40,52 @@ spec:
   auditLogRetentionDays: 180
 
   appUrl: "https://pocket-id.${SECRET_DOMAIN}"
+
+  # Terminate TLS in the pod rather than only at the gateway. This is what lets
+  # in-cluster clients reach the issuer directly: CoreDNS rewrites
+  # `pocket-id.${SECRET_DOMAIN}` to this Service, and the OIDC issuer is an
+  # https:// URL, so the Service itself has to answer TLS under that name.
+  # Consequences elsewhere: the gateway's backend hop needs the
+  # BackendTLSPolicy, and the probes below need scheme HTTPS.
+  tls:
+    secretRef:
+      name: pocket-id-tls
+
+  # Adds 443 alongside the operator's 1411 so the issuer URL needs no port.
+  # The operator owns the http/metrics ports; extra ports are merged in.
+  serviceTemplate:
+    spec:
+      ports:
+        - name: https
+          port: 443
+          targetPort: 1411
+          protocol: TCP
+
+  # Restated only to flip scheme to HTTPS — the pod no longer serves cleartext
+  # on 1411, and an HTTP probe against it fails, so the pod would never go
+  # ready. Thresholds match the operator's defaults; kubelet does not verify
+  # the cert on an HTTPS probe, so the pod-IP/hostname mismatch is fine.
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: 1411
+      scheme: HTTPS
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    httpGet:
+      path: /readyz
+      port: 1411
+      scheme: HTTPS
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 5
+
   route:
     enabled: true
     parentRefs:

--- a/kubernetes/apps/security/pocket-id/instance/instance.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/instance.yaml
@@ -54,12 +54,11 @@ spec:
   # Adds 443 alongside the operator's 1411 so the issuer URL needs no port.
   # The operator owns the http/metrics ports; extra ports are merged in.
   serviceTemplate:
-    spec:
-      ports:
-        - name: https
-          port: 443
-          targetPort: 1411
-          protocol: TCP
+    ports:
+      - name: https
+        port: 443
+        targetPort: 1411
+        protocol: TCP
 
   # Restated only to flip scheme to HTTPS — the pod no longer serves cleartext
   # on 1411, and an HTTP probe against it fails, so the pod would never go

--- a/kubernetes/apps/security/pocket-id/instance/kustomization.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./backendtlspolicy.yaml
+  - ./certificate.yaml
   - ./externalsecret.yaml
   - ./instance.yaml
   - ./pocketid-user.yaml


### PR DESCRIPTION
## Why

In-cluster, `pocket-id.${SECRET_DOMAIN}` resolved via k8s-gateway to the envoy-cloudflare LoadBalancer VIP. That was never an egress off the LAN — but because Envoy routes by `Host` header, any app whose egress policy allowed those gateway pods transitively reached **every route behind that gateway**. The cost was policy blast radius, and it grew with each app that gained a netpol.

## What

CoreDNS now rewrites the name to `pocket-id.security.svc.cluster.local` cluster-wide, so in-cluster OIDC clients hit the IdP Service directly and a single `toServices` entry is the whole allowance. External resolution never passes through CoreDNS, so the public path, the Cloudflare tunnel, and the external HTTPRoute are untouched.

The issuer is an `https://` URL and has to stay one — clients pin the `iss` claim against it, and hermes' OIDC plugin rejects a non-https issuer outright — so the Service itself has to answer TLS under that name:

- Pocket-ID terminates TLS in-pod from a cert-manager cert for the hostname.
- The Service gains `443 -> 1411` so the issuer URL needs no port.
- Probes are restated with `scheme: HTTPS`. The operator defaults them to HTTP on 1411; left alone they fail against a TLS listener and the pod never goes ready.
- A `BackendTLSPolicy` covers the gateway's backend hop, which is now HTTPS.

hermes drops its envoy-cloudflare rule for a direct `toServices` on pocket-id. Its allowlist also narrows to litellm alone — qwen, memini and the searxng MCP proxy are gone, so the proxy is the enforcement point for which models the sandbox gets rather than the policy.

## Verified on the branch

Deployed via `just flux-branch` and tested live.

From inside the hermes pod:

```
200   https://pocket-id.crayon.club/.well-known/openid-configuration
200   http://litellm.ai.svc.cluster.local:4000/health/liveliness
FAIL  timed out — http://qwen3-8-27b-mtp.ai:8080/v1/models
```

The 200 goes straight to the Service via the rewrite with a validated cert; the qwen timeout confirms the policy enforces rather than merely permits.

Nothing else regressed: `pocket-id` returns 200 externally through Cloudflare, the forward-auth apps that depend on the IdP (`hubble`, `prowlarr`, `radarr`) all return 200, and every Kustomization in the cluster is ready. Discovery still advertises the public `issuer` / `token_endpoint` / `jwks_uri`, so `iss` pinning is unaffected.

The CoreDNS `rewrite` block was also validated standalone on CoreDNS 1.14.7 before deploying — it parses, and `answer auto` returns the original query name against the pocket-id ClusterIP.

## Rollout note

The branch test took ~17 minutes of IdP downtime, because the pod's startup is gated on a **first-time** DNS-01 cert: cert-manager runs `--dns01-recursive-nameservers-only` against 1.1.1.1, which had cached NXDOMAIN for the challenge record, and `crayon.club`'s SOA minimum is 1800s.

That should **not** repeat on merge — the `pocket-id-tls` Secret survived the branch teardown (Flux owned the Certificate, not the Secret), so cert-manager will find a valid Secret and go Ready without a new ACME order. If it is ever re-issued from scratch, expect up to 30 minutes, or reuse the existing `*.${SECRET_DOMAIN}` wildcard via reflector instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)