### PR TITLE
feat(external-secrets): source the tunnel id and garage endpoint directly

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/garage-endpoint/clusterexternalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/garage-endpoint/clusterexternalsecret.yaml
@@ -1,0 +1,31 @@
+---
+# Cluster-scoped so it can land the Secret in database/ from a Kustomization that
+# runs ahead of cnpg-cluster. A plain ExternalSecret alongside the ObjectStore
+# would deadlock: Flux substitutes before it applies.
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: garage-endpoint
+spec:
+  externalSecretName: garage-endpoint
+  namespaceSelectors:
+    - matchLabels:
+        kubernetes.io/metadata.name: database
+  refreshTime: 1m
+  externalSecretSpec:
+    refreshInterval: 1h
+    refreshPolicy: Periodic
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: onepassword
+    target:
+      name: garage-endpoint
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        type: Opaque
+    data:
+      - secretKey: GARAGE_ENDPOINT_URL
+        remoteRef:
+          key: k8s-database-garage-cnpg
+          property: GARAGE_ENDPOINT_URL

--- a/kubernetes/apps/database/cloudnative-pg/garage-endpoint/clusterexternalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/garage-endpoint/clusterexternalsecret.yaml
@@ -24,8 +24,9 @@ spec:
       deletionPolicy: Retain
       template:
         type: Opaque
-    data:
-      - secretKey: GARAGE_ENDPOINT_URL
-        remoteRef:
+        mergePolicy: Replace
+        data:
+          GARAGE_ENDPOINT_URL: '{{ index . "GARAGE_ENDPOINT_URL" }}'
+    dataFrom:
+      - extract:
           key: k8s-database-garage-cnpg
-          property: GARAGE_ENDPOINT_URL

--- a/kubernetes/apps/database/cloudnative-pg/garage-endpoint/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/garage-endpoint/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterexternalsecret.yaml

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -1,4 +1,37 @@
 ---
+# Split out so cnpg-cluster can substituteFrom the Secret this creates —
+# Flux substitutes before it applies, so one Kustomization cannot do both.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: garage-endpoint
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+  healthChecks:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterExternalSecret
+      name: garage-endpoint
+    - apiVersion: v1
+      kind: Secret
+      name: garage-endpoint
+      namespace: database
+  healthCheckExprs:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterExternalSecret
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/garage-endpoint
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -31,17 +64,16 @@ metadata:
   name: cnpg-cluster
 spec:
   dependsOn:
-    - name: external-secrets-config
-      namespace: external-secrets
     - name: cnpg-operator
     - name: plugin-barman-cloud
+    - name: garage-endpoint
   interval: 1h
   path: ./kubernetes/apps/database/cloudnative-pg/cluster
   postBuild:
     substituteFrom:
       - name: cluster-global-config
         kind: ConfigMap
-      - name: cluster-secrets
+      - name: garage-endpoint
         kind: Secret
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -1,19 +1,51 @@
 ---
+# Split out so the app below can substituteFrom the Secret this creates —
+# Flux substitutes before it applies, so one Kustomization cannot do both.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudflare-tunnel-id
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+  healthChecks:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterExternalSecret
+      name: cloudflare-tunnel-id
+    - apiVersion: v1
+      kind: Secret
+      name: cloudflare-tunnel-id
+      namespace: network
+  healthCheckExprs:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterExternalSecret
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  interval: 1h
+  path: ./kubernetes/apps/network/cloudflare-tunnel/tunnel-id
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cloudflare-tunnel
 spec:
   dependsOn:
-    - name: external-secrets-config
-      namespace: external-secrets
+    - name: cloudflare-tunnel-id
   interval: 1h
   path: ./kubernetes/apps/network/cloudflare-tunnel/app
   postBuild:
     substituteFrom:
       - name: cluster-global-config
         kind: ConfigMap
-      - name: cluster-secrets
+      - name: cloudflare-tunnel-id
         kind: Secret
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/cloudflare-tunnel/tunnel-id/clusterexternalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/tunnel-id/clusterexternalsecret.yaml
@@ -1,0 +1,31 @@
+---
+# Cluster-scoped so it can land the Secret in network/ from a Kustomization that
+# runs ahead of the app. A plain ExternalSecret alongside the DNSEndpoint would
+# deadlock: Flux substitutes before it applies.
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: cloudflare-tunnel-id
+spec:
+  externalSecretName: cloudflare-tunnel-id
+  namespaceSelectors:
+    - matchLabels:
+        kubernetes.io/metadata.name: network
+  refreshTime: 1m
+  externalSecretSpec:
+    refreshInterval: 1h
+    refreshPolicy: Periodic
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: onepassword
+    target:
+      name: cloudflare-tunnel-id
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        type: Opaque
+    data:
+      - secretKey: CLOUDFLARE_TUNNEL_ID
+        remoteRef:
+          key: k8s-network-cloudflare-tunnel-secret
+          property: TUNNEL_ID

