### PR TITLE
fix(renovate): link hermes-agent releases instead of inlining them

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -109,6 +109,13 @@
         "docker.io/nousresearch/hermes-agent"
       ],
       sourceUrl: "https://github.com/NousResearch/hermes-agent",
+      // A single release ran to 40k characters, so inline notes drown the PR.
+      // Link each release in the jump instead; `releases` is empty for a
+      // digest-only update, hence the newVersion fallback.
+      fetchChangeLogs: "off",
+      prBodyNotes: [
+        "{{#if releases}}📝 Release notes: {{#each releases}}[`{{{version}}}`](https://github.com/NousResearch/hermes-agent/releases/tag/{{{version}}}){{#unless @last}} · {{/unless}}{{/each}}{{else}}📝 [Release notes for `{{{newVersion}}}`](https://github.com/NousResearch/hermes-agent/releases/tag/{{{newVersion}}}){{/if}}"
+      ],
     },
     {
       description: "searxng ships no GitHub releases or tags, so a plain link to CHANGELOG.rst is the only changelog Renovate can offer",


### PR DESCRIPTION
Follow-up to #1580. Wiring up hermes-agent's changelog worked, but the notes are enormous:

| release | body |
|---|---|
| `v2026.8.31` | **39,683 chars** |
| `v2026.8.27` | 1,972 chars |
| `v2026.8.19` | 1,655 chars |

One release is enough to bury the rest of the PR. Turn changelog fetching off for this package and link the releases instead.

## How

`fetchChangeLogs: "off"` drops the inline section; a `prBodyNotes` template links each release in the jump:

```
{{#if releases}}📝 Release notes: {{#each releases}}[`{{{version}}}`](…/releases/tag/{{{version}}}){{#unless @last}} · {{/unless}}{{/each}}{{else}}📝 [Release notes for `{{{newVersion}}}`](…/releases/tag/{{{newVersion}}}){{/if}}
```

Rendered through Handlebars against each input shape:

```
multi-release : 📝 Release notes: [`v2026.8.27`](…/tag/v2026.8.27) · [`v2026.8.31`](…/tag/v2026.8.31)
single release: 📝 Release notes: [`v2026.8.31`](…/tag/v2026.8.31)
digest (empty): 📝 [Release notes for `v2026.8.31`](…/tag/v2026.8.31)
```

The `{{else}}` branch is load-bearing: `releases` is empty on a digest-only update, which would otherwise leave a dangling "Release notes:" label with nothing after it.

`sourceUrl` stays, since it still drives the `(source)` link in the table.

## Why prBodyNotes works in a packageRule

It declares no `packageRules` parent in Renovate's option schema, so scoping it this way looks wrong at a glance. `getPrNotes` iterates `config.upgrades` and reads `upgrade.prBodyNotes`, and package rules are merged into each upgrade well before that — so it resolves per-package. The repo-config validator accepts it.

## Correction to #1579 and #1580

Both of those PRs carried a caveat that `renovate-config-validator` reported "Validating as global config" and that a repo-scoped check would be stronger. That was my mistake, not a tool limitation: the validator treats a file argument as global config unless given `--no-global`. Re-run with `--no-global --strict`, the merged config validates cleanly as repo config, and so does this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)