### PR TITLE
feat(litellm): publish Qwen3.8-Flash-Next through the proxy

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
@@ -47,6 +47,25 @@ spec:
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
+  name: llmkube-qwen3-8-flash-next
+spec:
+  modelName: llmkube/Qwen/Qwen3.8-Flash-Next
+  params:
+    # Must equal the ModelRouter backend name — BackendNameMatch routes on it.
+    model: openai/qwen3-8-flash-next
+    # The router-proxy, not the Service: flash-next and the 27b are both
+    # ModelPool members and cannot be resident at once, so the proxy is what
+    # swaps this one in before dispatching.
+    apiBase: http://inference-router-proxy.ai.svc.cluster.local:8080/v1
+    apiKey: sk-llmkube-noauth
+  info:
+    # ../../../llmkube/models/qwen3-8-flash-next.yaml contextSize. Well under
+    # the model's native 262144 — raise both together if it is ever widened.
+    maxInputTokens: 32768
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
   name: llmkube-qwen3-embedding-0-6b
 spec:
   modelName: llmkube/Qwen/Qwen3-Embedding-0.6B

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./priorityclass.yaml
   - ./qwen3-8-27b-mtp.yaml
+  - ./qwen3-8-flash-next.yaml
   - ./qwen3-embedding-0-6b.yaml
   - ./qwen3-reranker-0-6b.yaml
   - ./modelpool.yaml

--- a/kubernetes/apps/ai/llmkube/models/modelpool.yaml
+++ b/kubernetes/apps/ai/llmkube/models/modelpool.yaml
@@ -12,8 +12,13 @@ spec:
   # Caps how long the router holds a request while the incumbent drains and the
   # target cold-loads — and therefore also how long a request hangs while a Wolf
   # session holds the GPUs, before 503 + Retry-After.
-  swapBudget: 300s
+  #
+  # 900s, not 300s: swapping in flash-next cold-reads 74.5 GB off the cache PVC,
+  # which does not finish inside the budget the 16 GB 27B needed.
+  swapBudget: 900s
   default: qwen3-8-27b-mtp
   members:
     - inferenceServiceRef:
         name: qwen3-8-27b-mtp
+    - inferenceServiceRef:
+        name: qwen3-8-flash-next

--- a/kubernetes/apps/ai/llmkube/models/modelrouter.yaml
+++ b/kubernetes/apps/ai/llmkube/models/modelrouter.yaml
@@ -12,6 +12,9 @@ spec:
     - name: qwen3-8-27b-mtp
       inferenceServiceRef:
         name: qwen3-8-27b-mtp
