### PR TITLE
fix(searxng): key MCP rate limits by real client IP

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/mcpserver.yaml
@@ -17,6 +17,15 @@ spec:
       value: "8080"
     - name: MCP_HTTP_HOST
       value: "0.0.0.0"
+    # Without this, Express keeps `trust proxy` off and express-rate-limit keys
+    # every request by the socket peer — always the ToolHive proxy pod — so all
+    # clients share one bucket and trip 429 (-32029) together. The pod CIDR
+    # covers both hops (envoy-internal, ToolHive proxy) regardless of hop count.
+    - name: MCP_HTTP_TRUST_PROXY
+      value: "10.244.0.0/16"
+    # Default is 20/min, which a couple of agents reconnecting can exhaust.
+    - name: MCP_RATE_INIT_MAX
+      value: "120"
   podTemplateSpec:
     spec:
       containers:


### PR DESCRIPTION
## Problem

`mcp-searxng` rate-limits every client in the cluster into a **single shared bucket**, tripping HTTP 429 / JSON-RPC `-32029 "Too many requests"` for everyone at once.

The upstream image runs Express with `trust proxy` off by default. Its startup logs have been carrying the tell all along:

```
ERR_ERL_UNEXPECTED_X_FORWARDED_FOR: The 'X-Forwarded-For' header is set but
the Express 'trust proxy' setting is false (default).
```

Unable to read XFF, `express-rate-limit` keys each request by the socket peer address — which behind `envoy-internal` → ToolHive proxy is always the proxy pod (`10.244.0.98`). So the default `MCP_RATE_INIT_MAX` of 20 `initialize` calls per minute applied to the whole world combined.

Reproduced against the live endpoint:

```
1:200 2:200 ... 20:200 21:429 22:429 23:429 24:429
{"jsonrpc":"2.0","error":{"code":-32029,"message":"Too many requests"},"id":null}
```

Nothing is logged when the limiter fires, which is why the server looked healthy while clients failed.

## Fix

Set `MCP_HTTP_TRUST_PROXY` to the pod CIDR so Express walks X-Forwarded-For past both pod-network hops to the real LAN client. A CIDR rather than a numeric hop count keeps the walk correct if a hop is ever added or removed. Envoy already resolves the true client IP (`clientIPDetection.trustedCIDRs: 10.0.42.0/24` in `envoy.yaml`), so the address is present in the chain.

Raised `MCP_RATE_INIT_MAX` to 120 now that the budget is enforced per client — 20/min is tight for a single agent reconnecting.

## Verification

- `just test` — 193 passed (the 2 warnings are pre-existing offline-secret reads)
- Hop chain confirmed by pod IP: `envoy-internal` `10.244.0.73`, ToolHive proxy `10.244.0.98`, both inside `10.244.0.0/16`

**Not yet verified live.** The XFF walk landing on the LAN client rather than a pod address is reasoned from the topology, not observed. If the ToolHive proxy strips XFF instead of appending, Express would resolve to Envoy's pod IP and the bucket would still be shared, just roomier at 120/min. Worth re-running the burst test after this reconciles and confirming request 21 returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)