### PR TITLE
feat(llmkube): raise flash-next to IQ3_XXS and a 131072-token context

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
@@ -59,9 +59,9 @@ spec:
     apiBase: http://inference-router-proxy.ai.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
   info:
-    # ../../../llmkube/models/qwen3-8-flash-next.yaml contextSize. Well under
-    # the model's native 262144 — raise both together if it is ever widened.
-    maxInputTokens: 32768
+    # ../../../llmkube/models/qwen3-8-flash-next.yaml contextSize. Still under
+    # the model's native 262144 — raise both together.
+    maxInputTokens: 131072
 ---
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -33,8 +33,12 @@ spec:
       enabled: true
       mode: perService
       # A ZFS dataset gets a quota and no reservation, so this is a ceiling,
-      # not an allocation — each cache costs only the weights it holds.
-      size: 100Gi
+      # not an allocation — each cache costs only the weights it holds. Sized to
+      # hold two quants of the largest model at once: a quantization change
+      # writes to a new content-hash directory and the old one is still there
+      # until it is reaped, so 100Gi could not have swapped flash-next's 82 GB
+      # in on top of the 74.5 GB already cached. tank has ~719 GB free.
+      size: 250Gi
     priorityClasses:
       enabled: true
     metrics:

--- a/kubernetes/apps/ai/llmkube/models/modelrouter.yaml
+++ b/kubernetes/apps/ai/llmkube/models/modelrouter.yaml
@@ -18,8 +18,10 @@ spec:
   proxy:
     # The 120s default is a max-generation cap on non-streaming completions,
     # which a thinking 27B blows past. Streaming never reaches it (the first SSE
-    # chunk lands early), but litellm dispatches both.
-    responseHeaderTimeout: 600s
+    # chunk lands early), but litellm dispatches both. Raised to 1800s when
+    # flash-next went to reasoning_effort xhigh: at ~31 tok/s a long think plus
+    # its answer can run well past ten minutes on a non-streaming call.
+    responseHeaderTimeout: 1800s
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -30,8 +30,9 @@ spec:
       # low end, so raising it starves GPU0 and leaves GPU1 carrying relatively
       # more. 26 + 7:1 measured 21632 MiB (88%) on the 3090 Ti and 6181 MiB
       # (75%) on the 3070; the earlier 26 + 5:1 pushed the 3070 to 90% against
-      # the 3090 Ti's 71%. Retune this and moeCPULayers together; changing one
-      # alone moves both GPUs.
+      # the 3090 Ti's 71%. 30 takes another four layers off GPU0 only, so 7:1
+      # should land both near 75% -- verify, and retune this with moeCPULayers;
+      # changing one alone moves both GPUs.
       sharding:
         strategy: layer
         layerSplit:
@@ -60,8 +61,13 @@ spec:
   #   MoE experts           46.0 GB  -> 0.960 GB/layer x 48 layers, split here
   #   attn / norms / output   4.3 GB  -> GPU
   #
-  # At 26: CPU holds 31.7 + 25.0 = 56.7 GB, the GPUs hold the rest. Lower this
+  # At 30: CPU holds 31.7 + 28.8 = 60.5 GB, the GPUs hold the rest. Lower this
   # to trade host memory for VRAM.
+  #
+  # 26 could not fit contextSize 131072: GPU0 came up 1054.78 MiB short on the
+  # prompt-processing compute buffer and llama-server crashlooped. Every layer
+  # this claims comes off GPU0, which is exactly where that shortfall was, so
+  # 30 frees ~3.8 GB there -- ample margin over the 1 GB deficit.
   #
   # The old "do not exceed ~29, the node OOMs" ceiling was wrong. llama.cpp
   # mmaps the GGUF, so CPU-side weights are page cache, not anonymous memory --
