### PR TITLE
feat(flux): serve the domain from a ConfigMap as DOMAIN

### DIFF
--- a/kubernetes/apps/ai-sandbox/hermes/README.md
+++ b/kubernetes/apps/ai-sandbox/hermes/README.md
@@ -47,7 +47,7 @@ for what actually changed.
 
   Note the IdP is reached at its *Service*, not through the gateway that fronts
   it. That depends on the cluster-wide CoreDNS rewrite of
-  `pocket-id.${SECRET_DOMAIN}` (`apps/kube-system/coredns`) plus Pocket-ID
+  `pocket-id.${DOMAIN}` (`apps/kube-system/coredns`) plus Pocket-ID
   terminating TLS in-pod; without both, this rule resolves to the shared
   envoy-cloudflare VIP and login fails.
 
@@ -103,7 +103,7 @@ Because the pod now authenticates itself, it needs to reach the issuer
 server-side — for discovery, the token exchange, and the JWKS fetch. That took
 a new egress rule, and the obvious form of it does not work:
 
-`pocket-id.${SECRET_DOMAIN}` resolves (via k8s-gateway) to the
+`pocket-id.${DOMAIN}` resolves (via k8s-gateway) to the
 **envoy-cloudflare** LoadBalancer VIP — not envoy-internal, which fronts hermes
 itself. With Cilium's kube-proxy replacement, a service VIP is DNAT'd to its
 backend pod *before* the destination identity is resolved for policy, so the
@@ -171,7 +171,7 @@ Provider API keys are therefore *not* in an ESO-managed Secret — they live in
 kubectl -n ai-sandbox exec -it deploy/hermes -- hermes setup
 ```
 
-The dashboard is at `https://hermes.${SECRET_DOMAIN}/`, behind a Pocket-ID
+The dashboard is at `https://hermes.${DOMAIN}/`, behind a Pocket-ID
 login. To point the agent at an in-cluster model instead of an external
 provider, go through LiteLLM — the model services themselves are not reachable
 from the sandbox:
@@ -281,7 +281,7 @@ Can't be verified from manifests:
       browser tools) is the most likely thing to complain.
 - [ ] **`config` PVC is writable** by uid 10000 at `/opt/data` under
       `fsGroup: 10000` on OpenEBS-ZFS.
-- [ ] **OIDC works end-to-end**: `https://hermes.${SECRET_DOMAIN}/` redirects to
+- [ ] **OIDC works end-to-end**: `https://hermes.${DOMAIN}/` redirects to
       Pocket-ID and back to `/auth/callback`. A failure here is a pod that never
       goes ready (fail-closed), so check pod logs for the specific missing-env
       error before touching Pocket-ID.
@@ -295,5 +295,5 @@ Can't be verified from manifests:
 - [ ] Agent can reach the in-cluster LLM (`ai` :8080) and the public internet.
 - [ ] Negative check: from inside the pod, kube-apiserver and a LAN host
       (e.g. 10.0.42.1) are **unreachable**; DNS still resolves; and
-      `pocket-id.${SECRET_DOMAIN}` IS reachable.
+      `pocket-id.${DOMAIN}` IS reachable.
 - [ ] **`/dev/shm` is 1Gi** and browser tools work.

--- a/kubernetes/apps/ai-sandbox/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/app/helmrelease.yaml
@@ -77,12 +77,12 @@ spec:
               # Public origin, used to reconstruct the OIDC redirect_uri behind
               # the Envoy gateway. Without it the callback would be built from
               # the pod-internal host and Pocket-ID would reject the redirect.
-              HERMES_DASHBOARD_PUBLIC_URL: "https://hermes.${SECRET_DOMAIN}"
+              HERMES_DASHBOARD_PUBLIC_URL: "https://hermes.${DOMAIN}"
               # Self-hosted OIDC against Pocket-ID (plugins/dashboard_auth/self_hosted).
               # A non-loopback bind fails CLOSED unless an auth provider is
               # registered, so these three are load-bearing: get them wrong and
               # the dashboard refuses to start rather than serving unauthenticated.
-              HERMES_DASHBOARD_OIDC_ISSUER: "https://pocket-id.${SECRET_DOMAIN}"
+              HERMES_DASHBOARD_OIDC_ISSUER: "https://pocket-id.${DOMAIN}"
               HERMES_DASHBOARD_OIDC_CLIENT_ID:
                 valueFrom:
                   secretKeyRef:
@@ -168,7 +168,7 @@ spec:
       internal:
         enabled: true
         hostnames:
-          - "hermes.${SECRET_DOMAIN}"
+          - "hermes.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/app/networkpolicy.yaml
@@ -60,7 +60,7 @@ spec:
         # the issuer server-side for OIDC discovery, the token exchange, and
         # the JWKS fetch. This is a direct hit on the IdP Service rather than
         # on the gateway that fronts it: CoreDNS rewrites
