### PR TITLE
feat(renovate): expose the webhook receiver and sync repo hooks

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/job/externalsecret.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/externalsecret.yaml
@@ -29,3 +29,30 @@ spec:
   dataFrom:
     - extract:
         key: k8s-renovate-renovate-github-app
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: renovate-webhook
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: renovate-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      mergePolicy: Replace
+      metadata:
+        labels:
+          # Same opt-in as above; the operator reads this at a caller-chosen key.
+          renovate-operator.mogenius.com/allow-ref: "true"
+      data:
+        token: '{{ index . "token" }}'
+  dataFrom:
+    - extract:
+        key: k8s-renovate-renovate-webhook

--- a/kubernetes/apps/renovate/renovate-operator/job/renovatejob.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/job/renovatejob.yaml
@@ -19,6 +19,20 @@ spec:
     appIdSecretKey: APP_ID
     installationIdSecretKey: INSTALL_ID
     pemSecretKey: PEM
+  webhook:
+    enabled: true
+    # GitHub signs each delivery with this token as the X-Hub-Signature-256
+    # HMAC secret; sync applies it when it creates each repo's hook.
+    authentication:
+      enabled: true
+      secretRef:
+        name: renovate-webhook
+        key: token
+    # Puts the operator's hook on every discovered repo, so Dependency Dashboard
+    # and rebase checkboxes fire a run instead of waiting for the hourly tick.
+    # Uses the App installation token, which needs Repository webhooks: RW.
+    sync:
+      enabled: true
   renovateConfig:
     inline: |
       module.exports = {

--- a/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/operator/helmrelease.yaml
@@ -27,6 +27,19 @@ spec:
         - name: envoy-internal
           namespace: network
           sectionName: https
+    webhook:
+      enabled: true
+      route:
+        enabled: true
+        # Unlike the UI, this has to be reachable by GitHub, so it goes out
+        # through the Cloudflare gateway rather than envoy-internal. The chart
+        # derives WEBHOOK_BASE_URL from this hostname and appends it to
+        # policy.allowedHosts, which sync needs to write the hook URL.
+        hostnames: ["renovate-webhook.${DOMAIN}"]
+        parentRefs:
+          - name: envoy-cloudflare
+            namespace: network
+            sectionName: https
     auth:
       oidc:
         enabled: true


### PR DESCRIPTION
Renovate only acts on a Dependency Dashboard checkbox or a rebase request on its next tick, so a request can sit for the best part of an hour — worse than the hourly schedule suggests, since a run ends once it drains automerged branches and a request can miss several ticks in a row. The webhook receiver closes that gap.

### The three pieces

**The chart's own `webhook.route`, not a hand-rolled HTTPRoute.** This is the one non-obvious choice. The chart reads that hostname back out to derive `WEBHOOK_BASE_URL` *and* to append the host to `policy.allowedHosts`. Sync refuses to write a hook URL whose host isn't allowlisted, so a hand-rolled route like `flux-webhook`'s would have quietly broken sync under the policy engine enabled in #1605. Verified by rendering the chart: `WEBHOOK_BASE_URL: "https://renovate-webhook.example.com"` and `POLICY_ALLOWED_HOSTS: "…,codeberg.org,renovate-webhook.example.com"`. It goes out through `envoy-cloudflare` rather than `envoy-internal` because GitHub has to reach it; external-dns picks the record up from the HTTPRoute automatically.

**Delivery authentication,** so the public endpoint isn't an unauthenticated run trigger. On GitHub the token becomes the `X-Hub-Signature-256` HMAC secret, applied to each hook as sync creates it. Sourced from 1Password through ESO, with the same `renovate-operator.mogenius.com/allow-ref` opt-in the App key needs.

**Sync,** so the hook lands on every discovered repo instead of being added by hand 20 times.

### Exposure

Port 8082 serves only the six `/webhook/v1/*` POST endpoints — `/schedule`, `/github`, `/gitlab`, `/forgejo`, `/gitea`, `/bitbucket` (`src/webhook/server.go` at 6.2.0). Nothing else is registered on that router, so the chart's hardcoded `PathPrefix: /` is safe on a public gateway.

### Side effect worth knowing

Sync writes a webhook into **every repo the App discovers** — all ~20 under `dsluo/*`, not just this one. Reversible: disabling sync or deleting the RenovateJob removes them again via the `renovate-operator.mogenius.com/webhook-cleanup` finalizer. Narrowing the App installation to the repos Renovate actually runs on would be the cleaner long-term fix, but it's independent of this change.

### Prerequisites

- [x] 1Password item `k8s-renovate-renovate-webhook` with a `token` field — created and verified.
- [x] **"Repository webhooks: Read and write"** on the GitHub App, accepted on the installation — done. Not verifiable from outside the installation, so it's confirmed after deploy: sync either writes the hooks or logs a permission error and retries. Discovery and Renovate runs are unaffected either way.

`just test` passes (193, with the two pre-existing offline-secret warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
