### PR TITLE
refactor(llmkube): give each inference service its own model cache

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -18,23 +18,23 @@ spec:
       replicaCount: 1
       leaderElection:
         enabled: false
-      # Pin to the GPU node (talos1). The controller mounts the model-cache PVC
-      # that inference pods also share; openebs-zfspv is node-local, so the
-      # controller must live on the same node where GPU inference schedules.
-      nodeSelector:
-        kubernetes.io/hostname: talos1
       resources:
         requests:
           cpu: 10m
           memory: 256Mi
         limits:
           memory: 1Gi
-    # Shared model cache PVC. openebs-zfspv is node-local, so this binds on the
-    # controller's node (talos1) and is read by inference pods scheduled there.
+    # One cache PVC per InferenceService, bound wherever its pod schedules.
+    # `shared` mode's single PVC would need an RWX class to be readable from
+    # both nodes; openebs-zfspv is node-local, so it would pin every inference
+    # pod — including the CPU-only ones — to whichever node the PVC bound on.
+    # The tradeoff is no cross-service dedup.
     modelCache:
       enabled: true
+      mode: perService
+      # A ZFS dataset gets a quota and no reservation, so this is a ceiling,
+      # not an allocation — each cache costs only the weights it holds.
       size: 100Gi
-      accessMode: ReadWriteOnce
     priorityClasses:
       enabled: true
     metrics:


### PR DESCRIPTION
## What

Switches the llmkube model cache from `shared` to `perService`, and drops the controller's `talos1` nodeSelector.

## Why

`shared` mode creates a single cluster-wide PVC. With no `storageClass` set it lands on the default `openebs-zfspv`, which is node-local ZFS — so the PVC is RWO, bound to talos1, and every InferenceService that mounts it has to schedule there. That's fine for `qwen3-8-27b-mtp` (it requests both of talos1's GPUs regardless), but the embedding and reranker services are CPU-only and were pinned for no reason other than the cache.

Sharing one cache across both nodes would require an RWX class. That's an NFS export from `storage.lan` away rather than a distributed-storage project, but it isn't worth standing up for ~2G of small models.

`perService` is upstream's escape hatch for exactly this (defilantech/llmkube#728): each InferenceService gets its own RWO, WaitForFirstConsumer PVC that binds on whichever node its pod schedules to. Both nodes provision a `tank` zpool (`talos/talconfig.yaml:73`, `:147`), so `openebs-zfspv` serves either one. The tradeoff is no cross-service dedup — a model served twice is downloaded twice.

The motivation is running small models on the Arc Pro B50 in talos0. This unblocks the storage half; the scheduling half (generic-device-plugin for `devic.es/dri-render`) is still to come.

## Notes

- **The shared PVC is deleted on upgrade.** It's chart-managed with no `helm.sh/resource-policy: keep`, so `llmkube-model-cache` and its ZFS dataset go away and the per-service caches start empty. That's 36G of cached weights — two 17G entries (the live Qwen3.8-27B and a stale Qwen3.6), plus ~2G of embedding/reranker. Expect ~18G re-downloaded from HF on the next pod start; the stale copy is garbage-collected for free. Cache is derived data, nothing else is lost.
- `accessMode` was removed because perService caches are always RWO — the field only applies to `shared`.
- `size: 100Gi` is unchanged and safe per service: `openebs-zfspv` datasets get a ZFS `quota` with no `refreservation`, so it's a ceiling, not an allocation. The current cache reports `QUOTA 100G / REFRESERV none / REFER 35.4G`.
- In perService mode the controller's own `/models` volume is an `emptyDir`, so nothing pins it any more.

## Testing

- `just test` — 182 passed (the two `substituteFrom` secret warnings are pre-existing).
- `helm template` against the new values confirms `--model-cache-mode=perService`, no cluster-wide PVC, and no nodeSelector on the controller Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)