### PR TITLE
fix(renovate): make PRs surface changelogs for *arr, memini and searxng

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -45,6 +45,16 @@
       "/^kustomization\\.ya?ml(?:\\.j2)?$/"
     ],
   },
+  // memini's chart labels its source as this Forgejo instance. detectPlatform()
+  // only sniffs hostnames containing "forgejo"/"gitea"/etc, so without this the
+  // host resolves to no platform and Renovate skips the changelog entirely.
+  // The releases API is public, so no token is needed.
+  hostRules: [
+    {
+      matchHost: "git.erwanleboucher.dev",
+      hostType: "forgejo",
+    },
+  ],
   packageRules: [
     {
       description: "Flux Operator Group",
@@ -76,6 +86,29 @@
         commitMessageTopic: "{{{groupName}}} group",
       },
       minimumGroupSize: 2,
+    },
+    {
+      description: "*arr upstreams tag a 4-part version (v6.4.3.10645) or release-<version>, but the images tag 3 parts; without extractVersion Renovate can't match the release and the PR ships no changelog",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "ghcr.io/home-operations/prowlarr",
+        "ghcr.io/home-operations/qbittorrent",
+        "ghcr.io/home-operations/radarr",
+        "ghcr.io/home-operations/sonarr"
+      ],
+      extractVersion: "^(?:release-)?v?(?<version>\\d+\\.\\d+\\.\\d+)",
+    },
+    {
+      description: "searxng ships no GitHub releases or tags, so a plain link to CHANGELOG.rst is the only changelog Renovate can offer",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "ghcr.io/searxng/searxng"
+      ],
+      changelogUrl: "https://github.com/searxng/searxng/blob/master/CHANGELOG.rst",
     },
     {
       description: "Auto-merge GitHub Actions",


### PR DESCRIPTION
Renovate PRs like #1575 arrive with no changelog. The cause isn't auth or a missing `sourceUrl` — it's tag matching.

`getExactReleaseMatch` keeps upstream releases whose tag *ends with* the version, then requires the tag to match `<name>[@_/-]v?<version>`, falling back to exact equality with `<version>` or `v<version>`. Several of our images defeat that:

| repo | image tag | upstream release tag |
|---|---|---|
| Radarr/Radarr | `6.4.3` | `v6.4.3.10645` |
| Sonarr/Sonarr | `4.0.19` | `v4.0.19.3009` |
| Prowlarr/Prowlarr | `2.6.3` | `v2.6.3.5592` |
| qbittorrent/qBittorrent | `5.2.3` | `release-5.2.3` |

home-operations republishes upstream's 4-part version as a 3-part tag, so `v6.4.3.10645` doesn't end with `6.4.3`; qBittorrent's `release-5.2.3` has no dep name before the version. Neither path matches, so no notes.

## Changes

**`extractVersion` for the \*arr images** — the documented escape hatch: `getReleaseNotes` re-runs the regex over each release tag and compares the captured `version`. Applying it to the docker tags too is a bonus, since it drops the rolling `6.4` and `sha256-` tags from consideration.

bazarr is deliberately excluded: `v1.6.0` already matches exactly, and the regex would let a `v1.6.1-beta.36` prerelease pose as `1.6.1`.

**A `hostRules` entry for memini's Forgejo** — the chart labels its source as `git.erwanleboucher.dev`, and `detectPlatform()` only sniffs hostnames containing `forgejo`/`gitea`/`github`/etc. That host matches none, so it falls through to `hostRules.hostType`, finds nothing, and resolves to no platform — which is why #1571 renders no `(source)` link at all. Naming the host type is enough; the releases API is anonymous, so no token.

Worth noting the GitHub mirror is *not* a substitute here: it carries only tags, no releases and no `CHANGELOG.md`. The actual patch notes live on Forgejo.

**`changelogUrl` for searxng** — it publishes neither releases nor tags on GitHub, and `getReleaseNotesMd` only parses `.md`, not its `CHANGELOG.rst`. A plain link is the ceiling.

## Not addressed

Digest-only updates (#1572, #1555, #1568, #1567, #1553) carry no version change, so there is no release to point at. That's inherent to digest tracking.

## Validation

`renovate-config-validator` passes. It reported "Validating as global config" rather than repo config on both invocations — the schema check ran and passed, but that's a weaker check than a repo-scoped one.

Two things only the next run can confirm: that the \*arr bumps actually carry release notes, and that Mend's hosted app honours a repo-config `hostRules` entry rather than stripping it. `hostRules` is `stage: 'repository'` upstream, so it should be accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)