@@ -71,7 +77,7 @@ spec:
   # fault-in is slow. So 56.7 GB against 62 GiB of RAM is fine even though it
   # cannot all stay resident -- the sparse per_layer_token_embd lookups are
   # what stream, and they stream well.
-  moeCPULayers: 26
+  moeCPULayers: 30
   # NOT the "ple_ngram_embd" name upstream discussion uses — this GGUF calls the
   # 51B per-layer embedding table per_layer_token_embd, and a regex that misses
   # it puts 31.7 GB back on the GPU.
@@ -84,11 +90,16 @@ spec:
   # 1k tokens at f16 — about 1.5 GB here, against the 2484/1662 MiB the two GPUs
   # had free at 32768.
   #
-  # 262144 (the model's native window) is the next target but does NOT fit
-  # today: it needs ~2.5 GB of KV on GPU0 alone. Buy the room by raising
-  # moeCPULayers — streaming more experts is nearly free — and retune the
-  # tensor-split with it. KV is preallocated at load, so overshooting crashloops
-  # the pod at startup rather than failing a request.
+  # KV is not the only thing that grows with this. The prompt-processing
+  # compute buffer scales with batchSize x context for the full-attention
+  # layers, and it -- not the KV -- is what actually ran GPU0 out of memory at
+  # 131072 on moeCPULayers 26. Budget for both, and note batchSize is the other
+  # lever if VRAM ever gets tight (at the cost of prompt-eval throughput).
+  #
+  # Everything here is preallocated at load, so overshooting crashloops the pod
+  # at startup rather than failing a request -- and because this is a ModelPool
+  # member, a crashlooping load strands the pool in Swapping and takes the 27B
+  # down with it. Do not deploy a context bump without watching the load.
   #
   # Keep the litellm entry's maxInputTokens in step:
   # ../../litellm/proxy/models/llmkube.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -28,9 +28,10 @@ spec:
       # ones nearly free on the GPU — so the byte split is far more lopsided
       # than the ratio reads. Every layer moeCPULayers claims comes off GPU0's
       # low end, so raising it starves GPU0 and leaves GPU1 carrying relatively
-      # more. 22 + 6:1 measured 21630/6363 MiB; the earlier 26 + 5:1 pushed the
-      # 3070 to 90% against the 3090 Ti's 71%. 26 needs 7:1 to stay balanced.
-      # Retune this and moeCPULayers together; changing one alone moves both.
+      # more. 26 + 7:1 measured 21632 MiB (88%) on the 3090 Ti and 6181 MiB
+      # (75%) on the 3070; the earlier 26 + 5:1 pushed the 3070 to 90% against
+      # the 3090 Ti's 71%. Retune this and moeCPULayers together; changing one
+      # alone moves both GPUs.
       sharding:
         strategy: layer
         layerSplit:
@@ -79,9 +80,19 @@ spec:
 
   # --- typed preset fields ---
   # Hybrid attention (SSM layers + full attention every 4th) means KV is cheap:
-  # only 12 of 48 layers cache, at 2 KV heads, so 32768 costs well under 1 GB at
-  # f16. Room to raise this a long way — weights, not context, are the ceiling.
-  contextSize: 32768
+  # only 12 of 48 layers cache, at 2 KV heads, so this costs roughly 12 MiB per
+  # 1k tokens at f16 — about 1.5 GB here, against the 2484/1662 MiB the two GPUs
+  # had free at 32768.
+  #
+  # 262144 (the model's native window) is the next target but does NOT fit
+  # today: it needs ~2.5 GB of KV on GPU0 alone. Buy the room by raising
+  # moeCPULayers — streaming more experts is nearly free — and retune the
+  # tensor-split with it. KV is preallocated at load, so overshooting crashloops
+  # the pod at startup rather than failing a request.
+  #
+  # Keep the litellm entry's maxInputTokens in step:
+  # ../../litellm/proxy/models/llmkube.yaml
+  contextSize: 131072
   parallelSlots: 1 # slots divide contextSize, and CPU-side experts do not
   # parallelise well — one slot gets the whole window
   batchSize: 1024
