### PR TITLE
feat(renovate): self-host Renovate via mogenius/renovate-operator

### DIFF
--- a/.agents/skills/review-renovate-pr/SKILL.md
+++ b/.agents/skills/review-renovate-pr/SKILL.md
@@ -12,7 +12,7 @@ Produce an evidence-backed verdict on whether a Renovate PR is safe to merge. De
 Accept any of:
 - PR number (e.g. `693`) → `owner/repo` is this repo
 - Full PR URL
-- "latest" / "all open" → list open Renovate PRs first via `gh pr list --author "app/renovate" --state open`, then ask which one(s)
+- "latest" / "all open" → list open Renovate PRs first via `gh pr list --state open --search "head:renovate/"`, then ask which one(s)
 
 If the user did not specify a PR, list candidates and ask. Do not review all open PRs unless explicitly asked.
 

--- a/.claude/skills/review-renovate-pr/SKILL.md
+++ b/.claude/skills/review-renovate-pr/SKILL.md
@@ -12,7 +12,7 @@ Produce an evidence-backed verdict on whether a Renovate PR is safe to merge. De
 Accept any of:
 - PR number (e.g. `693`) → `owner/repo` is this repo
 - Full PR URL
-- "latest" → `gh pr list --author "app/renovate" --state open`, pick the newest, confirm with the user
+- "latest" → `gh pr list --state open --search "head:renovate/"`, pick the newest, confirm with the user
 - **No PR specified, or "all open" / "the open renovate PRs" / multiple PR numbers → batch mode (the default)**: review every open Renovate PR, one subagent per PR in parallel — read `references/batch.md` and follow it. Do not review PRs serially in the main context when there is more than one, and do not stop to ask which PRs to review.
 
 ## Tool rules

--- a/.claude/skills/review-renovate-pr/references/batch.md
+++ b/.claude/skills/review-renovate-pr/references/batch.md
@@ -5,7 +5,7 @@ Reviewing all open Renovate PRs in parallel subagents is the normal way this ski
 ## 1. Enumerate
 
 ```
-gh pr list --author "app/renovate" --state open --json number,title,labels,createdAt
+gh pr list --state open --search "head:renovate/" --json number,title,labels,createdAt
 ```
 
 ## 2. Dispatch — one subagent per PR, all in one message

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -18,9 +18,6 @@
   dependencyDashboard: true,
   dependencyDashboardTitle: "Renovate Dashboard",
   timezone: "America/Detroit",
-  schedule: [
-    "* 14-16 * * *"
-  ],
   ignorePaths: [
     "**/*.sops.*"
   ],

--- a/kubernetes/apps/renovate/kustomization.yaml
+++ b/kubernetes/apps/renovate/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: renovate
+components:
+  - ../../components/cluster-global-config
+resources:
+  - ./namespace.yaml
+  - ./renovate-operator/ks.yaml

--- a/kubernetes/apps/renovate/namespace.yaml
+++ b/kubernetes/apps/renovate/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: renovate
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/renovate/renovate-operator/job/externalsecret.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: renovate-github-app
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: renovate-github-app
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      mergePolicy: Replace
+      metadata:
+        labels:
+          # Opts this Secret in to being read at caller-chosen keys, which the
+          # operator's policy engine demands once it is switched on.
+          renovate-operator.mogenius.com/allow-ref: "true"
+      data:
+        APP_ID: '{{ index . "APP_ID" }}'
+        INSTALL_ID: '{{ index . "INSTALL_ID" }}'
+        PEM: '{{ index . "PEM" }}'
+  dataFrom:
+    - extract:
+        key: k8s-renovate-renovate-github-app

--- a/kubernetes/apps/renovate/renovate-operator/job/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./renovatejob.yaml

