### PR TITLE
feat(talos)!: upgrade nodes to Talos v1.14.0 via tuppr

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.9
+    version: v1.14.0
   policy:
     rebootMode: powercycle
   healthChecks:


### PR DESCRIPTION
**Step 1 of 3** toward Talos 1.14 + Kubernetes 1.37. Supersedes half of #1598 (see below).

## What this does

Bumps only the tuppr `TalosUpgrade` CR to v1.14.0. Merging it fires the webhook, Flux reconciles, and tuppr rolls both nodes onto Talos 1.14.

tuppr's upgrade **installs the new Talos version and preserves each node's existing machine config** rather than regenerating it, so the current v1alpha1 config keeps working — v1.14 still accepts the deprecated fields. Nothing about the config format changes here.

That also means `workloadIsolation` does **not** flip in this step: nodes upgraded in place keep the old non-isolated behaviour. It would only change on a config regeneration, which is step 2, where it's explicitly pinned off.

## Why this doesn't touch `talos/topf.yaml`

Renovate's #1598 bundles the `topf.yaml` talosVersion bump with this same CR change. That combination cannot be merged on its own — I tested it against main's current patches and `topf render` fails:

```
talos0: error patching control plane configs: patch delete:
path 'machine.nodeLabels.node.kubernetes.io/exclude-from-external-load-balancers'
in document '/v1alpha1': failed to delete path: lookup failed
```

At the 1.14 contract that label moves out of `machine.nodeLabels` and into `KubeNodeConfig`, so the existing v1alpha1 `$patch: delete` finds nothing. The version bump is therefore inseparable from the multi-doc conversion, which lands in step 2.

#1598 is superseded by this PR plus that one.

## Order of operations

1. **This PR** — nodes move to Talos 1.14, config untouched.
2. `topf.yaml` talosVersion + the v1alpha1 → multi-doc conversion, applied manually with `topf apply`.
3. #1593 — Kubernetes 1.37 (requires Talos 1.14).

> [!WARNING]
> Do not run `topf apply` between this merging and step 2 landing. `topf.yaml` still says `v1.13.9` in that window, so an apply would rewrite `.machine.install.image` back to the 1.13.9 installer — the same drift that broke talos1's Secure Boot in June. `just diff` is read-only and safe.

## Verifying

```bash
kubectl -n system-upgrade get talosupgrade talos -w
talosctl -n 10.0.42.3,10.0.42.4 version --short   # expect v1.14.0
kubectl get nodes -o wide
talosctl -n 10.0.42.3 get securitystate            # SECUREBOOT still true
```

Both nodes reboot (`rebootMode: powercycle`), one at a time, gated by the existing kopiur health checks. talos0 is the only control plane, so there is an etcd-quorum-of-one window while it cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
