### PR TITLE
feat: deploy Hister with ToolHive MCP proxy

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/virtualkey.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/virtualkey.yaml
@@ -16,6 +16,22 @@ spec:
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMVirtualKey
 metadata:
+  name: hister
+spec:
+  proxyRef: litellm
+  keyAlias: hister
+  secretName: hister-litellm-key
+  secretKey: OPENAI_API_KEY
+  models:
+    - "llmkube/Qwen/Qwen3-Embedding-0.6B"
+  secretAnnotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: tools
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
   name: opencode
 spec:
   proxyRef: litellm

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hister/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hister/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hister-mcp-credentials
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: hister-mcp-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      mergePolicy: Replace
+      data:
+        AUTHORIZATION: 'Bearer {{ index . "HISTER_ACCESS_TOKEN" }}'
+  dataFrom:
+    - extract:
+        key: k8s-ai-toolhive-hister-mcp-credentials

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hister/httproute.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hister/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-hister
+spec:
+  hostnames:
+    - "hister-mcp.${DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: mcp-hister-remote-proxy
+          port: 8080

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hister/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hister/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpremoteproxy.yaml
+  - ./httproute.yaml
+  - ./networkpolicy.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hister/mcpremoteproxy.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hister/mcpremoteproxy.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/toolhive.stacklok.dev/mcpremoteproxy_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPRemoteProxy
+metadata:
+  name: hister
+spec:
+  remoteUrl: http://hister.tools.svc.cluster.local:4433/mcp
+  allowPrivateEndpoint: true
+  transport: streamable-http
+  proxyPort: 8080
+  headerForward:
+    addHeadersFromSecret:
+      - headerName: Authorization
+        valueSecretRef:
+          name: hister-mcp-credentials
+          key: AUTHORIZATION
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+    limits:
+      memory: 256Mi

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hister/networkpolicy.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hister/networkpolicy.yaml
@@ -1,0 +1,29 @@
+---
+# Only the internal Envoy data plane may reach this proxy; this prevents
+# ClusterIP bypass around the internal Gateway route.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-hister
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcpremoteproxy
+      app.kubernetes.io/instance: hister
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+            gateway.networking.k8s.io/gateway-name: envoy-internal
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./searxng
+  - ./hister

--- a/kubernetes/apps/tools/hister/README.md
+++ b/kubernetes/apps/tools/hister/README.md
@@ -1,0 +1,50 @@
+# Hister operations
+
+Hister is exposed at `https://hister.${DOMAIN}`. The server uses Pocket ID for browser login and personal tokens for API clients, the browser extension, CLI, and ToolHive.
+
+## ToolHive bootstrap
+
+After the first Pocket ID login, create a personal access token from the Hister profile page. Store it in the 1Password item `k8s-ai-toolhive-hister-mcp-credentials` under the field `HISTER_ACCESS_TOKEN`. ESO then creates the `AUTHORIZATION` value consumed by ToolHive; never store the token in Git or use the OIDC client secret for this field.
+
+The ToolHive route is intentionally on the internal Gateway, and the backend token is only reachable by the Envoy internal data plane; direct ClusterIP access is denied by Cilium. Reconcile the ToolHive Flux Kustomization after the 1Password item exists.
+
+## CLI authentication
+
+Install the Hister CLI matching the server release, then pass the server URL and personal token explicitly. Keep the token in a shell environment or secret manager; do not put it in a config file committed to Git.
+
+```sh
+export HISTER_URL="https://hister.${DOMAIN}"
+read -rsp 'Hister personal token: ' HISTER_TOKEN; export HISTER_TOKEN; echo
+
+hister --server-url "$HISTER_URL" --token "$HISTER_TOKEN" search 'kubernetes'
+hister --server-url "$HISTER_URL" --token "$HISTER_TOKEN" index https://example.com/article
+```
+
+## Index and crawl
+
+Direct indexing fetches each URL once and does not create a crawl job:
+
+```sh
+hister --server-url "$HISTER_URL" --token "$HISTER_TOKEN" index https://example.com/article
+```
+
+Create a bounded persistent recursive crawl by restricting its domain and page count:
+
+```sh
+hister --server-url "$HISTER_URL" --token "$HISTER_TOKEN" index \
+  --recursive \
+  --job-id example-docs \
+  --allowed-domain example.com \
+  --max-depth 5 \
+  --max-links 100 \
+  https://example.com/docs
+```
+
+Inspect and resume a crawl with the same personal token. `hister crawl` inspects the persisted job; `hister index --job-id` resumes its pending queue:
+
+```sh
+hister --server-url "$HISTER_URL" --token "$HISTER_TOKEN" crawl show example-docs
+hister --server-url "$HISTER_URL" --token "$HISTER_TOKEN" index --job-id example-docs
+```
+
+Crawl queues and statuses are persisted in Hister's PostgreSQL database. Kubernetes does not schedule crawls automatically; run these commands from a trusted client when a crawl is wanted. A stopped crawl can be resumed without restarting from the beginning.

