### PR TITLE
feat(renovate): enable the operator's policy engine

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/job/externalsecret.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/externalsecret.yaml
@@ -19,7 +19,8 @@ spec:
       metadata:
         labels:
           # Opts this Secret in to being read at caller-chosen keys, which the
-          # operator's policy engine demands once it is switched on.
+          # operator's policy engine requires. Without it the job is refused
+          # with SecretRefNotOptedIn.
           renovate-operator.mogenius.com/allow-ref: "true"
       data:
         APP_ID: '{{ index . "APP_ID" }}'

--- a/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
@@ -43,6 +43,12 @@ spec:
       enabled: false
     rbac:
       ownNamespaceOnly: true
+    policy:
+      # Bounds what a RenovateJob may make the operator do with its own
+      # credentials. The chart defaults already cover this job; its
+      # githubAppReference additionally needs the allow-ref label on the Secret,
+      # which job/externalsecret.yaml sets.
+      enabled: true
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
The operator acts on a RenovateJob with its **own** cluster credentials, so `create`/`patch` on `renovatejobs` is effectively a grant of the operator's ServiceAccount. Absent the policy engine, a spec can redirect `provider.endpoint` to exfiltrate the installation token, or name any Secret in the namespace at a caller-chosen key via `githubAppReference`. The operator logs a warning about running unsecured.

Enabling it is a values change only — it renders as `POLICY_*` env vars on the operator Deployment.

The chart defaults already cover this deployment. Verified against `src/internal/policy/policy.go` at 6.2.0 rather than the values comments:

- `provider.name: github` with no endpoint resolves to `https://api.github.com` (`utils.GetPlatformAndEndpoint`), which is in the default `allowedHosts`.
- `spec.image` is matched on repository only — tag and digest are stripped by `parseImageRef` — so the pinned `ghcr.io/renovatebot/renovate:44.61.3@sha256:…` matches the default `allowedImages` entry.
- The job sets no `serviceAccount` and no `securityContext`, satisfying the `allowedServiceAccounts: []` and `allowRootUser: false` defaults.
- `githubAppReference` requires the `renovate-operator.mogenius.com/allow-ref` label. The ExternalSecret already templates it, and it is present on the live Secret.

`codeberg.org` needed no change: `allowedHosts` bounds destinations the *operator* takes from the CR, not what the Renovate container fetches for datasources or changelogs — and it is a chart default regardless.

The RenovateJob's `Accepted` condition should move from `PolicyDisabled` to `PolicySatisfied` after reconcile. If anything was mis-assessed above it surfaces there as a refusal reason rather than as a silent failure.

`just test` passes (193, with the two pre-existing offline-secret warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)