### PR TITLE
fix(llmkube): shift a layer off the 3070 for the re-quantized 27b

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-27b-mtp.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-27b-mtp.yaml
@@ -19,15 +19,19 @@ spec:
       count: 2 # 3090 Ti + 3070 on talos1
       vendor: nvidia
       layers: 999 # preset ngl=999 (full offload)
-      # Emit a single --tensor-split 6,1 (preset value). llmkube derives the
-      # ratio from the layerSplit range sizes (6 vs 1), so we must NOT also pass
-      # --tensor-split in extraArgs or llama.cpp gets it twice. The ranges only
-      # express the 6:1 proportion; they need not match the real layer count.
+      # Emit a single --tensor-split 7,1. llmkube derives the ratio from the
+      # layerSplit range sizes (7 vs 1), so we must NOT also pass --tensor-split
+      # in extraArgs or llama.cpp gets it twice. The ranges only express the 7:1
+      # proportion; they need not match the real layer count.
+      #
+      # 7:1, not the preset 6:1: this quant back-loads its bits, so the 3070 held
+      # 20% of the weights at 6:1 (3209 MiB) and could not also fit the MTP draft
+      # compute buffer. One layer less puts it back under the ~2920 MiB that fit.
       sharding:
         strategy: layer
         layerSplit:
-          - "0-5" # 3090 Ti — 6 parts
-          - "6-6" # 3070 — 1 part
+          - "0-6" # 3090 Ti — 7 parts
+          - "7-7" # 3070 — 1 part
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService


### PR DESCRIPTION
## What

Moves the 27b's tensor split from 6:1 to 7:1 (`layerSplit: ["0-6", "7-7"]`), shifting roughly one
layer off the 3070.

## Why

unsloth re-quantized `Qwen3.8-27B-UD-Q4_K_XL.gguf` in place on 2026-08-19 — HF commit
`313447f257`, 17,923,394,624 → 17,559,178,144 bytes (16.69 → 16.35 GiB), 5.25 → 5.14 BPW. The old
file kept serving out of the shared model cache for eleven days, so nothing noticed beyond
`Model` reporting `SourceDrifted=True`. #1549 then gave each service its own empty PVC, the init
container re-fetched from `main`, and the new file landed for the first time.

It is smaller overall but back-loads its bits, so under the 6:1 split the 3070's share *grew*:

| | old quant | new quant @ 6:1 | new quant @ 7:1 |
| --- | --- | --- | --- |
| CUDA0 (3090 Ti) | 13479.81 MiB | 12843.56 MiB | 13110.46 MiB |
| CUDA1 (3070) | 2920.76 MiB | **3209.67 MiB** | **2942.76 MiB** |

289 MiB more on a card whose `uBatchSize: 256` was already documented as the ceiling that just
fits, and the MTP draft context's second compute buffer stopped fitting:

```
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 1617.09 MiB on device 1:
  cudaMalloc failed: out of memory
common_speculative_init_result: failed to create MTP context
srv llama_server: exiting due to model loading error
```

llama.cpp's own fit check said the same thing before aborting: `CUDA1: 7842 total, 8200 used`,
`need to use 3055 MiB less in total`.

7:1 moves about one layer (~345 MiB at this quant's bit width) back to the 3090 Ti, which has
636 MiB more room than it did under the old quant. The source URL stays on `main` — this is a
VRAM fit fix, not a pin.

Ruled out along the way: the llama.cpp b10666 bump is not implicated. VictoriaLogs shows clean
starts on that image with the old file on 2026-08-29 at 00:42 and 20:59; only the file changed.

## Verification

Applied on-cluster via `just flux-branch`. The pod went Ready in 32 seconds with zero restarts
after ~47 minutes of crash-looping, and the numbers land where the table above predicts.

This also unblocked the end-to-end check that #1550 could not run:

```
NAME         POLICY   RESIDENT          PHASE
talos1-gpu   sticky   qwen3-8-27b-mtp   Ready
```

Three requests through the router-proxy returned 200 (one streaming), dispatching to
`backend: qwen3-8-27b-mtp` at `timeoutMs: 600000`, with a real completion at the far end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