--- a/kubernetes/apps/tools/hister/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/hister/app/helmrelease.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app hister
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/asciimoo/hister
+              tag: v0.19.0@sha256:dae5ae63f292bf6075c7c60cfef031e15d809a19b09db34d9e54306aab490e9b
+            env:
+              HISTER__SERVER__ADDRESS: 0.0.0.0:4433
+              HISTER__SERVER__BASE_URL: https://hister.${DOMAIN}
+              DB_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: hister-postgres-secret
+                    key: username
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: hister-postgres-secret
+                    key: password
+              HISTER__SERVER__DATABASE:
+                dependsOn: [DB_USERNAME, DB_PASSWORD]
+                value: host=postgres-rw.database.svc.cluster.local user=$(DB_USERNAME) password=$(DB_PASSWORD) dbname=hister port=5432 sslmode=disable TimeZone=UTC
+              HISTER__APP__USER_HANDLING: "true"
+              HISTER__SERVER__OAUTH_ONLY: "true"
+              HISTER__SERVER__OAUTH__OIDC__CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: hister-oidc-credentials
+                    key: OIDC_CLIENT_ID
+              HISTER__SERVER__OAUTH__OIDC__CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: hister-oidc-credentials
+                    key: OIDC_CLIENT_SECRET
+              HISTER__SERVER__OAUTH__OIDC__CONFIGURATION_URL: https://pocket-id.${DOMAIN}/.well-known/openid-configuration
+              HISTER__SEMANTIC_SEARCH__ENABLE: "true"
+              HISTER__SEMANTIC_SEARCH__EMBEDDING_ENDPOINT: http://litellm.ai.svc.cluster.local:4000/v1/embeddings
+              HISTER__SEMANTIC_SEARCH__EMBEDDING_MODEL: llmkube/Qwen/Qwen3-Embedding-0.6B
+              HISTER__SEMANTIC_SEARCH__API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: hister-litellm-key
+                    key: OPENAI_API_KEY
+              HISTER__SEMANTIC_SEARCH__DIMENSIONS: "1024"
+              HISTER__SEMANTIC_SEARCH__MAX_CONTEXT_LENGTH: "512"
+              HISTER__SEMANTIC_SEARCH__CHUNK_OVERLAP: "64"
+              HISTER__SEMANTIC_SEARCH__MAX_EMBEDDING_BATCH_SIZE: "8"
+              HISTER__SEMANTIC_SEARCH__MAX_EMBEDDING_CONCURRENCY: "2"
+              HISTER__SEMANTIC_SEARCH__EMBEDDING_TIMEOUT: "300"
+              HISTER__SERVER__MAX_BATCH_BODY_SIZE: "100"
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 4433
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    service:
+      *app :
+        ports:
+          http:
+            port: *port
+    route:
+      *app :
+        hostnames:
+          - "hister.${DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /hister/data
+      tmp:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 256Mi
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/tools/hister/app/kustomization.yaml
+++ b/kubernetes/apps/tools/hister/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/tools/hister/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/hister/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hister
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/hister/db/externalsecret.yaml
+++ b/kubernetes/apps/tools/hister/db/externalsecret.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hister-postgres-secret
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: hister-postgres-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      mergePolicy: Replace
+      data:
+        username: '{{ index . "username" }}'
+        password: '{{ index . "password" }}'
+  dataFrom:
+    - extract:
+        key: k8s-tools-hister-postgres-secret