-        # `pocket-id.${SECRET_DOMAIN}` to this Service cluster-wide, and the
+        # `pocket-id.${DOMAIN}` to this Service cluster-wide, and the
         # pod terminates TLS itself. Going via envoy-cloudflare instead would
         # transitively allow every route behind that gateway.
         - k8sService:

--- a/kubernetes/apps/ai-sandbox/hermes/ks.yaml
+++ b/kubernetes/apps/ai-sandbox/hermes/ks.yaml
@@ -50,6 +50,8 @@ spec:
       KOPIUR_UID: "10000"
       KOPIUR_GID: "10000"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/ai-sandbox/kustomization.yaml
+++ b/kubernetes/apps/ai-sandbox/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai-sandbox
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./hermes/ks.yaml

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   # - ./llama-cpp/ks.yaml

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -66,6 +68,8 @@ spec:
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -94,6 +98,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -126,6 +132,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/ai/litellm/proxy/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/proxy.yaml
@@ -83,7 +83,7 @@ spec:
     # the Secret the pocket-id operator writes. Who may log in is gated at
     # pocket-id by the litellm-users group (usergroup.yaml), not here.
     - name: PROXY_BASE_URL
-      value: "https://litellm.${SECRET_DOMAIN}"
+      value: "https://litellm.${DOMAIN}"
     - name: GENERIC_CLIENT_ID
       valueFrom:
         secretKeyRef:
@@ -144,7 +144,7 @@ spec:
 
   route:
     hostnames:
-      - "litellm.${SECRET_DOMAIN}"
+      - "litellm.${DOMAIN}"
     parentRefs:
       - name: envoy-internal
         namespace: network

--- a/kubernetes/apps/ai/llama-cpp/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-cpp/app/helmrelease.yaml
@@ -106,7 +106,7 @@ spec:
     route:
       ? *app
       : hostnames:
-          - "llama.${SECRET_DOMAIN}"
+          - "llama.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/ai/llama-cpp/ks.yaml
+++ b/kubernetes/apps/ai/llama-cpp/ks.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -36,6 +38,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   dependsOn:

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-27b-mtp.yaml
@@ -119,7 +119,7 @@ metadata:
   name: qwen3-8-27b-mtp
 spec:
   hostnames:
-    - "qwen.${SECRET_DOMAIN}"
+    - "qwen.${DOMAIN}"
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
       ui:
         enabled: true
         hostnames:
-          - "memini.${SECRET_DOMAIN}"
+          - "memini.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -21,6 +21,8 @@ spec:
       KOPIUR_UID: "65532"
       KOPIUR_GID: "65532"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
               tag: 2026.8.28-a30b2d474@sha256:addd2cf36efb4b9815a2820a522aef7cce4da0d1c0e4527f6675f5663332fc9b
             env:
               SEARXNG_PORT: &port 8080
-              SEARXNG_BASE_URL: https://search.${SECRET_DOMAIN}
+              SEARXNG_BASE_URL: https://search.${DOMAIN}
               SEARXNG_VALKEY_URL: valkey://searxng-valkey.ai.svc.cluster.local:6379/0
             envFrom:
               - secretRef:
@@ -83,7 +83,7 @@ spec:
     route:
       *app :
         hostnames:
-          - "search.${SECRET_DOMAIN}"
+          - "search.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/ai/searxng/ks.yaml
+++ b/kubernetes/apps/ai/searxng/ks.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -34,6 +36,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   dependsOn:
@@ -57,6 +61,8 @@ spec:
   path: ./kubernetes/apps/ai/toolhive/mcp-servers
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   dependsOn:

--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/httproute.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/httproute.yaml
@@ -5,7 +5,7 @@ metadata:
   name: mcp-searxng
 spec:
   hostnames:
-    - "search-mcp.${SECRET_DOMAIN}"
+    - "search-mcp.${DOMAIN}"
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
@@ -15,4 +15,4 @@ spec:
               name: cert-manager-secret
               key: api-token
         selector:
-          dnsZones: ["${SECRET_DOMAIN}"]
+          dnsZones: ["${DOMAIN}"]

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -24,6 +24,8 @@ spec:
   path: ./kubernetes/apps/cert-manager/cert-manager/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -13,6 +13,8 @@ spec:
   path: ./kubernetes/apps/database/cloudnative-pg/operator
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -37,6 +39,8 @@ spec:
   path: ./kubernetes/apps/database/cloudnative-pg/cluster
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -60,6 +64,8 @@ spec:
   path: ./kubernetes/apps/database/cloudnative-pg/plugin-barman-cloud
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: database
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
           - port: http
     route:
       app:
-        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        hostnames: ["{{ .Release.Name }}.${DOMAIN}"]
         parentRefs:
           - name: envoy-cloudflare
             namespace: network

