### PR TITLE
fix(renovate): point atuin and actual at their repos for changelogs

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -128,6 +128,26 @@
       ],
     },
     {
+      description: "atuin labels org.opencontainers.image.source on its version tags but not on `latest`, and Renovate only reads labels from `latest`, so it resolves no sourceUrl and skips the changelog",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "ghcr.io/atuinsh/atuin"
+      ],
+      sourceUrl: "https://github.com/atuinsh/atuin",
+    },
+    {
+      description: "The actual image carries no OCI labels on any tag, so Renovate has no repo to pull release notes from; its tags are upstream's minus the leading v",
+      matchDatasources: [
+        "docker"
+      ],
+      matchPackageNames: [
+        "ghcr.io/actualbudget/actual"
+      ],
+      sourceUrl: "https://github.com/actualbudget/actual",
+    },
+    {
       description: "searxng ships no GitHub releases or tags, so a plain link to CHANGELOG.rst is the only changelog Renovate can offer",
       matchDatasources: [
         "docker"


### PR DESCRIPTION
`ghcr.io/atuinsh/atuin` and `ghcr.io/actualbudget/actual` produce PRs with no source link and no Release Notes section (#1590, #1589).

Renovate's docker datasource reads OCI labels only from the `latest` tag, never from the version tag it's bumping to. A debug dry-run confirms it:

```
getLabels(https://ghcr.io, atuinsh/atuin, latest)
getLabels(https://ghcr.io, actualbudget/actual, latest)
getLabels(https://ghcr.io, bjw-s-labs/helm/app-template, 5.1.0)   ← resolves
```

Neither `latest` carries `org.opencontainers.image.source` — atuin labels its version tags but not `latest`; actual ships no OCI labels on any tag. Both end up with `sourceUrl` unset.

Fixed by setting `sourceUrl` explicitly, matching the existing hermes-agent rule. No `extractVersion` needed — upstream tags `v18.21.0`/`v26.9.0` match the image tags via Renovate's `v<version>` fallback, unlike the four-part *arr tags.

Verified by re-running the dry-run with these rules forced: both sourceUrls now resolve. Config passes `renovate-config-validator`.

---

Follow-ups once this merges:

- #1590 and #1589 won't backfill notes on their own — tick the rebase checkbox on each.
- `ghcr.io/atuinsh/atuin-ai-server` also has no `sourceUrl`, but it's pinned to `main@sha256:…`; digest-only updates have no release to point at, so it's left alone. Worth revisiting when it gets semver (there's already a TODO on that line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)