### PR TITLE
feat(llmkube): pool the 27b behind a ModelRouter

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
@@ -14,9 +14,11 @@
 # spec.params.model is NOT the client-facing name — it is litellm's provider
 # routing prefix plus the string forwarded upstream, and never leaves the proxy.
 # The prefix must resolve against litellm.provider_list; "llmkube/" is not a
-# provider and would raise "LLM Provider NOT provided". llama.cpp ignores the
-# forwarded model string (it serves whatever it loaded), so the modelRef the
-# projection used is kept verbatim rather than swapped for the --alias.
+# provider and would raise "LLM Provider NOT provided". The forwarded string is
+# load-bearing for the 27b: it reaches the router-proxy, whose BackendNameMatch
+# strategy picks the backend by it, so it must equal the ModelRouter backend
+# name. The entries that still hit llama.cpp directly ignore it (it serves
+# whatever it loaded), so they keep the modelRef the projection used.
 #
 # metadata.name is deliberately NOT the InferenceService name: the generated
 # models carry a controller ownerReference to their InferenceService, so reusing
@@ -29,7 +31,10 @@ spec:
   modelName: llmkube/Qwen/Qwen3.8-27B-MTP
   params:
     model: openai/qwen3-8-27b-mtp
-    apiBase: http://qwen3-8-27b-mtp.ai.svc.cluster.local:8080/v1
+    # The router-proxy, not the Service: qwen is a ModelPool member, and the proxy
+    # is what makes a non-resident member resident before dispatching to it.
+    # See ../../../llmkube/models/modelrouter.yaml.
+    apiBase: http://inference-router-proxy.ai.svc.cluster.local:8080/v1
     # llama.cpp runs without --api-key, but litellm's openai provider errors on
     # an unset key and falls back to OPENAI_API_KEY. Any non-empty string does.
     # (Repeated per document — YAML anchors do not cross a --- boundary.)

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -52,6 +52,13 @@ spec:
       inferencePodMonitor:
         enabled: true
         additionalLabels: null
+      # The router-proxy's own listener, which carries the llmkube_router_* and
+      # llmkube_modelpool_* series (swap count/duration, hold duration, coalesced
+      # and held requests). The pool metrics are emitted by the proxy, not the
+      # controller, so the ServiceMonitor below does not cover them.
+      routerPodMonitor:
+        enabled: true
+        additionalLabels: null
       # Scrapes the controller-manager's own llmkube_* metrics, which the
       # Operator health row added to the llmkube-inference dashboard in 0.9.14
       # reads (reconcile rate/duration, time-to-ready, fleet readiness, replica

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./qwen3-8-27b-mtp.yaml
   - ./qwen3-embedding-0-6b.yaml
   - ./qwen3-reranker-0-6b.yaml
+  - ./modelpool.yaml
+  - ./modelrouter.yaml

--- a/kubernetes/apps/ai/llmkube/models/modelpool.yaml
+++ b/kubernetes/apps/ai/llmkube/models/modelpool.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelPool
+metadata:
+  name: talos1-gpu
+spec:
+  # Informational — members declare their own resource requests. nodeSelector is
+  # deliberately unset: the operator never reads it, and members land on talos1
+  # anyway because it is the only node advertising nvidia.com/gpu: 2.
+  gpu: 2
+  swapPolicy: sticky
+  # Caps how long the router holds a request while the incumbent drains and the
+  # target cold-loads — and therefore also how long a request hangs while a Wolf
+  # session holds the GPUs, before 503 + Retry-After.
+  swapBudget: 300s
+  default: qwen3-8-27b-mtp
+  members:
+    - inferenceServiceRef:
+        name: qwen3-8-27b-mtp

--- a/kubernetes/apps/ai/llmkube/models/modelrouter.yaml
+++ b/kubernetes/apps/ai/llmkube/models/modelrouter.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: inference
+spec:
+  # Routes an unmatched request to the backend whose name equals the request's
+  # "model" field, so a new pool member costs one backend entry and no rules.
+  defaultRouteStrategy: BackendNameMatch
+  defaultRoute: qwen3-8-27b-mtp
+  backends:
+    - name: qwen3-8-27b-mtp
+      inferenceServiceRef:
+        name: qwen3-8-27b-mtp
+  proxy:
+    # The 120s default is a max-generation cap on non-streaming completions,
+    # which a thinking 27B blows past. Streaming never reaches it (the first SSE
+    # chunk lands early), but litellm dispatches both.
+    responseHeaderTimeout: 600s
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-27b-mtp.yaml
@@ -38,7 +38,9 @@ spec:
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda-b10666@sha256:150b59966fb5b2cb1a8fa9d226267c56ebd22c520c7b3640331cde87f3c4fb01
   runtimeClassName: nvidia