--- a/kubernetes/apps/default/echo/ks.yaml
+++ b/kubernetes/apps/default/echo/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/default/echo/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/documents/kustomization.yaml
+++ b/kubernetes/apps/documents/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: documents
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/documents/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/documents/paperless/app/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
               tag: 3.1.0
             env:
               # host
-              PAPERLESS_URL: https://paperless.${SECRET_DOMAIN}
+              PAPERLESS_URL: https://paperless.${DOMAIN}
               PAPERLESS_PORT: &port 8000
 
               PAPERLESS_SECRET_KEY:
@@ -163,7 +163,7 @@ spec:
     route:
       paperless:
         hostnames:
-          - "paperless.${SECRET_DOMAIN}"
+          - "paperless.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/documents/paperless/ks.yaml
+++ b/kubernetes/apps/documents/paperless/ks.yaml
@@ -28,6 +28,8 @@ spec:
       KOPIUR_UID: "4001"
       KOPIUR_GID: "4001"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
       - name: paperless-oidc-credentials

--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml

--- a/kubernetes/apps/finance/actual/app/helmrelease.yaml
+++ b/kubernetes/apps/finance/actual/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
                   secretKeyRef:
                     name: *oidcSecret
                     key: OIDC_CLIENT_SECRET
-              ACTUAL_OPENID_SERVER_HOSTNAME: "https://actual.${SECRET_DOMAIN}"
+              ACTUAL_OPENID_SERVER_HOSTNAME: "https://actual.${DOMAIN}"
             probes:
               liveness:
                 enabled: true
@@ -80,7 +80,7 @@ spec:
     route:
       ? *app
       : hostnames:
-          - "actual.${SECRET_DOMAIN}"
+          - "actual.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/finance/actual/ks.yaml
+++ b/kubernetes/apps/finance/actual/ks.yaml
@@ -24,6 +24,8 @@ spec:
       KOPIUR_UID: "1000"
       KOPIUR_GID: "1000"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/finance/kustomization.yaml
+++ b/kubernetes/apps/finance/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: finance
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./actual/ks.yaml

--- a/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
@@ -4,7 +4,7 @@ kind: HTTPRoute
 metadata:
   name: github-webhook
 spec:
-  hostnames: ["flux-webhook.${SECRET_DOMAIN}"]
+  hostnames: ["flux-webhook.${DOMAIN}"]
   parentRefs:
     - name: envoy-cloudflare
       namespace: network

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -12,6 +12,8 @@ spec:
   path: ./kubernetes/apps/flux-system/flux-instance/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       networkPolicy:
         create: false
       config:
-        baseURL: "https://flux.${SECRET_DOMAIN}"
+        baseURL: "https://flux.${DOMAIN}"
         authentication:
           type: OAuth2
           oauth2:

--- a/kubernetes/apps/flux-system/flux-operator/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/httproute.yaml
@@ -4,7 +4,7 @@ kind: HTTPRoute
 metadata:
   name: flux-operator
 spec:
-  hostnames: ["flux.${SECRET_DOMAIN}"]
+  hostnames: ["flux.${DOMAIN}"]
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -18,6 +18,8 @@ spec:
       APP_ICON_URL: "https://raw.githubusercontent.com/fluxcd/website/refs/heads/main/assets/icons/logo.svg"
       OIDC_APP_NAME: Flux Operator
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
       - name: flux-operator-oidc-credentials

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       verifyImages: true
       prComments: true
       statusChecks: true
-      publicUrl: https://konflate.${SECRET_DOMAIN}
+      publicUrl: https://konflate.${DOMAIN}
     secret:
       existingSecret: konflate-secret
     deploymentAnnotations:
@@ -27,7 +27,7 @@ spec:
           namespace: network
           sectionName: https
       hostnames:
-        - konflate.${SECRET_DOMAIN}
+        - konflate.${DOMAIN}
     resources:
       limits:
         memory: 2Gi

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/flux-system/konflate/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/games/games-on-whales/ks.yaml
+++ b/kubernetes/apps/games/games-on-whales/ks.yaml
@@ -45,6 +45,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   sourceRef:

--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: games
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./games-on-whales/ks.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -47,6 +47,8 @@ spec:
   path: ./kubernetes/apps/kopiur-system/kopiur/repository
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kopiur-system
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/kube-system/cilium/hubble/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/hubble/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
   name: hubble
 spec:
   hostnames:
-    - "hubble.${SECRET_DOMAIN}"
+    - "hubble.${DOMAIN}"
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/cilium/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -51,6 +53,8 @@ spec:
       OIDC_APP_NAME: Hubble
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/cilium.svg"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -57,10 +57,10 @@ spec:
           - name: rewrite
             parameters: stop
             configBlock: |-