--- a/kubernetes/apps/tools/hister/db/kustomization.yaml
+++ b/kubernetes/apps/tools/hister/db/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml

--- a/kubernetes/apps/tools/hister/ks.yaml
+++ b/kubernetes/apps/tools/hister/ks.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hister-database
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+    - name: cnpg-cluster
+      namespace: database
+  components:
+    - ../../../../components/database
+  interval: 1h
+  path: ./kubernetes/apps/tools/hister/db
+  postBuild:
+    substitute:
+      APP: hister
+      DATABASE_EXTENSIONS: |
+        [
+          { name: vector }
+        ]
+    substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hister
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+    - name: hister-database
+    - name: pocket-id
+      namespace: security
+    - name: litellm
+      namespace: ai
+    - name: kopiur-repository
+      namespace: kopiur-system
+  components:
+    - ../../../../components/oidc
+    - ../../../../components/kopiur
+  interval: 1h
+  path: ./kubernetes/apps/tools/hister/app
+  postBuild:
+    substitute:
+      APP: *app
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/hister.svg"
+      OIDC_APP_NAME: Hister
+      OIDC_CALLBACK_PATH: /api/oauth/callback?provider=oidc
+      KOPIUR_CAPACITY: 20Gi
+      KOPIUR_UID: "65532"
+      KOPIUR_GID: "65532"
+    substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -7,3 +7,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml
+  - ./hister/ks.yaml

--- a/kubernetes/components/database/ks.yaml
+++ b/kubernetes/components/database/ks.yaml
@@ -17,6 +17,9 @@ spec:
       # DB_APP overrides the database/role/secret name when it differs from the
       # app name (e.g. pocket-id -> pocketid).
       DB_APP: ${DB_APP:=${APP}}
+      # DATABASE_EXTENSIONS must be a flow-style array; q is reserved for this
+      # nested substitution and keeps the value scalar until the Database field.
+      EXTENSIONS: ${q:='}${DATABASE_EXTENSIONS:=}${q:='}
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/components/database/resources/database.yaml
+++ b/kubernetes/components/database/resources/database.yaml
@@ -8,3 +8,4 @@ spec:
   owner: ${DB_APP}
   cluster:
     name: postgres
+  extensions: ${EXTENSIONS:=[]}


### PR DESCRIPTION
## Summary
- Deploy Hister in tools with PostgreSQL, persistent Kopiur storage, Pocket ID OIDC, and LiteLLM semantic search.
- Add the ToolHive MCP remote proxy, dedicated Hister token ExternalSecret, internal Gateway route, and Cilium protection.
- Extend the shared database component with optional flow-style DATABASE_EXTENSIONS substitution for Hister's pgvector database.
- Apply review fixes for remote-proxy Service naming and labels; keep MCP access on the internal Gateway instead of using a browser-redirect OIDC policy.

## Validation
- just test — 198 checks passed.
- ToolHive manifests rendered successfully and passed server-side dry-run validation.
- No live resources were deployed.
- No tokens, passwords, OIDC secrets, cookies, or indexed content are committed.

## Remaining
Runtime verification and provisioning the 1Password-backed Hister personal token remain pending.

## Model
Implemented and reviewed with openai-codex/gpt-5.6-luna (high reasoning).