@@ -114,11 +125,21 @@ spec:
     - --chat-template-kwargs
     - '{"reasoning_effort":"xhigh"}'
 
-  # Unmeasured at this quant. UD-IQ1_M at moeCPULayers=22 did 317 tok/s prompt
-  # on a 7k-token prompt and 31 tok/s generation; IQ3_XXS moves 10.7 GB more
-  # onto the CPU side, so expect generation to fall. Re-measure before trusting
-  # any number here. A cold load faults the weights in at ~300 MiB/s and the
-  # first request after a swap is much slower than steady state.
+  # Measured warm on talos1, uncached prompts: 371 tok/s prompt eval on 9.2k
+  # tokens (284 on 2.5k -- smaller batches amortize the fixed cost worse), and
+  # 31 tok/s generation regardless of prompt size. UD-IQ1_M at moeCPULayers=22
+  # did 317 / 31, so the extra 8.7 GB on the CPU side costs nothing measurable
+  # once the page cache is warm: major faults sit at 3-4.5k/s either way.
+  #
+  # Give it time to warm. The same prompt read 308 tok/s twenty minutes after
+  # load and 371 once settled -- benchmark a fresh pod and you will understate
+  # it. Randomize the prompt too, or llama.cpp's prefix cache returns
+  # cached_tokens and reports a meaningless five-figure tok/s.
+  #
+  # The cold path is the only place this quant is worse. The first request
+  # after a load or a pool swap pays the fault-in: 72k major faults/s, and a
+  # small prompt measured 4 tok/s prompt eval (14.5s to first token). Budget
+  # for that on the first request, not the steady state.
   resources:
     # Experts run on CPU here, so this is real compute, not the 1 core the
     # fully-offloaded 27B needs.

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -9,11 +9,11 @@ spec:
   # ends at resolve/main so prefix + "/" + entry is a valid HF download URL.
   source: https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/main
   files:
-    - UD-IQ1_M/Qwen3.8-Flash-Next-UD-IQ1_M-00001-of-00003.gguf
-    - UD-IQ1_M/Qwen3.8-Flash-Next-UD-IQ1_M-00002-of-00003.gguf
-    - UD-IQ1_M/Qwen3.8-Flash-Next-UD-IQ1_M-00003-of-00003.gguf
+    - UD-IQ3_XXS/Qwen3.8-Flash-Next-UD-IQ3_XXS-00001-of-00003.gguf
+    - UD-IQ3_XXS/Qwen3.8-Flash-Next-UD-IQ3_XXS-00002-of-00003.gguf
+    - UD-IQ3_XXS/Qwen3.8-Flash-Next-UD-IQ3_XXS-00003-of-00003.gguf
   format: gguf
-  quantization: UD-IQ1_M
+  quantization: UD-IQ3_XXS
   hardware:
     accelerator: cuda
     gpu:
@@ -21,20 +21,21 @@ spec:
       count: 2 # 3090 Ti + 3070 on talos1
       vendor: nvidia
       layers: 999 # ngl=999; expert tensors come back off the GPU via moeCPULayers
-      # Emit a single --tensor-split 6,1. Only the ratio matters, not the range
+      # Emit a single --tensor-split 7,1. Only the ratio matters, not the range
       # sizes.
       #
       # This ratio splits LAYERS, and moeCPULayers below makes the low-numbered
       # ones nearly free on the GPU — so the byte split is far more lopsided