-              name exact pocket-id.${SECRET_DOMAIN} pocket-id.security.svc.cluster.local
+              name exact pocket-id.${DOMAIN} pocket-id.security.svc.cluster.local
               answer auto
           - name: forward
-            parameters: ${SECRET_DOMAIN} 10.0.42.128
+            parameters: ${DOMAIN} 10.0.42.128
           - name: forward
             parameters: . /etc/resolv.conf
           - name: cache

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/coredns/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/intel-gpu-resource-driver/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/metrics-server/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kube-system/reflector/ks.yaml
+++ b/kubernetes/apps/kube-system/reflector/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/reflector/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/reloader/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/kube-system/snapshot-controller/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/maker/kustomization.yaml
+++ b/kubernetes/apps/maker/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: maker
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./orcaslicer/ks.yaml

--- a/kubernetes/apps/maker/orcaslicer/app/helmrelease.yaml
+++ b/kubernetes/apps/maker/orcaslicer/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
     route:
       *app :
         hostnames:
-          - "orcaslicer.${SECRET_DOMAIN}"
+          - "orcaslicer.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/maker/orcaslicer/ks.yaml
+++ b/kubernetes/apps/maker/orcaslicer/ks.yaml
@@ -25,6 +25,8 @@ spec:
       KOPIUR_UID: "911"
       KOPIUR_GID: "911"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
     route:
       *app :
         hostnames:
-          - &host "bazarr.${SECRET_DOMAIN}"
+          - &host "bazarr.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -27,6 +27,8 @@ spec:
       KOPIUR_UID: "4009"
       KOPIUR_GID: "4009"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
     route:
       jellyfin:
         hostnames:
-          - "jellyfin.${SECRET_DOMAIN}"
+          - "jellyfin.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -19,6 +19,8 @@ spec:
       KOPIUR_UID: "4006"
       KOPIUR_GID: "4006"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./bazarr/ks.yaml

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -83,7 +83,7 @@ spec:
     route:
       *app :
         hostnames:
-          - &host "prowlarr.${SECRET_DOMAIN}"
+          - &host "prowlarr.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -22,6 +22,8 @@ spec:
       APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/prowlarr.svg"
       OIDC_APP_NAME: Prowlarr
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -141,7 +141,7 @@ spec:
     route:
       *app :
         hostnames:
-          - &host qb.${SECRET_DOMAIN}
+          - &host qb.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -28,6 +28,8 @@ spec:
       KOPIUR_UID: "4005"
       KOPIUR_GID: "4005"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -84,7 +84,7 @@ spec:
     route:
       *app :
         hostnames:
-          - &host "radarr.${SECRET_DOMAIN}"
+          - &host "radarr.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -28,6 +28,8 @@ spec:
       KOPIUR_UID: "4010"
       KOPIUR_GID: "4010"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       KOPIUR_UID: "1000"
       KOPIUR_GID: "1000"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
                 sabnzbd.media.svc,
                 sabnzbd.media.svc.cluster,
                 sabnzbd.media.svc.cluster.local,
-                sabnzbd.${SECRET_DOMAIN}
+                sabnzbd.${DOMAIN}
               SABNZBD__API_KEY:
                 valueFrom:
                   secretKeyRef:
@@ -88,7 +88,7 @@ spec:
     route:
       *app :
         hostnames:
-          - &host "sabnzbd.${SECRET_DOMAIN}"
+          - &host "sabnzbd.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -27,6 +27,8 @@ spec:
       KOPIUR_UID: "4008"
       KOPIUR_GID: "4008"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
     route:
       *app :
         hostnames:
-          - "seerr.${SECRET_DOMAIN}"
+          - "seerr.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -21,6 +21,8 @@ spec:
       KOPIUR_UID: "1000"
       KOPIUR_GID: "1000"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -84,7 +84,7 @@ spec:
     route:
       *app :
         hostnames:
-          - &host "sonarr.${SECRET_DOMAIN}"
+          - &host "sonarr.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -28,8 +28,10 @@ spec:
       KOPIUR_UID: "4007"
       KOPIUR_GID: "4007"
     substituteFrom:
-    - name: cluster-secrets
-      kind: Secret
+      - name: cluster-global-config
+        kind: ConfigMap
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease-proxied.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease-proxied.yaml
@@ -29,7 +29,7 @@ spec:
     sources: ["crd", "gateway-httproute"]
     txtPrefix: k8s.
     txtOwnerId: default
-    domainFilters: ["${SECRET_DOMAIN}"]
+    domainFilters: ["${DOMAIN}"]
     serviceMonitor:
       enabled: true
     podAnnotations:

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease-unproxied.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease-unproxied.yaml
@@ -35,7 +35,7 @@ spec:
     # Distinct owner id so this instance and cloudflare-dns-proxied don't fight
     # over each other's records (they manage disjoint gateways/hostnames).
     txtOwnerId: unproxied
