### PR TITLE
feat(ai): add litellm virtual key for home assistant

### DIFF
--- a/kubernetes/apps/ai/litellm/proxy/pushsecret.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/pushsecret.yaml
@@ -46,3 +46,28 @@ spec:
         kind: PushSecretMetadata
         spec:
           fieldType: concealed
+---
+# Home Assistant runs outside the cluster (homeassistant.lan), so the key is
+# delivered by hand out of 1Password rather than reflected into a namespace.
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: home-assistant-litellm-key
+spec:
+  deletionPolicy: None
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: onepassword
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: home-assistant-litellm-key
+  data:
+    - match:
+        remoteRef:
+          remoteKey: k8s-ai-home-assistant-litellm-key
+      metadata:
+        apiVersion: kubernetes.external-secrets.io/v1alpha1
+        kind: PushSecretMetadata
+        spec:
+          fieldType: concealed

--- a/kubernetes/apps/ai/litellm/proxy/virtualkey.yaml
+++ b/kubernetes/apps/ai/litellm/proxy/virtualkey.yaml
@@ -36,3 +36,18 @@ spec:
   secretKey: OPENAI_API_KEY
   models:
     - "llmkube/*"
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: home-assistant
+spec:
+  proxyRef: litellm
+  keyAlias: home-assistant
+  secretName: home-assistant-litellm-key
+  secretKey: OPENAI_API_KEY
+  # The client-facing modelName from ./models/llmkube.yaml, not params.model —
+  # a name that matches nothing does not fail open, it leaves the key able to
+  # call nothing.
+  models:
+    - llmkube/google/gemma-4-12B-it-qat


### PR DESCRIPTION
Scoped to gemma-4-12b-qat only, using the client-facing modelName from models/llmkube.yaml. Home Assistant runs outside the cluster on homeassistant.lan, so delivery is via PushSecret to 1Password (k8s-ai-home-assistant-litellm-key) rather than reflector, matching the opencode/pi pattern.