-      # than the ratio reads. 6:1 gives GPU0 layers 0-40, but only 41-22=19 of
-      # those still carry experts, while GPU1's 7 layers all do. Measured:
-      # 21630 MiB on the 3090 Ti, 6363 MiB on the 3070. Retune this and
-      # moeCPULayers together; changing one alone moves both GPUs.
+      # than the ratio reads. Every layer moeCPULayers claims comes off GPU0's
+      # low end, so raising it starves GPU0 and leaves GPU1 carrying relatively
+      # more. 22 + 6:1 measured 21630/6363 MiB; the earlier 26 + 5:1 pushed the
+      # 3070 to 90% against the 3090 Ti's 71%. 26 needs 7:1 to stay balanced.
+      # Retune this and moeCPULayers together; changing one alone moves both.
       sharding:
         strategy: layer
         layerSplit:
-          - "0-5" # 3090 Ti — 6 parts
-          - "6-6" # 3070 — 1 part
+          - "0-6" # 3090 Ti — 7 parts
+          - "7-7" # 3070 — 1 part
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -51,23 +52,28 @@ spec:
   # No spec.replicas -- the ModelPool owns a pooled member's replica count.
   priorityClassName: gpu-preemptible
 
-  # 74.5 GB of weights against ~30 GB of VRAM, so most of the model lives in
-  # host RAM. Two placements do the work, and the split is what makes it fit:
+  # 82.0 GB of weights against ~34 GB of VRAM, so most of the model lives
+  # off-GPU. Two placements do the work, and the split is what makes it fit:
   #
-  #   per_layer_token_embd  28.8 GB  -> CPU (tensorOverrides below)
-  #   MoE experts           41.8 GB  -> 0.872 GB/layer x 48 layers, split here
-  #   attn / norms / output  3.9 GB  -> GPU
+  #   per_layer_token_embd  31.7 GB  -> CPU (tensorOverrides below)
+  #   MoE experts           46.0 GB  -> 0.960 GB/layer x 48 layers, split here
+  #   attn / norms / output   4.3 GB  -> GPU
   #
-  # At 22: CPU holds 28.8 + 19.2 = 48 GB, the GPUs hold the rest. Lower this to
-  # trade RAM for VRAM. Do not raise it past ~29 (the node OOMs) and do not drop
-  # it far below 22 without also widening the tensor-split above.
+  # At 26: CPU holds 31.7 + 25.0 = 56.7 GB, the GPUs hold the rest. Lower this
+  # to trade host memory for VRAM.
   #
-  # 26 also ran, but left the 3070 at 90% while the 3090 Ti sat at 71%; 22 with
-  # a 6:1 split balances them at 88%/78% and measured no slower.
-  moeCPULayers: 22
+  # The old "do not exceed ~29, the node OOMs" ceiling was wrong. llama.cpp
+  # mmaps the GGUF, so CPU-side weights are page cache, not anonymous memory --
+  # measured 41 GiB cache against 2.4 GiB RSS. They are evictable, and eviction
+  # is cheap: under load the node sustained 26 MiB/s of reads and 3.9k major
+  # faults/s and still turned in 317 tok/s prompt eval. Only a cold whole-model
+  # fault-in is slow. So 56.7 GB against 62 GiB of RAM is fine even though it
+  # cannot all stay resident -- the sparse per_layer_token_embd lookups are
+  # what stream, and they stream well.
+  moeCPULayers: 26
   # NOT the "ple_ngram_embd" name upstream discussion uses — this GGUF calls the
   # 51B per-layer embedding table per_layer_token_embd, and a regex that misses
-  # it puts 28.8 GB back on the GPU.
+  # it puts 31.7 GB back on the GPU.
   tensorOverrides:
     - per_layer_token_embd=CPU
 
@@ -101,20 +107,29 @@ spec:
     - "0.0"
     - --repeat-penalty
     - "1.0"
-    # Default effort is xhigh, which at ~32 tok/s would spend minutes of
-    # thinking per reply. medium keeps latency sane.
+    # xhigh is the model default and the best-quality setting; it spends
+    # minutes of thinking per reply at this generation rate, which is why the
+    # ModelRouter's responseHeaderTimeout had to go up with it. Drop to
+    # "medium" here if latency matters more than answer quality.
     - --chat-template-kwargs