-    domainFilters: ["${SECRET_DOMAIN}"]
+    domainFilters: ["${DOMAIN}"]
     serviceMonitor:
       enabled: true
     podAnnotations:

--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/network/cloudflare-dns/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
@@ -5,6 +5,6 @@ metadata:
   name: cloudflare-tunnel
 spec:
   endpoints:
-    - dnsName: "cloudflare.${SECRET_DOMAIN}"
+    - dnsName: "cloudflare.${DOMAIN}"
       recordType: CNAME
       targets: ["${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com"]

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -72,15 +72,15 @@ spec:
             ingress:
               # Apex domain — the wildcard below does NOT match the bare apex, so
               # an explicit rule is required (e.g. Matrix /.well-known delegation).
-              - hostname: "${SECRET_DOMAIN}"
+              - hostname: "${DOMAIN}"
                 originRequest:
                   http2Origin: true
-                  originServerName: cloudflare.${SECRET_DOMAIN}
+                  originServerName: cloudflare.${DOMAIN}
                 service: https://envoy-cloudflare.{{ .Release.Namespace }}.svc.cluster.local:443
-              - hostname: "*.${SECRET_DOMAIN}"
+              - hostname: "*.${DOMAIN}"
                 originRequest:
                   http2Origin: true
-                  originServerName: cloudflare.${SECRET_DOMAIN}
+                  originServerName: cloudflare.${DOMAIN}
                 service: https://envoy-cloudflare.{{ .Release.Namespace }}.svc.cluster.local:443
               - service: http_status:404
     persistence:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/network/cloudflare-tunnel/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/network/envoy-gateway/app/certificate.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/certificate.yaml
@@ -2,11 +2,11 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: "${SECRET_DOMAIN/./-}-production"
+  name: "${DOMAIN/./-}-production"
 spec:
-  secretName: "${SECRET_DOMAIN/./-}-production-tls"
+  secretName: "${DOMAIN/./-}-production-tls"
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: "${SECRET_DOMAIN}"
-  dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
+  commonName: "${DOMAIN}"
+  dnsNames: ["${DOMAIN}", "*.${DOMAIN}"]

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -46,12 +46,12 @@ kind: Gateway
 metadata:
   name: envoy-cloudflare
   annotations:
-    external-dns.alpha.kubernetes.io/target: cloudflare.${SECRET_DOMAIN}
+    external-dns.alpha.kubernetes.io/target: cloudflare.${DOMAIN}
 spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: cloudflare.${SECRET_DOMAIN}
+      external-dns.alpha.kubernetes.io/hostname: cloudflare.${DOMAIN}
       lbipam.cilium.io/ips: "10.0.42.130"
   listeners:
     - name: http
@@ -69,19 +69,19 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: ${SECRET_DOMAIN/./-}-production-tls
+            name: ${DOMAIN/./-}-production-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: envoy-internal
   annotations:
-    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+    external-dns.alpha.kubernetes.io/target: internal.${DOMAIN}
 spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: internal.${SECRET_DOMAIN}
+      external-dns.alpha.kubernetes.io/hostname: internal.${DOMAIN}
       lbipam.cilium.io/ips: "10.0.42.129"
   listeners:
     - name: http
@@ -99,7 +99,7 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: ${SECRET_DOMAIN/./-}-production-tls
+            name: ${DOMAIN/./-}-production-tls
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -109,7 +109,7 @@ metadata:
     # DNS for routes on this gateway is managed by the cloudflare-dns-unproxied
     # external-dns instance (--gateway-name=envoy-towonel), which defaults to
     # DNS-only (no --cloudflare-proxied) so traffic reaches the VPS relay direct.
-    external-dns.alpha.kubernetes.io/target: towonel.${SECRET_DOMAIN}
+    external-dns.alpha.kubernetes.io/target: towonel.${DOMAIN}
 spec:
   gatewayClassName: envoy
   infrastructure:
@@ -131,7 +131,7 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: ${SECRET_DOMAIN/./-}-production-tls
+            name: ${DOMAIN/./-}-production-tls
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/network/envoy-gateway/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   interval: 1h
   values:
     fullnameOverride: k8s-gateway
-    domain: "${SECRET_DOMAIN}"
+    domain: "${DOMAIN}"
     ttl: 1
     service:
       type: LoadBalancer

--- a/kubernetes/apps/network/k8s-gateway/ks.yaml
+++ b/kubernetes/apps/network/k8s-gateway/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/network/k8s-gateway/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: network
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/network/towonel-agent/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/dnsendpoint.yaml
@@ -5,7 +5,7 @@ metadata:
   name: towonel-agent
 spec:
   endpoints:
-    - dnsName: "towonel.${SECRET_DOMAIN}"
+    - dnsName: "towonel.${DOMAIN}"
       recordType: CNAME
       targets: ["edge-na.towonel.dev"]
       providerSpecific:

--- a/kubernetes/apps/network/towonel-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       logLevel: info
       healthPort: 9090
       services:
-        - hostname: "*.${SECRET_DOMAIN}"
+        - hostname: "*.${DOMAIN}"
           origin: envoy-towonel.network.svc.cluster.local:443
       inviteTokenSecret:
         name: towonel-agent-secret

--- a/kubernetes/apps/network/towonel-agent/ks.yaml
+++ b/kubernetes/apps/network/towonel-agent/ks.yaml
@@ -12,6 +12,8 @@ spec:
     - name: envoy-gateway
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -45,7 +45,7 @@ spec:
       plugin_admin_enabled: "false"
     server:
       enable_gzip: "true"
-      root_url: https://grafana.${SECRET_DOMAIN}
+      root_url: https://grafana.${DOMAIN}
   deployment:
     spec:
       strategy:
@@ -85,7 +85,7 @@ spec:
   httpRoute:
     spec:
       hostnames:
-        - "grafana.${SECRET_DOMAIN}"
+        - "grafana.${DOMAIN}"
       parentRefs:
         - name: envoy-internal
           namespace: network

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -11,6 +11,8 @@ spec:
   path: ./kubernetes/apps/observability/grafana/operator
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -51,6 +53,8 @@ spec:
       KOPIUR_UID: "1000"
       KOPIUR_GID: "1000"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./grafana/ks.yaml

--- a/kubernetes/apps/observability/snmp-exporter/ks.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/ks.yaml
@@ -12,8 +12,10 @@ spec:
   path: ./kubernetes/apps/observability/snmp-exporter/app
   postBuild:
     substituteFrom:
-      - kind: Secret
-        name: cluster-secrets
+      - name: cluster-global-config
+        kind: ConfigMap
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
           disabled: true
         httpRoute:
           hostnames:
-            - "metrics-ingest.${SECRET_DOMAIN}"
+            - "metrics-ingest.${DOMAIN}"
           parentRefs:
             - name: envoy-internal
               namespace: network

--- a/kubernetes/apps/observability/victoria/k8s-stack/httproute.yaml
+++ b/kubernetes/apps/observability/victoria/k8s-stack/httproute.yaml
@@ -5,7 +5,7 @@ metadata:
   name: vmagent-metrics-ingest
 spec:
   hostnames:
-    - "metrics-ingest.${SECRET_DOMAIN}"
+    - "metrics-ingest.${DOMAIN}"
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -19,6 +19,8 @@ spec:
   path: ./kubernetes/apps/observability/victoria/operator
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -55,6 +57,8 @@ spec:
       KOPIUR_UID: "1000"
       KOPIUR_GID: "1000"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -90,6 +94,8 @@ spec:
       KOPIUR_UID: "65534"
       KOPIUR_GID: "65534"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/openebs-system/kustomization.yaml
+++ b/kubernetes/apps/openebs-system/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openebs-system
+components:
+  - ../../components/cluster-global-config
 
 
 resources:

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -13,6 +13,8 @@ spec:
   path: ./kubernetes/apps/openebs-system/openebs/app
   postBuild:
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: security
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./pocket-id/ks.yaml

--- a/kubernetes/apps/security/pocket-id/instance/backendtlspolicy.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/backendtlspolicy.yaml
@@ -16,5 +16,5 @@ spec:
       name: pocket-id
       sectionName: http
   validation:
-    hostname: "pocket-id.${SECRET_DOMAIN}"
+    hostname: "pocket-id.${DOMAIN}"
     wellKnownCACertificates: System

--- a/kubernetes/apps/security/pocket-id/instance/certificate.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/certificate.yaml
@@ -8,5 +8,5 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: "pocket-id.${SECRET_DOMAIN}"
-  dnsNames: ["pocket-id.${SECRET_DOMAIN}"]
+  commonName: "pocket-id.${DOMAIN}"
+  dnsNames: ["pocket-id.${DOMAIN}"]

--- a/kubernetes/apps/security/pocket-id/instance/instance.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/instance.yaml
@@ -39,11 +39,11 @@ spec:
 
   auditLogRetentionDays: 180
 
-  appUrl: "https://pocket-id.${SECRET_DOMAIN}"
+  appUrl: "https://pocket-id.${DOMAIN}"
 
   # Terminate TLS in the pod rather than only at the gateway. This is what lets
   # in-cluster clients reach the issuer directly: CoreDNS rewrites
