### PR TITLE
fix(cnpg): pin postgres to 18.6-standard-trixie

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -101,6 +101,19 @@
       extractVersion: "^(?:release-)?v?(?<version>\\d+\\.\\d+\\.\\d+)",
     },
     {
+      description: "postgres-containers publishes no releases or tags, so there is nothing for Renovate to fetch; link PostgreSQL's own notes for the minor version instead",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "ghcr.io/cloudnative-pg/postgresql"
+      ],
+      // Tags are <version>-<flavor>-<distro>, so strip the suffix to build the URL.
+      prBodyNotes: [
+        "{{#if newVersion}}📝 [PostgreSQL {{lookup (split newVersion '-') 0}} release notes](https://www.postgresql.org/docs/release/{{lookup (split newVersion '-') 0}}/){{/if}}"
+      ],
+    },
+    {
       description: "The Docker Hub image carries no org.opencontainers.image.source label, so Renovate has no repo to pull release notes from; its tags match upstream's exactly",
       matchDatasources: [
         "docker"

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -11,7 +11,9 @@ spec:
   # single instance on node-local storage: the PDB can never be satisfied (no
   # failover target), so it would deadlock node drains during tuppr upgrades.
   enablePDB: false
-  imageName: ghcr.io/cloudnative-pg/postgresql:18@sha256:a66f9e4c34950b78668fa4741bf55e6a58227cc31a6e60c128f2ce1d4c072928
+  # Must stay fully qualified: bare tags (:18) are the deprecated bullseye
+  # line, removed at its EOL, and they hide the PostgreSQL minor version.
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:c2a773217853c6e0ffe7da9c37ea456466efb20cf844f27511a73fa6a81e3152
 
   primaryUpdateStrategy: unsupervised
   # switch to switchover when instances > 1


### PR DESCRIPTION
`ghcr.io/cloudnative-pg/postgresql:18` is the deprecated legacy tag. It resolves to a **different image** than any `18.6-*` tag:

```
18                      → sha256:899d3ed…   version 18.6   base debian:bullseye-slim
18.6                    → sha256:899d3ed…   (same image)
18.6-standard-trixie    → sha256:c2a7732…   version 18.6   base debian:trixie-slim
```

Upstream's README calls these bare tags deprecated — `system` flavor on Debian bullseye — and says they "will be removed when `bullseye` images reach end of life."

It also hid the PostgreSQL minor version. The pin walked **18.1 → 18.6** entirely as digest-only Renovate PRs, so six minor releases landed without the version appearing in a single commit message. #1568 is the latest of those.

## Changes

**`cluster.yaml`** — repinned to `18.6-standard-trixie@sha256:c2a7732…`.

`standard` rather than `minimal`: minimal drops LLVM JIT and ships fewer locales, and we gain nothing from the smaller image. The `system` flavor we're leaving bundles Barman Cloud binaries that are redundant here, since WAL archiving runs through the barman-cloud plugin (`cluster.yaml:35`) — which is exactly the pairing upstream recommends instead of `system`.

Renovate will now treat `-standard-trixie` as a compatibility suffix, so future updates arrive as `18.6 → 18.7` within that line.

**`.renovaterc.json5`** — `postgres-containers` publishes no GitHub releases or tags at all, so there is nothing for Renovate to fetch. A `prBodyNotes` template links PostgreSQL's own notes instead, stripping the flavor suffix off `newVersion`:

```
18.7-standard-trixie → 📝 [PostgreSQL 18.7 release notes](https://www.postgresql.org/docs/release/18.7/)
```

`split` is a registered Renovate helper; the template was rendered against sample versions and the URL pattern confirmed (`/release/18.6/` → 200).

## Collation: checked, no action needed

bullseye → trixie crosses glibc 2.31 → 2.41, which would normally put text index ordering at risk. It doesn't here — every database is `C` collation, libc provider, `datcollversion` NULL:

```
app|C|c|          atuin|C|c|        litellm|C|c|      paperless|C|c|
pocketid|C|c|     postgres|C|c|     prowlarr|C|c|     radarr|C|c|
seerr|C|c|        sonarr|C|c|       template0|C|c|    template1|C|c|
```

PostgreSQL doesn't version-track `C`/`POSIX` because it's byte comparison, so no REINDEX is required.

PostgreSQL stays at **18.6** across this change — only the OS and flavor move.

## Impact

CNPG will roll the pod. With `instances: 1` and `primaryUpdateMethod: restart`, that's a brief outage for everything behind this cluster.

## Validation

- `renovate-config-validator --no-global --strict` — passes as repo config
- `just test` — 189/189, only the two pre-existing offline-secret warnings

Supersedes #1568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)