+    - name: qwen3-8-flash-next
+      inferenceServiceRef:
+        name: qwen3-8-flash-next
   proxy:
     # The 120s default is a max-generation cap on non-streaming completions,
     # which a thinking 27B blows past. Streaming never reaches it (the first SSE

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8-flash-next
+spec:
+  # Sharded GGUF: source is a repo PREFIX and files[] selects the shards, with
+  # files[0] handed to llama.cpp (it discovers the siblings itself). The prefix
+  # ends at resolve/main so prefix + "/" + entry is a valid HF download URL.
+  source: https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/main
+  files:
+    - UD-IQ1_M/Qwen3.8-Flash-Next-UD-IQ1_M-00001-of-00003.gguf
+    - UD-IQ1_M/Qwen3.8-Flash-Next-UD-IQ1_M-00002-of-00003.gguf
+    - UD-IQ1_M/Qwen3.8-Flash-Next-UD-IQ1_M-00003-of-00003.gguf
+  format: gguf
+  quantization: UD-IQ1_M
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      count: 2 # 3090 Ti + 3070 on talos1
+      vendor: nvidia
+      layers: 999 # ngl=999; expert tensors come back off the GPU via moeCPULayers
+      # Emit a single --tensor-split 5,1. Only the ratio matters, not the range
+      # sizes. 5:1 puts ~3.9 GB of the ~23 GB of GPU-resident weights on the
+      # 3070, leaving it ~3 GB for compute buffers — the same buffer starvation
+      # that forced 7:1 on the 27B applies here.
+      sharding:
+        strategy: layer
+        layerSplit:
+          - "0-4" # 3090 Ti — 5 parts
+          - "5-5" # 3070 — 1 part
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-8-flash-next
+spec:
+  modelRef: qwen3-8-flash-next
+  runtime: llamacpp
+  # b10666 already carries qwen4exp (merged upstream 2026-08-27, six commits
+  # before this build). Do NOT roll this tag back below b10666 — older builds
+  # cannot load the architecture at all.
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda-b10666@sha256:150b59966fb5b2cb1a8fa9d226267c56ebd22c520c7b3640331cde87f3c4fb01
+  runtimeClassName: nvidia
+  # No spec.replicas -- the ModelPool owns a pooled member's replica count.
+  priorityClassName: gpu-preemptible
+
+  # 74.5 GB of weights against ~30 GB of VRAM, so most of the model lives in
+  # host RAM. Two placements do the work, and the split is what makes it fit:
+  #
+  #   per_layer_token_embd  28.8 GB  -> CPU (tensorOverrides below)
+  #   MoE experts           41.8 GB  -> 0.872 GB/layer x 48 layers, split here
+  #   attn / norms / output  3.9 GB  -> GPU
+  #
+  # At moeCPULayers=26: CPU holds 28.8 + 22.7 = 51.5 GB, GPU holds 23.1 GB of
+  # weights plus KV and compute buffers. Viable range is 23..29 — below 23 the
+  # GPUs OOM, above 29 the node does. Lower the number to trade RAM for VRAM.
+  moeCPULayers: 26
+  # NOT the "ple_ngram_embd" name upstream discussion uses — this GGUF calls the
+  # 51B per-layer embedding table per_layer_token_embd, and a regex that misses
+  # it puts 28.8 GB back on the GPU.
+  tensorOverrides:
+    - per_layer_token_embd=CPU
+
+  # --- typed preset fields ---
+  # Hybrid attention (SSM layers + full attention every 4th) means KV is cheap:
+  # only 12 of 48 layers cache, at 2 KV heads, so 32768 costs well under 1 GB at
+  # f16. Room to raise this a long way — weights, not context, are the ceiling.
+  contextSize: 32768
+  parallelSlots: 1 # slots divide contextSize, and CPU-side experts do not
+  # parallelise well — one slot gets the whole window
+  batchSize: 1024
+  uBatchSize: 256 # same 3070 compute-buffer ceiling the 27B landed on
+  jinja: true # required for the chat-template-kwargs below
+
+  # KV left at f16 deliberately: q8_0 would save only a few hundred MB here and
+  # quantized KV is unproven against the SSM layers of a brand-new architecture.
+
+  extraArgs:
+    - --alias
+    - Qwen/Qwen3.8-Flash-Next
+    # Unsloth's thinking-mode preset for this model, unmodified.
+    - --temp
+    - "1.0"
+    - --top-p
+    - "0.95"
+    - --top-k
+    - "20"
+    - --min-p
+    - "0.0"
+    - --presence-penalty
+    - "0.0"
+    - --repeat-penalty
+    - "1.0"
+    # Default effort is xhigh; with the experts on CPU that spends minutes per
+    # reply. Raise once the tok/s is known.
+    - --chat-template-kwargs
+    - '{"reasoning_effort":"medium"}'
+
+  resources:
+    # Experts run on CPU here, so this is real compute, not the 1 core the
+    # fully-offloaded 27B needs.
+    cpu: "8"
+    # Covers the 51.5 GB of CPU-resident weights. Fits only because the pool
+    # never runs this and the 27B at once — together they exceed the node.
+    memory: 50Gi
+    gpu: 2
+
+  endpoint:
+    port: 8080
+    type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen3-8-flash-next
+spec:
+  hostnames:
+    - "flash.${DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: qwen3-8-flash-next
+          port: 8080

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -21,15 +21,20 @@ spec:
       count: 2 # 3090 Ti + 3070 on talos1
       vendor: nvidia
       layers: 999 # ngl=999; expert tensors come back off the GPU via moeCPULayers
-      # Emit a single --tensor-split 5,1. Only the ratio matters, not the range
-      # sizes. 5:1 puts ~3.9 GB of the ~23 GB of GPU-resident weights on the
-      # 3070, leaving it ~3 GB for compute buffers — the same buffer starvation
-      # that forced 7:1 on the 27B applies here.
+      # Emit a single --tensor-split 6,1. Only the ratio matters, not the range
+      # sizes.
+      #
+      # This ratio splits LAYERS, and moeCPULayers below makes the low-numbered
+      # ones nearly free on the GPU — so the byte split is far more lopsided
+      # than the ratio reads. 6:1 gives GPU0 layers 0-40, but only 41-22=19 of
+      # those still carry experts, while GPU1's 7 layers all do. Measured:
+      # 21630 MiB on the 3090 Ti, 6363 MiB on the 3070. Retune this and
+      # moeCPULayers together; changing one alone moves both GPUs.
       sharding:
         strategy: layer
         layerSplit:
-          - "0-4" # 3090 Ti — 5 parts
-          - "5-5" # 3070 — 1 part
+          - "0-5" # 3090 Ti — 6 parts
+          - "6-6" # 3070 — 1 part
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -53,10 +58,13 @@ spec:
   #   MoE experts           41.8 GB  -> 0.872 GB/layer x 48 layers, split here
   #   attn / norms / output  3.9 GB  -> GPU
   #
-  # At moeCPULayers=26: CPU holds 28.8 + 22.7 = 51.5 GB, GPU holds 23.1 GB of
-  # weights plus KV and compute buffers. Viable range is 23..29 — below 23 the
-  # GPUs OOM, above 29 the node does. Lower the number to trade RAM for VRAM.
-  moeCPULayers: 26
+  # At 22: CPU holds 28.8 + 19.2 = 48 GB, the GPUs hold the rest. Lower this to
+  # trade RAM for VRAM. Do not raise it past ~29 (the node OOMs) and do not drop
+  # it far below 22 without also widening the tensor-split above.
+  #
+  # 26 also ran, but left the 3070 at 90% while the 3090 Ti sat at 71%; 22 with
+  # a 6:1 split balances them at 88%/78% and measured no slower.
+  moeCPULayers: 22
   # NOT the "ple_ngram_embd" name upstream discussion uses — this GGUF calls the
   # 51B per-layer embedding table per_layer_token_embd, and a regex that misses
   # it puts 28.8 GB back on the GPU.
@@ -93,16 +101,19 @@ spec:
     - "0.0"
     - --repeat-penalty
     - "1.0"
-    # Default effort is xhigh; with the experts on CPU that spends minutes per
-    # reply. Raise once the tok/s is known.
+    # Default effort is xhigh, which at ~32 tok/s would spend minutes of
+    # thinking per reply. medium keeps latency sane.
     - --chat-template-kwargs
     - '{"reasoning_effort":"medium"}'
 
+  # Measured on talos1 at this config: ~450 tok/s prompt on a 6.3k-token
+  # prompt, ~32 tok/s generation. The first request after a swap is far
+  # slower (~170 tok/s prompt) while mmap faults the CPU-side weights in.
   resources:
     # Experts run on CPU here, so this is real compute, not the 1 core the
     # fully-offloaded 27B needs.
     cpu: "8"
-    # Covers the 51.5 GB of CPU-resident weights. Fits only because the pool
+    # Covers the 48 GB of CPU-resident weights. Fits only because the pool
     # never runs this and the 27B at once — together they exceed the node.
     memory: 50Gi
     gpu: 2


### PR DESCRIPTION
Publishes the Qwen3.8-Flash-Next InferenceService through LiteLLM so clients can reach it by model name, and adds the model itself as a second `ModelPool` member behind the existing `ModelRouter`.

## What's here

- `qwen3-8-flash-next.yaml` — the `Model` + `InferenceService` + `HTTPRoute`, using UD-IQ1_M with the MoE experts split across CPU and both GPUs
- `modelpool.yaml` / `modelrouter.yaml` — flash-next joins `talos1-gpu` as a pool member and a router backend; the 27B stays the pool default
- `litellm/proxy/models/llmkube.yaml` — a hand-written `LiteLLMModel` entry publishing it as `llmkube/Qwen/Qwen3.8-Flash-Next`

## Notes for review

`LiteLLMModel.spec.params.model` points at `openai/qwen3-8-flash-next`, which must equal the ModelRouter backend name — `BackendNameMatch` routes on that string. `apiBase` is the router-proxy rather than the Service, because flash-next and the 27B cannot be resident at once and the proxy is what swaps this one in before dispatching.

`metadata.name` deliberately differs from the InferenceService name: operator-generated models carry an ownerReference, and reusing the name would let llmkube's GC delete a Flux-managed resource.

## Verified live

- `/v1/models` lists the model; a warm completion returned in 9.1s
- Swapping back to the 27B succeeded cleanly at 36.1s, leaving the pool on its default

One cold-swap 502 was observed once, in the flash-next direction only, when the router dispatched within ~0.9s of readiness flipping. Evidence points at an endpoint-programming race amplified by the router's 15s default `quarantineDuration`, which swallowed litellm's whole retry burst. It did not reproduce in the 27B direction, so it is one observation rather than a demonstrated general defect — `quarantineDuration` is worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ndwnwvv2uSWP7R1tCz6BT