-  # `pocket-id.${SECRET_DOMAIN}` to this Service, and the OIDC issuer is an
+  # `pocket-id.${DOMAIN}` to this Service, and the OIDC issuer is an
   # https:// URL, so the Service itself has to answer TLS under that name.
   # Consequences elsewhere: the gateway's backend hop needs the
   # BackendTLSPolicy, and the probes below need scheme HTTPS.
@@ -90,14 +90,14 @@ spec:
     parentRefs:
       - name: envoy-cloudflare
         namespace: network
-    hostnames: ["pocket-id.${SECRET_DOMAIN}"]
+    hostnames: ["pocket-id.${DOMAIN}"]
 
   smtp:
     host: smtp.migadu.com
     port: 465
     tls: tls
     skipCertVerify: false
-    from: &from "pocketid@${SECRET_DOMAIN}"
+    from: &from "pocketid@${DOMAIN}"
     user: *from
     password:
       valueFrom:

--- a/kubernetes/apps/security/pocket-id/ks.yaml
+++ b/kubernetes/apps/security/pocket-id/ks.yaml
@@ -33,6 +33,8 @@ spec:
       # role/database/secret predate the component and use the undashed name
       DB_APP: pocketid
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/social/continuwuity/app/helmrelease.yaml
+++ b/kubernetes/apps/social/continuwuity/app/helmrelease.yaml
@@ -122,7 +122,7 @@ spec:
     route:
       *app :
         hostnames:
-          - "matrix.${SECRET_DOMAIN}"
+          - "matrix.${DOMAIN}"
         parentRefs:
           - name: envoy-cloudflare
             namespace: network
@@ -132,7 +132,7 @@ spec:
                 port: *port
       federation:
         hostnames:
-          - "federation.${SECRET_DOMAIN}"
+          - "federation.${DOMAIN}"
         parentRefs:
           - name: envoy-cloudflare
             namespace: network
@@ -142,7 +142,7 @@ spec:
                 port: *port
       well-known:
         hostnames:
-          - "${SECRET_DOMAIN}"
+          - "${DOMAIN}"
         parentRefs:
           - name: envoy-cloudflare
             namespace: network

--- a/kubernetes/apps/social/continuwuity/ks.yaml
+++ b/kubernetes/apps/social/continuwuity/ks.yaml
@@ -20,6 +20,8 @@ spec:
       KOPIUR_UID: "1001"
       KOPIUR_GID: "1001"
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/social/kustomization.yaml
+++ b/kubernetes/apps/social/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: social
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./continuwuity/ks.yaml

--- a/kubernetes/apps/social/sable/app/helmrelease.yaml
+++ b/kubernetes/apps/social/sable/app/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
     route:
       *app :
         hostnames:
-          - "chat.${SECRET_DOMAIN}"
+          - "chat.${DOMAIN}"
         parentRefs:
           - name: envoy-cloudflare
             namespace: network

--- a/kubernetes/apps/social/sable/ks.yaml
+++ b/kubernetes/apps/social/sable/ks.yaml
@@ -15,6 +15,8 @@ spec:
       APP: *app
       
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: system-upgrade
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./tuppr/ks.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true
@@ -38,6 +40,8 @@ spec:
     substitute:
       APP: *app
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/kubernetes/components/cluster-global-config/configmap.yaml
+++ b/kubernetes/components/cluster-global-config/configmap.yaml
@@ -1,0 +1,8 @@
+---
+# Plain resource, not a generator: Flux's substituteFrom needs a stable name.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-global-config
+data:
+  DOMAIN: crayon.club

--- a/kubernetes/components/cluster-global-config/kustomization.yaml
+++ b/kubernetes/components/cluster-global-config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./configmap.yaml

--- a/kubernetes/components/oidc/variants/base/oidcclient.yaml
+++ b/kubernetes/components/oidc/variants/base/oidcclient.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   name: ${OIDC_APP_NAME:=${OIDC_APP:=${APP}}}
   clientID: ${OIDC_APP:=${APP}}
-  launchUrl: https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${SECRET_DOMAIN}
+  launchUrl: https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${DOMAIN}
   callbackUrls:
-    - https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${SECRET_DOMAIN}${OIDC_CALLBACK_PATH:=/oauth2/callback}
+    - https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${DOMAIN}${OIDC_CALLBACK_PATH:=/oauth2/callback}
   pkceEnabled: ${OIDC_PKCE_ENABLED:=false}
   logoUrl: ${APP_ICON_URL}
   secret:

--- a/kubernetes/components/oidc/variants/envoy/securitypolicy.yaml
+++ b/kubernetes/components/oidc/variants/envoy/securitypolicy.yaml
@@ -10,9 +10,9 @@ spec:
       name: ${HTTPROUTE_NAME:=${APP}}
   oidc:
     provider:
-      issuer: "https://pocket-id.${SECRET_DOMAIN}"
+      issuer: "https://pocket-id.${DOMAIN}"
     clientID: "${OIDC_APP:=${APP}}"
     clientSecret:
       name: "${OIDC_APP:=${APP}}-oidc-credentials"
