### PR TITLE
fix(ai): PushSecret deletionPolicy None, not Retain

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/pushsecret.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/pushsecret.yaml
@@ -4,7 +4,9 @@ kind: PushSecret
 metadata:
   name: opencode-litellm-key
 spec:
-  deletionPolicy: Retain
+  # Governs the copy in 1Password, not the k8s Secret. Retain is ExternalSecret
+  # vocabulary (target.deletionPolicy); PushSecret only accepts Delete/None.
+  deletionPolicy: None
   refreshInterval: 1h
   secretStoreRefs:
     - name: onepassword
@@ -27,7 +29,7 @@ kind: PushSecret
 metadata:
   name: pi-litellm-key
 spec:
-  deletionPolicy: Retain
+  deletionPolicy: None
   refreshInterval: 1h
   secretStoreRefs:
     - name: onepassword


### PR DESCRIPTION
The two litellm PushSecrets added in 1f7b46d1 (#1614) have never reconciled.
`PushSecret.spec.deletionPolicy` accepts only `Delete` and `None`, so Flux has
failed the whole `litellm` Kustomization on a dry-run error ever since:

```
PushSecret/ai/opencode-litellm-key dry-run failed (Invalid):
spec.deletionPolicy: Unsupported value: "Retain": supported values: "Delete", "None"
```

## The mix-up

`Retain` is ExternalSecret vocabulary. The two fields share a name and are
otherwise unrelated:

| field | accepts | governs |
| --- | --- | --- |
| `ExternalSecret.target.deletionPolicy` | `Delete` / `Merge` / `Retain` (default `Retain`) | the Kubernetes Secret |
| `PushSecret.deletionPolicy` | `Delete` / `None` (default `None`) | the copy in the provider, here 1Password |

`None` is the value that means "leave the 1Password item alone", which is the
intent `Retain` was reaching for. The repo's many
`ExternalSecret … target.deletionPolicy: Retain` entries are correct and
untouched; these two PushSecrets are the only ones of their kind in the repo.

## Blast radius

Wider than the PushSecrets themselves — the failed dry-run also blocked
everything downstream:

- `litellm-chatgpt-login` and `litellm-chatgpt-models` both report
  `dependency 'ai/litellm' is not ready`
- the `opencode` and `pi` `LiteLLMVirtualKey`s and both PushSecrets show as
  *created* rather than *configured* in a dry-run, i.e. they never reached the
  cluster at all

## Validation

- `just test` — 193 ✓ (the two `substituteFrom` warnings are pre-existing)
- server-side dry-run of the **entire** `litellm/proxy` tree, not just the
  edited file: Flux stops at the first invalid object, so this confirms nothing
  else was queued behind the error. Everything now validates.

Independent of #1634 and mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
