### PR TITLE
feat: atuin-ai

### DIFF
--- a/kubernetes/apps/ai/litellm/operator/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm/operator/ocirepository.yaml
@@ -9,5 +9,11 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.0.18
-  url: oci://ghcr.io/home-operations/charts/litellm-operator
+    # TEMPORARY fork of upstream 0.0.19-dev, adding spec.secretAnnotations and
+    # spec.secretLabels to LiteLLMVirtualKey — which is what lets
+    # ../proxy/virtualkey.yaml hand its Secret to reflector. The chart also pins
+    # image.repository/digest to the matching build, so nothing is overridden in
+    # ./helmrelease.yaml. Point both back at home-operations once the change is
+    # released upstream.
+    tag: 0.0.19-virtualkey.1
+  url: oci://ghcr.io/dsluo/charts/litellm-operator

--- a/kubernetes/apps/ai/litellm/proxy/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ./externalsecret.yaml
   - ./keys-externalsecret.yaml
   - ./proxy.yaml
+  - ./virtualkey.yaml
   - ./models
   - ./usergroup.yaml

--- a/kubernetes/apps/ai/litellm/proxy/virtualkey.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/virtualkey.yaml
@@ -1,0 +1,33 @@
+---
+# Lives here, not next to its consumer: the operator resolves both spec.proxyRef
+# and spec.secretName in the VirtualKey's OWN namespace, so a copy in tools
+# would never find the proxy and its Secret would land in the wrong place.
+# reflector carries the Secret across to tools instead.
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: atuin-ai
+spec:
+  proxyRef: litellm
+  keyAlias: atuin-ai
+  secretName: atuin-ai-litellm-key
+  secretKey: CHAT_API_KEY
+  # reflector only mirrors a Secret whose SOURCE carries these; the mirror-side
+  # annotation alone does nothing. Needs the forked operator — stock 0.0.16 has
+  # no way to put any annotation on a minted Secret, and pre-creating one from
+  # Flux trips its SecretNotOwned check and the key is never minted.
+  secretAnnotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: tools
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+  # Client-facing modelName values (./models, ../chatgpt-models), not the
+  # upstream params.model. A name matching nothing does not fail open — an
+  # empty list permits everything, but a wrong entry leaves the key able to
+  # call nothing. Must stay in sync with the [[models]] blocks in
+  # kubernetes/apps/tools/atuin/ai/resources/config.toml.
+  models:
+    - llmkube/Qwen/Qwen3.8-Flash-Next
+    - llmkube/Qwen/Qwen3.8-27B-MTP
+    - chatgpt/gpt-5.6-sol
+    - chatgpt/gpt-5.6-terra
+    - chatgpt/gpt-5.6-luna

--- a/kubernetes/apps/tools/atuin/ai/externalsecret.yaml
+++ b/kubernetes/apps/tools/atuin/ai/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+# CHAT_API_KEY is not here: it comes from the LiteLLMVirtualKey in
+# kubernetes/apps/ai/litellm/proxy/virtualkey.yaml, which reflector mirrors into
+# this namespace as atuin-ai-litellm-key. Nothing in this repo creates that
+# Secret, so it will not appear until the key is minted over there.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: atuin-ai-secret
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: atuin-ai-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      mergePolicy: Replace
+      data:
+        # Unset would leave the server open to anything on the internal network,
+        # holding a key to every model below. Must match [ai] api_token in the
+        # Atuin CLI.
+        AUTH_TOKEN: '{{ index . "AUTH_TOKEN" }}'
+  dataFrom:
+    - extract:
+        key: k8s-tools-atuin-ai-secret

--- a/kubernetes/apps/tools/atuin/ai/helmrelease.yaml
+++ b/kubernetes/apps/tools/atuin/ai/helmrelease.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app atuin-ai
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/atuinsh/atuin-ai-server
+              # TODO: atuin-ai-server does not have semver yet
+              tag: main@sha256:3d11028588ebfddb0685169e35cbc7121d3577b6eee3831e845fbe5c28e48d92
+            env:
+              CHAT_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: atuin-ai-litellm-key
+                    key: CHAT_API_KEY
+              AUTH_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: atuin-ai-secret
+                    key: AUTH_TOKEN
+    service:
+      *app :
+        ports:
+          http:
+            port: &port 8080
+    route:
+      *app :
+        hostnames:
+          - "atuin-ai.${DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+    persistence:
+      config:
+        type: configMap
+        name: atuin-ai-config
+        globalMounts:
+          - path: /etc/atuin-ai/config.toml
+            subPath: config.toml
+            readOnly: true

--- a/kubernetes/apps/tools/atuin/ai/kustomization.yaml
+++ b/kubernetes/apps/tools/atuin/ai/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+configMapGenerator:
+  - name: atuin-ai-config
+    files:
+      - ./resources/config.toml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/tools/atuin/ai/ocirepository.yaml
+++ b/kubernetes/apps/tools/atuin/ai/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: atuin-ai
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/atuin/ai/resources/config.toml
+++ b/kubernetes/apps/tools/atuin/ai/resources/config.toml
@@ -1,0 +1,41 @@
+port = 8080
+
+endpoint = "http://litellm.ai.svc.cluster.local:4000/v1"
+
+default_model = "qwen3.8-27b"
+
+[api_key]
+env = "CHAT_API_KEY"
+
+[request.body]
+stream_options = { include_usage = true }
+
+[[models]]
+alias = "qwen3.8-flash-next"
+name = "Qwen3.8 Flash Next"
+description = "Local via llmkube"
+model = "llmkube/Qwen/Qwen3.8-Flash-Next"
+
+[[models]]
+alias = "qwen3.8-27b"
+name = "Qwen3.8 27B"
+description = "Local via llmkube"
+model = "llmkube/Qwen/Qwen3.8-27B-MTP"
+
+[[models]]
+alias = "sol"
+name = "GPT-5.6 Sol"
+description = "ChatGPT subscription backend"
+model = "chatgpt/gpt-5.6-sol"
+
+[[models]]
+alias = "terra"
+name = "GPT-5.6 Terra"
+description = "ChatGPT subscription backend"
+model = "chatgpt/gpt-5.6-terra"
+
+[[models]]
+alias = "luna"
+name = "GPT-5.6 Luna"
+description = "ChatGPT subscription backend"
+model = "chatgpt/gpt-5.6-luna"

--- a/kubernetes/apps/tools/atuin/ks.yaml
+++ b/kubernetes/apps/tools/atuin/ks.yaml
@@ -24,3 +24,32 @@ spec:
     namespace: flux-system
   targetNamespace: tools
   wait: false
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app atuin-ai
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+    # For the LiteLLMVirtualKey whose Secret reflector mirrors in here — the
+    # pod cannot start without CHAT_API_KEY. Ordering only: reflector copies
+    # asynchronously, so a first deploy still waits on the mirror.
+    - name: litellm
+      namespace: ai
+  interval: 1h
+  path: ./kubernetes/apps/tools/atuin/ai
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false


### PR DESCRIPTION
Deploys the atuin-ai server in `tools` namespace, using LiteLLM credentials via litellm-operator.

Uses my [dsluo/litellm-operator](https://github.com/dsluo/litellm-operator) fork to enable reflector annotations to copy the LiteLLMVirtualKey-generated Secret to the `tools` namespace.

TODO: swap back to upstream once home-operations/litellm-operator#137 is merged.
TODO: make the LiteLLMVirtualKey w/secretAnnotations pattern a component for reuse for other workloads.