-    - '{"reasoning_effort":"medium"}'
+    - '{"reasoning_effort":"xhigh"}'
 
-  # Measured on talos1 at this config: ~450 tok/s prompt on a 6.3k-token
-  # prompt, ~32 tok/s generation. The first request after a swap is far
-  # slower (~170 tok/s prompt) while mmap faults the CPU-side weights in.
+  # Unmeasured at this quant. UD-IQ1_M at moeCPULayers=22 did 317 tok/s prompt
+  # on a 7k-token prompt and 31 tok/s generation; IQ3_XXS moves 10.7 GB more
+  # onto the CPU side, so expect generation to fall. Re-measure before trusting
+  # any number here. A cold load faults the weights in at ~300 MiB/s and the
+  # first request after a swap is much slower than steady state.
   resources:
     # Experts run on CPU here, so this is real compute, not the 1 core the
     # fully-offloaded 27B needs.
     cpu: "8"
-    # Covers the 48 GB of CPU-resident weights. Fits only because the pool
-    # never runs this and the 27B at once — together they exceed the node.
+    # NOT sized to the 56.7 GB of CPU-side weights, and deliberately so: those
+    # are mmap'd page cache and the container's real anonymous footprint is
+    # ~2.4 GiB. This request exists to soft-reserve page cache -- it is the only
+    # thing stopping the scheduler from packing talos1 with pods that would
+    # evict the model and push it back to cold-load speeds. 50Gi is near the
+    # most that still schedules (62893Mi allocatable, ~8 GB requested by
+    # everything else).
     memory: 50Gi
     gpu: 2
 

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -27,12 +27,19 @@ spec:
       # This ratio splits LAYERS, and moeCPULayers below makes the low-numbered
       # ones nearly free on the GPU — so the byte split is far more lopsided
       # than the ratio reads. Every layer moeCPULayers claims comes off GPU0's
-      # low end, so raising it starves GPU0 and leaves GPU1 carrying relatively
-      # more. 26 + 7:1 measured 21632 MiB (88%) on the 3090 Ti and 6181 MiB
-      # (75%) on the 3070; the earlier 26 + 5:1 pushed the 3070 to 90% against
-      # the 3090 Ti's 71%. 30 takes another four layers off GPU0 only, so 7:1
-      # should land both near 75% -- verify, and retune this with moeCPULayers;
-      # changing one alone moves both GPUs.
+      # low end, so raising it unloads GPU0 and leaves GPU1 carrying relatively
+      # more.
+      #
+      # Measured at 30 + 7:1 with contextSize 131072: 20502 MiB (83%, 3614 free)
+      # on the 3090 Ti and 7023 MiB (86%, 820 free) on the 3070.
+      #
+      # THE 3070 IS NOW THE CONSTRAINT, which inverts what this file assumed
+      # while the window was 32768 (then: 21632/2484 free on the 3090 Ti against
+      # 6181/1662 on the 3070). Raising moeCPULayers unloads GPU0 only, but KV
+      # and compute buffers grow on BOTH cards, so widening the context handed
+      # GPU1 another 842 MiB with nothing to offset it. More CPU offload cannot
+      # help GPU1 -- going wider needs the split shifted toward the 3090 Ti, or
+      # a smaller batchSize.
       sharding:
         strategy: layer
         layerSplit:
@@ -74,9 +81,11 @@ spec:
   # measured 41 GiB cache against 2.4 GiB RSS. They are evictable, and eviction
   # is cheap: under load the node sustained 26 MiB/s of reads and 3.9k major
   # faults/s and still turned in 317 tok/s prompt eval. Only a cold whole-model
-  # fault-in is slow. So 56.7 GB against 62 GiB of RAM is fine even though it
+  # fault-in is slow. So 60.5 GB against 62 GiB of RAM is fine even though it
   # cannot all stay resident -- the sparse per_layer_token_embd lookups are