-    redirectURL: "https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${SECRET_DOMAIN}/oauth2/callback"
+    redirectURL: "https://${SUBDOMAIN:=${OIDC_APP:=${APP}}}.${DOMAIN}/oauth2/callback"
     logoutPath: "/logout"

--- a/templates/kubernetes/apps/{{namespace}}/kustomization.yaml.jinja
+++ b/templates/kubernetes/apps/{{namespace}}/kustomization.yaml.jinja
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: {{namespace}}
+components:
+  - ../../components/cluster-global-config
 resources:
   - ./namespace.yaml
   - ./{{app}}/ks.yaml

--- a/templates/kubernetes/apps/{{namespace}}/{{app}}/.ks-fragment-{{component}}.yaml.jinja
+++ b/templates/kubernetes/apps/{{namespace}}/{{app}}/.ks-fragment-{{component}}.yaml.jinja
@@ -26,6 +26,8 @@ spec:
       KOPIUR_GID: "{{kopiur_gid}}"
       {%- endif %}
     substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
       - name: cluster-secrets
         kind: Secret
   prune: true

--- a/templates/kubernetes/apps/{{namespace}}/{{app}}/{{component}}/helmrelease.yaml.jinja
+++ b/templates/kubernetes/apps/{{namespace}}/{{app}}/{{component}}/helmrelease.yaml.jinja
@@ -30,7 +30,7 @@ spec:
     route:
       *app :
         hostnames:
-          - "{{app}}.${SECRET_DOMAIN}"
+          - "{{app}}.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
First of three PRs retiring the `cluster-secrets` ClusterExternalSecret fan-out. This one
moves the domain out of it; the two remaining values follow in #2, and the teardown is #3.

## Why

`postBuild.substituteFrom: {kind: Secret, name: cluster-secrets}` appears in 47 `ks.yaml`
files, every one of which also `dependsOn: external-secrets-config`. Flux resolves that
Secret in the namespace of the Kustomization *object*, and this repo puts Kustomization CRs
in per-app namespaces — which is the whole reason the fan-out exists: a source
ExternalSecret, a second ClusterSecretStore that reads the cluster's own API, a
ServiceAccount with TokenRequest RBAC, a ClusterExternalSecret, a namespace label on 19
namespaces, a patch in the Flux Operator HelmRelease to re-add that label, and 20 health
checks.

All of that to distribute three values, one of which — the domain — was never a secret. It
came from cluster-template and was kept only so it could be swapped in one place. A
ConfigMap does that job with no ESO involvement at all.

## What changed

- **New `kubernetes/components/cluster-global-config/`** — a kustomize Component emitting a
  plain ConfigMap (not a generator: `substituteFrom` needs a stable name).
- **Wired into all 20 `kubernetes/apps/<ns>/kustomization.yaml`.** It has to be a component
  *there* rather than in `ks.yaml`'s `spec.components`, because the ConfigMap must be applied
  by `cluster-apps` before the child Kustomizations build. The parent's `namespace:` transform
  stamps a copy into each namespace.
- **All 60 `substituteFrom` blocks list the ConfigMap alongside the Secret.** Nothing flips
  over at once — `DOMAIN` resolves from the ConfigMap while `CLOUDFLARE_TUNNEL_ID` and
  `GARAGE_ENDPOINT_URL` keep coming from `cluster-secrets`.
- **`SECRET_DOMAIN` → `DOMAIN`** in 48 files, preserving both shapes: 79 × `${DOMAIN}` and
  5 × `${DOMAIN/./-}` (cert names).
- Copier templates updated to match, so new apps scaffold correctly.

`config/clusterexternalsecret.yaml` is deliberately *not* renamed — its three `SECRET_DOMAIN`
occurrences name a 1Password field and Secret key, not a substitution variable. That key
becomes unused here and is deleted in PR #3.

Two `ks.yaml` files had `substituteFrom` blocks that differed in key order (`snmp-exporter`)
and list indentation (`sonarr`); both are normalized to the dominant style.

## Verification

- `just test` — 180 passed. Warnings went **2 → 1**: flate can read a ConfigMap out of Git,
  so the domain now renders for real offline instead of as an empty placeholder, and the
  `continuwuity` unresolved-substitution warning is gone. The remaining warning is the
  expected `cluster-secrets` one, which goes away in PR #3.
- `flate build` renders real hostnames (`grafana.crayon.club`, `jellyfin.crayon.club`,
  `*.crayon.club` for the wildcard cert) with no empty-domain artifacts.
- `kustomize build` on two namespaces confirms the ConfigMap lands in the correct namespace.

Purely additive and reversible — no resource is removed and no substitution source is
dropped.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
