### PR TITLE
feat(ai): raise gemma-4-12b-qat to its native 262144 context

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/models/llmkube.yaml
@@ -107,8 +107,8 @@ spec:
     apiBase: http://gemma-4-12b-qat.ai.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
   info:
-    # ../../../llmkube/models/gemma-4-12b-qat.yaml contextSize, well under the
-    # model's native 262144 — raise both together, and re-check the B50's VRAM.
-    maxInputTokens: 65536
+    # ../../../llmkube/models/gemma-4-12b-qat.yaml contextSize, now the model's
+    # native maximum — raise both together, and re-check the B50's VRAM.
+    maxInputTokens: 262144
     supportsVision: true
     supportsFunctionCalling: true

--- a/kubernetes/apps/ai/llmkube/models/gemma-4-12b-qat.yaml
+++ b/kubernetes/apps/ai/llmkube/models/gemma-4-12b-qat.yaml
@@ -68,13 +68,15 @@ spec:
   # runs on talos0's B50, which DRA places it on.
 
   # --- typed preset fields ---
-  # 65536 of the model's native 262144. Gemma 4 12B's 8 global-attention layers
-  # use head_dim 512, costing ~64 KiB/token at q8_0; the 40 sliding layers are
-  # capped by the 1024-token window. That puts the cache near 4.4 GiB, which on
-  # top of 6.7 GiB of weights (model + mmproj + drafter) leaves the 16 GiB card
-  # headroom for a concurrent Jellyfin transcode. Raising this trades that
-  # headroom roughly 1:1.
-  contextSize: 65536
+  # The model's native maximum. Cheap here because only the 8 global-attention
+  # layers scale with context, and they carry ONE kv head each (the GGUF's
+  # head_count_kv is a per-layer array — config.json's num_key_value_heads: 8
+  # describes the 40 sliding layers, which the 1024-token window caps anyway).
+  # That is ~8.5 KiB/token at q8_0, so the cache is ~2.1 GiB here against 6.7
+  # GiB of weights (model + mmproj + drafter). Measured 8.85 GiB total at 65536
+  # before this bump, so expect ~10.5 of the card's 16 GiB, leaving room for a
+  # concurrent Jellyfin transcode.
+  contextSize: 262144
   cacheTypeK: q8_0
   cacheTypeV: q8_0
   # Load-bearing for the two lines above: quantized KV needs flash attention,


### PR DESCRIPTION
Raises `gemma-4-12b-qat` from 65536 to the model's native 262144, now that
there is a measurement to size it against rather than an estimate.

## The estimate that set 65536 was wrong by ~6x

It came from `config.json`'s `num_key_value_heads: 8` applied to the global
layers' `head_dim: 512`. The GGUF tells a different story —
`gemma4.attention.head_count_kv` is a **per-layer array**:

```
gemma4.attention.head_count_kv     = [8, 8, 8, 8, 8, 1, 8, 8, ...]
gemma4.attention.key_length        = 512   # global layers
gemma4.attention.key_length_swa    = 256   # sliding layers
gemma4.attention.sliding_window    = 1024
```

The `1` sits at index 5, which `config.json`'s `layer_types` confirms is a
`full_attention` layer. So the 8 global layers — the only ones that scale with
context — carry **one** kv head each; the `8` describes the 40 sliding layers,
which their 1024-token window caps regardless. This is the model card's
"global layers feature unified Keys and Values". llama.cpp goes further and
shares KV between layer pairs on this architecture:

```
llama_kv_cache: layer 3: sharing with layer 47
llama_kv_cache: layer 0: sharing with layer 46
```

## Measured on the B50 at 65536

```
resident VRAM: 8.85 GiB of 16
```

Roughly 6.7 GiB of that is weights (model + mmproj + MTP drafter), leaving
~2.2 GiB for cache **and** compute buffers combined — against the ~4.4 GiB I
had claimed for cache alone. Since compute buffers don't scale with context,
only the ~0.7 GiB cache portion grows.

At ~8.5 KiB/token, 262144 adds about 1.6 GiB:

| | 65536 (measured) | 262144 (expected) |
| --- | --- | --- |
| weights + mmproj + drafter | 6.7 GiB | 6.7 GiB |
| KV cache | ~0.7 GiB | ~2.1 GiB |
| compute buffers | ~1.5 GiB | ~1.5 GiB |
| **total** | **8.85 GiB** | **~10.5 GiB** |
| free of 16 GiB | 7.2 GiB | ~5.5 GiB |

A QSV transcode wants well under 1 GiB of that, so Jellyfin keeps its
headroom.

## The assumption worth checking

That `kv_unified: true` means the cache totals `n_ctx`, not `n_ctx × n_slots`.
The startup log reported `n_slots = 4, n_ctx_slot = 65536` at
`contextSize: 65536`, so slot count and cache size are decoupled — were it
per-slot, the cache alone would have been ~2.1 GiB and consumed the entire
non-weight remainder, leaving nothing for compute buffers. That is
self-inconsistent, so unified-total is the reading that fits the measurement.

If it is wrong, the failure mode is an allocation failure at startup and a
crashloop — not data loss — and this is a one-line revert.

## Also

`litellm`'s `maxInputTokens` moves in lockstep, as the comment on that entry
requires.

`just test` — 193 ✓ (the two `substituteFrom` warnings are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