--- a/kubernetes/apps/network/cloudflare-tunnel/tunnel-id/clusterexternalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/tunnel-id/clusterexternalsecret.yaml
@@ -24,8 +24,9 @@ spec:
       deletionPolicy: Retain
       template:
         type: Opaque
-    data:
-      - secretKey: CLOUDFLARE_TUNNEL_ID
-        remoteRef:
+        mergePolicy: Replace
+        data:
+          CLOUDFLARE_TUNNEL_ID: '{{ index . "TUNNEL_ID" }}'
+    dataFrom:
+      - extract:
           key: k8s-network-cloudflare-tunnel-secret
-          property: TUNNEL_ID

--- a/kubernetes/apps/network/cloudflare-tunnel/tunnel-id/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/tunnel-id/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterexternalsecret.yaml


### PR DESCRIPTION
Second of three PRs retiring the `cluster-secrets` ClusterExternalSecret fan-out. #1546 moved
the domain to a ConfigMap; this moves the last two values off the fan-out, leaving it with no
consumers. The teardown follows in #3.

## Why

`CLOUDFLARE_TUNNEL_ID` and `GARAGE_ENDPOINT_URL` each have exactly one consumer, in one
namespace. They were being copied into all 19 namespaces because Flux resolves
`substituteFrom` in the namespace of the Kustomization *object*, and the only tool the repo
had for that was the cluster-wide fan-out.

Each now comes straight from the `onepassword` store into the single namespace that needs it.

## Shape

```
kubernetes/apps/network/cloudflare-tunnel/
  ks.yaml                 # cloudflare-tunnel-id (wait: true) → cloudflare-tunnel
  tunnel-id/              # the ClusterExternalSecret
  app/

kubernetes/apps/database/cloudnative-pg/
  ks.yaml                 # garage-endpoint (wait: true) → cnpg-cluster
  garage-endpoint/
  cluster/ operator/ plugin-barman-cloud/
```

The ClusterExternalSecret lives with the app that uses it, not in the ESO config directory —
keeping the value's definition next to its consumer is most of the point of removing the
fan-out.

Two things force the shape:

- **Cluster-scoped.** A `ClusterExternalSecret` escapes the Kustomization's `targetNamespace`,
  so it can land a Secret in `network` or `database` from a Kustomization that runs ahead of
  the app.
- **A separate Kustomization.** Flux substitutes *before* it applies, so an ExternalSecret
  sitting beside the `DNSEndpoint` or the `ObjectStore` would deadlock on a cold bootstrap:
  the build fails for the missing Secret, so the ExternalSecret never lands. Each provider
  Kustomization is `wait: true` with health checks on both the ClusterExternalSecret and the
  Secret it produces.

`cloudflare-tunnel` and `cnpg-cluster` now depend on their provider rather than directly on
`external-secrets-config`; that dependency is transitive through it.

Values were added as fields on the existing 1Password items rather than in new ones —
`k8s-network-cloudflare-tunnel-secret` gained `TUNNEL_ID`, `k8s-database-garage-cnpg` gained
`GARAGE_ENDPOINT_URL`.

## Note on the provider API

The first attempt used `data[].remoteRef` with `key: <item>` + `property: <field>`. The
`onepasswordSDK` provider does not implement `property` — a `data[]` entry needs its key to be
a full `op://vault/item/field` URI, and a bare item name is only valid under
`dataFrom.extract`. It failed with:

```
the secret reference could not be parsed: secret reference has invalid format
```

Second commit switches both to `dataFrom.extract` with an explicit template, matching the four
ExternalSecrets already working against this store. `mergePolicy: Replace` plus a single
`template.data` key keeps the co-located `TUNNEL_TOKEN` and Garage access keys out of the
result.

## Verification

`just test` — 182 passed (up 2: the new Kustomizations).

Live-tested on-cluster via `just flux-branch`:

- both ExternalSecrets `SecretSynced` / Ready
- both Secrets byte-identical to what the fan-out serves today (hash-compared)
- one key in each Secret — no leakage of `TUNNEL_TOKEN` or the Garage credentials
- `DNSEndpoint` renders `cloudflare.crayon.club → <tunnel-id>.cfargotunnel.com`
- `ObjectStore` renders `endpointURL: http://10.0.40.40:3900`
- cloudflared Running 1/1, no restart attributable to this change
- **zero not-ready Kustomizations cluster-wide** after convergence

Worth recording: during the failed first attempt the `wait: true` gating contained it exactly
as intended. `cloudflare-tunnel` and `cnpg-cluster` refused to build rather than substituting
an empty string, so no broken `.cfargotunnel.com` CNAME reached Cloudflare and no ObjectStore
got an empty endpoint.

Nothing is removed here — the fan-out still serves the remaining 57 `substituteFrom` blocks
until #3 tears it down.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