-  replicas: 1
+  # No spec.replicas -- the ModelPool in ./modelpool.yaml owns a pooled member's
+  # replica count, and a value here would make Flux fight the controller on a swap.
+
   # Negative priority (value -100) so games-on-whales Wolf streaming sessions
   # (default priority 0) preempt this pod and free a GPU on talos1. See
   # ./priorityclass.yaml and kubernetes/apps/games/games-on-whales/README.md.


### PR DESCRIPTION
## What

Puts a `ModelPool` in front of the 27b — one pool (`talos1-gpu`), one member for now — and a
`ModelRouter` (`inference`) whose router-proxy fronts it, with litellm's 27b entry repointed at
that proxy. Also drops `spec.replicas` from the pooled InferenceService and turns on the chart's
router PodMonitor.

## Why

`talos1` has two GPUs and one tenant that wants both: qwen requests `nvidia.com/gpu: 2` so the
`gpu-preemptible` PriorityClass can hand the whole set to a games-on-whales session. Adding a
second big model would mean either buying VRAM for both or giving up that preemption story. A
ModelPool is the shape for the alternative: N single-model InferenceServices share one exclusive
slot, at most one resident, and the operator drains and unloads the incumbent before the next
loads. Standing it up while there is only one member — and the swap machinery is therefore inert —
makes adding model #2 additive rather than a re-plumbing of the request path.

The router is here now for the same reason. The pool controller's only demand signal is
`spec.replicas` on a member; nothing in the operator watches traffic. Request-triggered loading
lives in the router-proxy (`internal/router/activator.go`), which learns pool membership from a
ModelRouter. litellm can't activate a stopped member — a request to its Service just finds no
endpoints — so without the router the pool would need something else to flip the slot. litellm
keeps policy/keys/observability; the proxy is only the thing that makes a cold member resident
before a request lands.

Details worth knowing:

- **`defaultRouteStrategy: BackendNameMatch`** routes on the request's `model` field, so a new
  member costs one `backends:` entry and no rules. That makes litellm's forwarded model string
  load-bearing (it must equal the backend name), which the comment in `llmkube.yaml` now says.
- **`spec.replicas` is dropped from qwen** because the pool controller is the sole owner of a
  pooled member's replica count — it patches non-owners to 0 during a swap, and a value in git
  would have Flux fighting it. The CRD defaults to 1, so this is a no-op with one member.
- **Embedding and reranker keep pointing at their own Services.** The proxy mounts only
  `POST /v1/chat/completions`, `GET /v1/models` and `/health`, so `/v1/embeddings` and
  `/v1/rerank` have no path through it.
- **`responseHeaderTimeout: 600s`** — the 120s default is a max-generation cap on non-streaming
  completions, which a thinking 27b blows past.
- The operator generates the proxy Deployment, Service, and the SA/Role/RoleBinding that lets it
  patch InferenceService replicas, and pins the proxy to one replica because activation
  serialises through an in-process lock.

## Behaviour change

With the proxy in the path, a request arriving while a Wolf session holds the GPUs is now held
until `swapBudget` (300s) and then fails `503` + `Retry-After`, where before it failed
immediately against a Service with no endpoints. The `qwen.${DOMAIN}` HTTPRoute still points at
the InferenceService directly, so llama.cpp's own UI stays reachable and remains a fast-failing
escape hatch.

## Verification

`just test` passes. Both new CRs pass `kubectl apply --dry-run=server` (so the ModelRouter
validating webhook accepts them). Applied on-cluster via `just flux-branch`: pool reports
`MembersValid=True` / `MetalSupported=True` / `SwapDeferred=False`, the router publishes its
endpoint, the router-proxy pod runs, and qwen's `spec.replicas` correctly defaults back to 1.

The end-to-end request path is **not** yet verified, for an unrelated reason: qwen has been
crash-looping since #1549 landed. The empty per-service cache re-fetched the GGUF from
HuggingFace, where unsloth re-quantized `Qwen3.8-27B-UD-Q4_K_XL.gguf` on 2026-08-19 (commit
`313447f257`, 16.69 → 16.35 GiB, 5.25 → 5.14 BPW). The new recipe puts ~289 MiB *more* on the
3070's share of the `6,1` split, which OOMs the MTP draft compute buffer. Fix tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