--- a/kubernetes/apps/renovate/renovate-operator/job/renovatejob.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/renovatejob.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: renovate
+spec:
+  schedule: "0 * * * *"
+  image: ghcr.io/renovatebot/renovate:44.59.3@sha256:c59046f064f86fbda58c47185aa346f3478e08aeec6bf87888859779c25ab165
+  parallelism: 2
+  provider:
+    name: github
+  discoveryFilters:
+    - "dsluo/*"
+  skipForks: true
+  # The operator mints and refreshes the installation token itself, so there is
+  # no RENOVATE_TOKEN to keep in sync.
+  githubAppReference:
+    secretName: renovate-github-app
+    appIdSecretKey: APP_ID
+    installationIdSecretKey: INSTALL_ID
+    pemSecretKey: PEM
+  renovateConfig:
+    inline: |
+      module.exports = {
+        onboarding: false,
+        requireConfig: 'optional',
+        // Commits go through the GitHub API so they are attributed to the App;
+        // without it a GitHub App install needs a gitAuthor matching the bot user.
+        platformCommit: 'enabled',
+      };
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi

--- a/kubernetes/apps/renovate/renovate-operator/job/renovatejob.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/renovatejob.yaml
@@ -23,7 +23,9 @@ spec:
     inline: |
       module.exports = {
         onboarding: false,
-        requireConfig: 'optional',
+        // Discovery returns every repo the App is installed on; 'required'
+        // keeps Renovate off the ones that were never onboarded.
+        requireConfig: 'required',
         // Commits go through the GitHub API so they are attributed to the App;
         // without it a GitHub App install needs a gitAuthor matching the bot user.
         platformCommit: 'enabled',

--- a/kubernetes/apps/renovate/renovate-operator/ks.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/ks.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: renovate-operator
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+    - name: pocket-id
+      namespace: security
+  components:
+    - ../../../../components/oidc
+  interval: 1h
+  path: ./kubernetes/apps/renovate/renovate-operator/operator
+  postBuild:
+    substitute:
+      APP: renovate
+      OIDC_APP_NAME: Renovate
+      OIDC_CALLBACK_PATH: /auth/callback
+      # The chart enables PKCE by default; the pocket-id client does not.
+      OIDC_PKCE_ENABLED: "true"
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/renovate.svg"
+    substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: renovate
+  # The RenovateJob below needs the CRD this release installs.
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: renovate-job
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+    - name: renovate-operator
+  interval: 1h
+  path: ./kubernetes/apps/renovate/renovate-operator/job
+  postBuild:
+    substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: renovate
+  wait: false

--- a/kubernetes/apps/renovate/renovate-operator/ks.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/ks.yaml
@@ -20,7 +20,7 @@ spec:
       OIDC_CALLBACK_PATH: /auth/callback
       # The chart enables PKCE by default; the pocket-id client does not.
       OIDC_PKCE_ENABLED: "true"
-      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/renovate.svg"
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/mend-renovate.svg"
     substituteFrom:
       - name: cluster-global-config
         kind: ConfigMap

--- a/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app renovate-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    # Without this every object is named renovate-operator-renovate-operator.
+    fullnameOverride: renovate-operator
+    crd:
+      install: true
+      # Ship the CRDs as ordinary release resources rather than through the
+      # chart's kubectl-image Helm hook Job, so upgrades ride the normal path.
+      mode: template
+    config:
+      logStorage:
+        mode: memory
+      jobTTLSecondsAfterFinished: 86400
+    route:
+      enabled: true
+      hostnames: ["renovate.${DOMAIN}"]
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+          sectionName: https
+    auth:
+      oidc:
+        enabled: true
+        issuerUrl: "https://pocket-id.${DOMAIN}"
+        clientId: renovate
+        existingSecret: renovate-oidc-credentials
+        secretKey: OIDC_CLIENT_SECRET
+        # TLS terminates at the Gateway; the chart only infers https from
+        # ingress.tls, which this deployment does not use.
+        redirectUrl: "https://renovate.${DOMAIN}/auth/callback"
+    authorization:
+      # pocket-id decides who may log in, and everyone who does is an admin.
+      # Leaving this on would hide every job until access rules are configured.
+      enabled: false
+    rbac:
+      ownNamespaceOnly: true
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+      dashboard:
+        enabled: true
+        grafanaDashboard:
+          instanceSelector:
+            matchLabels:
+              dashboards: grafana
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi

--- a/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
@@ -50,6 +50,9 @@ spec:
       dashboard:
         enabled: true
         grafanaDashboard:
+          # The Grafana instance lives in observability; without this the CR
+          # reconciles to nothing.
+          allowCrossNamespaceImport: true
           instanceSelector:
             matchLabels:
               dashboards: grafana

--- a/kubernetes/apps/renovate/renovate-operator/operator/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/renovate/renovate-operator/operator/ocirepository.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/operator/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: renovate-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 6.2.0
+  url: oci://ghcr.io/mogenius/helm-charts/renovate-operator


### PR DESCRIPTION
Replaces the Mend-hosted Renovate app — already uninstalled — with
`mogenius/renovate-operator` running in-cluster. The hosted service was slow to
pick up upstream releases; the operator runs discovery on an hourly cron and
fans out one Renovate executor Job per discovered repo.

New `renovate` namespace, UI at `renovate.${DOMAIN}` behind pocket-id.

## Design notes

- **Auth** uses the CRD's native `githubAppReference`: the operator signs a JWT
  from App credentials in 1Password and mints installation tokens itself, so
  there is no ESO `GithubAccessToken` generator or token-refresh secret to
  maintain.
- **`authorization.enabled: false`** — pocket-id already decides who may log in
  and this is a single-operator install. The fail-closed default would hide
  every job until access rules were configured.
- **`crd.mode: template`** ships the CRDs as ordinary release resources rather
  than through the chart's kubectl-image Helm hook Job, so upgrades ride the
  normal Flux path.
- **`requireConfig: 'required'`** — discovery returns every repo the App is
  installed on (20, as it turns out), so this keeps Renovate off the ones that
  were never onboarded. They exit in ~8s each.
- Drops the global `schedule: ["* 14-16 * * *"]` from `.renovaterc.json5`. That
  window existed to be polite to the shared hosted service; on our own cluster
  it would preserve the exact latency this change removes.

## Verified on-cluster

Deployed via `just flux-branch` and exercised end to end before merge:

| Check | Result |
|---|---|
| CRDs | both installed via `crd.mode: template` |
| Operator pod | Running 1/1 |
| HTTPRoute | Accepted on `envoy-internal`, UI returns 200 |
| pocket-id OIDC client | Ready |
| GitHub App token | minted, no errors |
| Discovery job | Complete in 23s, 20 projects found |
| `dsluo/homelab` run | `result: done`, `status: onboarded`, `enabled: true`, 33s |
| Metrics | ServiceMonitor → VMServiceScrape `operational`; Grafana dashboard syncing |

The pre-merge run correctly deferred all 13 pending updates under "Awaiting
Schedule" — it reads config from `main`, which still had the time window — and
created zero branches.

## Cutover notes

The bot identity changes from `app/renovate` to `app/the-big-joe`. Renovate
locates its Dependency Dashboard and PRs among items *it authored*, so the old
state does not carry over: it opened a fresh dashboard (#1586) rather than
adopting #425, and listed #1528's branch as "PR Edited (Blocked)" because the
commits came from the previous bot. Already handled — the old dashboard and PRs
are closed and the stale `renovate/*` branch deleted, so the new bot starts
clean.

The `review-renovate-pr` skills matched PRs by `--author "app/renovate"`, which
would now return nothing. Switched to `--search "head:renovate/"` so they track
the branch prefix and stay correct across any future identity change.

## Follow-ups (not in this PR)

- Webhooks, so Dependency Dashboard checkboxes and rebase requests act
  immediately instead of at the next tick.
- `policy.enabled: true` once this settles; the credentials Secret already
  carries the `allow-ref` label it requires.
- S3 repository cache via the existing `infra/backblaze/` B2 setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
