### PR TITLE
fix(renovate): point hermes-agent at its upstream repo for changelogs

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -101,6 +101,16 @@
       extractVersion: "^(?:release-)?v?(?<version>\\d+\\.\\d+\\.\\d+)",
     },
     {
+      description: "The Docker Hub image carries no org.opencontainers.image.source label, so Renovate has no repo to pull release notes from; its tags match upstream's exactly",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "docker.io/nousresearch/hermes-agent"
+      ],
+      sourceUrl: "https://github.com/NousResearch/hermes-agent",
+    },
+    {
       description: "searxng ships no GitHub releases or tags, so a plain link to CHANGELOG.rst is the only changelog Renovate can offer",
       matchDatasources: [
         "docker"


### PR DESCRIPTION
Follow-up to #1579, for one of the packages that PR listed as unaddressed.

`NousResearch/hermes-agent` does publish release notes — the gap is that Renovate never finds the repo. Pulling the Docker Hub image's config blob for `v2026.8.31` shows the labels are:

```json
{ "org.opencontainers.image.revision": "29112bef099274229cadff79cdff7bf7b99c4b77" }
```

No `org.opencontainers.image.source`, so the docker datasource resolves no `sourceUrl` and #1570 renders no `(source)` link at all.

Unlike the \*arr images in #1579, this needs no `extractVersion`: the upstream release tags match the image tags exactly (`v2026.8.31`, `v2026.8.27`, …), so `getReleaseNotes`' `tag === version` fallback resolves them once the repo is known. A `sourceUrl` override is the whole fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)