-  # what stream, and they stream well.
+  # what stream, and they stream well. Going 26 -> 30 alongside a 4x context
+  # measured no slower: 369 tok/s prompt at 9k and 30-33 tok/s generation,
+  # unchanged.
   moeCPULayers: 30
   # NOT the "ple_ngram_embd" name upstream discussion uses — this GGUF calls the
   # 51B per-layer embedding table per_layer_token_embd, and a regex that misses
@@ -86,9 +95,8 @@ spec:
 
   # --- typed preset fields ---
   # Hybrid attention (SSM layers + full attention every 4th) means KV is cheap:
-  # only 12 of 48 layers cache, at 2 KV heads, so this costs roughly 12 MiB per
-  # 1k tokens at f16 — about 1.5 GB here, against the 2484/1662 MiB the two GPUs
-  # had free at 32768.
+  # only 12 of 48 layers cache, at 2 KV heads, so it costs roughly 12 MiB per
+  # 1k tokens at f16.
   #
   # KV is not the only thing that grows with this. The prompt-processing
   # compute buffer scales with batchSize x context for the full-attention
@@ -100,6 +108,12 @@ spec:
   # at startup rather than failing a request -- and because this is a ModelPool
   # member, a crashlooping load strands the pool in Swapping and takes the 27B
   # down with it. Do not deploy a context bump without watching the load.
+  #
+  # Depth costs time, not memory: prompt eval falls from 369 tok/s at 9k to 229
+  # at 68k, so a 68k prompt is ~5 minutes to first token and a full 131k window
+  # roughly 10. That is what responseHeaderTimeout on the ModelRouter has to
+  # cover -- at the old 600s a 68k request would have failed. Verified end to
+  # end: a needle planted mid-prompt at 68013 tokens came back exact.
   #
   # Keep the litellm entry's maxInputTokens in step:
   # ../../litellm/proxy/models/llmkube.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-8-flash-next.yaml
@@ -21,7 +21,7 @@ spec:
       count: 2 # 3090 Ti + 3070 on talos1
       vendor: nvidia
       layers: 999 # ngl=999; expert tensors come back off the GPU via moeCPULayers
-      # Emit a single --tensor-split 7,1. Only the ratio matters, not the range
+      # Emit a single --tensor-split 8,1. Only the ratio matters, not the range
       # sizes.
       #
       # This ratio splits LAYERS, and moeCPULayers below makes the low-numbered
@@ -33,18 +33,27 @@ spec:
       # Measured at 30 + 7:1 with contextSize 131072: 20502 MiB (83%, 3614 free)
       # on the 3090 Ti and 7023 MiB (86%, 820 free) on the 3070.
       #
-      # THE 3070 IS NOW THE CONSTRAINT, which inverts what this file assumed
-      # while the window was 32768 (then: 21632/2484 free on the 3090 Ti against
-      # 6181/1662 on the 3070). Raising moeCPULayers unloads GPU0 only, but KV
-      # and compute buffers grow on BOTH cards, so widening the context handed
-      # GPU1 another 842 MiB with nothing to offset it. More CPU offload cannot
-      # help GPU1 -- going wider needs the split shifted toward the 3090 Ti, or
-      # a smaller batchSize.
+      # Raising moeCPULayers unloads GPU0 only, but KV and compute buffers grow
+      # on BOTH cards, so widening the context to 131072 left GPU1 with just
+      # 820 MiB free against the 3090 Ti's 3614. Only this ratio can relieve
+      # GPU1; more CPU offload cannot.
+      #
+      # 8:1 is the balance point, measured at contextSize 131072 /
+      # moeCPULayers 30 -- do not go further:
+      #
+      #   7:1  3614 free / 820 free   works, 3070 on the edge
+      #   8:1  2232 free / 2236 free  works, even
+      #   9:1  crashloops -- GPU0 cannot allocate its 2112 MiB KV block
+      #
+      # Each ratio step moves ~1.4 GB from GPU1 to GPU0, so from 8:1 another
+      # step leaves the 3090 Ti near 830 MiB -- under the single contiguous
+      # 2112 MiB the KV cache needs. Free VRAM on GPU0 is therefore not
+      # spendable down to zero: it must stay above that block.
       sharding:
         strategy: layer
         layerSplit:
-          - "0-6" # 3090 Ti — 7 parts
-          - "7-7" # 3070 — 1 part
+          - "0-7" # 3090 Ti — 8 parts
+          - "8-8" # 3070 — 1 part
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService


### PR DESCRIPTION
Stacked on #1558 — merge that first, and this diff reduces to its own five commits.

Raises Qwen3.8-Flash-Next from the bottom of the quant ladder to UD-IQ3_XXS and widens its context 4×, both of which were previously believed impossible on this hardware.

## What changed the calculus

IQ1_M and a 32768 window were chosen on the assumption that CPU-resident weights had to stay RAM-resident. They don't. llama.cpp mmaps the GGUF, so the CPU side is page cache, not anonymous memory — measured **41 GiB of `container_memory_cache` against 2.4 GiB RSS**, with `working_set` collapsing from 44 GiB to 2.7 GiB within two minutes of idle as the pages aged to inactive.

Eviction is also cheap. Under load the node sustained 26 MiB/s of reads and 3.9k major faults/s while still delivering 317 tok/s prompt eval. Only a cold whole-model fault-in is slow. The 31.7 GB `per_layer_token_embd` table is a sparse per-token lookup, and it streams well.

## The changes

| | before | after |
|---|---|---|
| quantization | UD-IQ1_M (74.5 GB) | **UD-IQ3_XXS (82.0 GB)** |
| contextSize | 32768 | **131072** |
| moeCPULayers | 22 | **30** |
| tensor-split | 6:1 | **8:1** |
| reasoning_effort | medium | **xhigh** |
| responseHeaderTimeout | 600s | **1800s** |
| modelCache.size | 100Gi | **250Gi** |

## Measured, not estimated

The quant upgrade cost nothing once warm: **369 tok/s** prompt eval on an uncached 9.2k prompt and **31 tok/s** generation, against IQ1_M's 317 / 31.

The split ladder was established by live-patching each ratio and measuring:

```
7:1  3614 free / 820 free   works, 3070 on the edge
8:1  2232 free / 2236 free  works, even
9:1  crashloops -- GPU0 cannot allocate its 2112 MiB KV block
```

Long context verified end to end: a needle planted mid-prompt at **68,013 tokens** came back exact.

## Things worth knowing before touching this again

- **Everything preallocates at load**, so an overshoot crashloops the pod at startup rather than failing a request — and because this is a `ModelPool` member, that strands the pool in `Swapping` and takes the 27B down with it. Watch the load.
- **The compute buffer, not the KV, is usually what OOMs.** It scales with `batchSize × context` for the full-attention layers, and it is what broke the first attempt at 131072.
- **GPU0's free VRAM is not spendable to zero** — the KV needs one contiguous 2112 MiB block.
- **Benchmarks mislead twice over:** the page cache needs ~20 minutes to settle (the same prompt read 308 tok/s early and 371 warm), and llama.cpp's prefix cache silently returns `cached_tokens` and reports a five-figure tok/s unless the prompt is randomized.
- **`reasoning_effort: xhigh` consumes the whole token budget** — every test run spent ~1015 of 1024 completion tokens on reasoning and never reached an answer. Callers need `max_tokens` in the thousands.

Context beyond 131072 was tested and rejected: 196608 loads but leaves the 3090 Ti with 248 MiB free, and 262144 is ~1 GB short before considering that a full-depth prompt is ~30 minutes to first token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ndwnwvv2uSWP7R1tCz6BT