### PR TITLE
feat(nvr): deploy Frigate NVR against the Protect cameras

### DIFF
--- a/kubernetes/apps/nvr/frigate/app/configmap.yaml
+++ b/kubernetes/apps/nvr/frigate/app/configmap.yaml
@@ -38,9 +38,11 @@ data:
     proxy:
       header_map:
         role: x-forwarded-groups
-      role_map:
-        admin:
-          - frigate-admins
+        # Nested under header_map, not alongside it -- docs.frigate.video shows
+        # the dev layout, where it sits at the proxy level.
+        role_map:
+          admin:
+            - frigate-admins
       # Anything without the header -- i.e. the ungated /api route, which
       # strips it -- is read-only.
       default_role: viewer

--- a/kubernetes/apps/nvr/frigate/app/configmap.yaml
+++ b/kubernetes/apps/nvr/frigate/app/configmap.yaml
@@ -37,7 +37,10 @@ data:
       default_role: viewer
 
     ffmpeg:
-      hwaccel_args: preset-intel-qsv-h264 # Arc; fall back to preset-vaapi if ffmpeg errors
+      # vaapi, not intel-qsv: on the B50 (Battlemage) libva loads iHD fine but
+      # QSV device creation fails with EEXIST -- "Error setting child device
+      # handle: -17". vaapi drives the same renderD128 without that layer.
+      hwaccel_args: preset-vaapi
 
     detect:
       enabled: true

--- a/kubernetes/apps/nvr/frigate/app/configmap.yaml
+++ b/kubernetes/apps/nvr/frigate/app/configmap.yaml
@@ -1,0 +1,347 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frigate-config
+data:
+  config.yml: |
+    ---
+    mqtt:
+      enabled: false # no broker in-cluster; the HA integration works over the API
+
+    detectors:
+      ov:
+        type: openvino
+        device: GPU # the B50, claimed via DRA
+
+    # Bundled with the image, so nothing is downloaded at runtime.
+    model:
+      path: /openvino-model/ssdlite_mobilenet_v2.xml
+      labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+      width: 300
+      height: 300
+      input_tensor: nhwc
+      input_pixel_format: bgr
+
+    # Envoy's OIDC SecurityPolicy is the gate. default_role bounds the
+    # ungated /api route -- anonymous callers get read-only.
+    auth:
+      enabled: false
+    # 8971 ships a self-signed cert by default; without this the gateway would
+    # need a BackendTLSPolicy to trust it. Envoy already terminates TLS.
+    tls:
+      enabled: false
+    proxy:
+      header_map:
+        user: x-forwarded-email
+      default_role: viewer
+
+    ffmpeg:
+      hwaccel_args: preset-intel-qsv-h264 # Arc; fall back to preset-vaapi if ffmpeg errors
+
+    detect:
+      enabled: true
+      fps: 5
+      # width/height omitted on purpose: Frigate probes them off the stream,
+      # and the three vendor families have three different sub resolutions.
+
+    objects:
+      track:
+        - person
+
+    snapshots:
+      enabled: true
+
+    # Protect still owns recording. To move it here: uncomment the retention
+    # below, the record input on each camera, and swap the `media` volume in
+    # helmrelease.yaml from emptyDir to NFS.
+    record:
+      enabled: false
+      # continuous:
+      #   days: 0
+      # alerts:
+      #   retain:
+      #     days: 30
+      # detections:
+      #   retain:
+      #     days: 30
+
+    go2rtc:
+      streams:
+        basement1:
+          - rtsp://{FRIGATE_BASEMENT1_USER}:{FRIGATE_BASEMENT1_PASSWORD}@basement1.lan:554/cam/realmonitor?channel=1&subtype=0
+        basement1_sub:
+          - rtsp://{FRIGATE_BASEMENT1_USER}:{FRIGATE_BASEMENT1_PASSWORD}@basement1.lan:554/cam/realmonitor?channel=1&subtype=1
+        basement2:
+          - rtsp://{FRIGATE_BASEMENT2_USER}:{FRIGATE_BASEMENT2_PASSWORD}@basement2.lan:554/cam/realmonitor?channel=1&subtype=0
+        basement2_sub:
+          - rtsp://{FRIGATE_BASEMENT2_USER}:{FRIGATE_BASEMENT2_PASSWORD}@basement2.lan:554/cam/realmonitor?channel=1&subtype=1
+        basement3:
+          - rtsp://{FRIGATE_BASEMENT3_USER}:{FRIGATE_BASEMENT3_PASSWORD}@basement3.lan:554/cam/realmonitor?channel=1&subtype=0
+        basement3_sub:
+          - rtsp://{FRIGATE_BASEMENT3_USER}:{FRIGATE_BASEMENT3_PASSWORD}@basement3.lan:554/cam/realmonitor?channel=1&subtype=1
+        basement4:
+          - rtsp://{FRIGATE_BASEMENT4_USER}:{FRIGATE_BASEMENT4_PASSWORD}@basement4.lan:554/cam/realmonitor?channel=1&subtype=0
+        basement4_sub:
+          - rtsp://{FRIGATE_BASEMENT4_USER}:{FRIGATE_BASEMENT4_PASSWORD}@basement4.lan:554/cam/realmonitor?channel=1&subtype=1
+        basement5:
+          - rtsp://{FRIGATE_BASEMENT5_USER}:{FRIGATE_BASEMENT5_PASSWORD}@basement5.lan:554/ch0
+        basement5_sub:
+          - rtsp://{FRIGATE_BASEMENT5_USER}:{FRIGATE_BASEMENT5_PASSWORD}@basement5.lan:554/ch1
+        basement6:
+          - rtsp://{FRIGATE_BASEMENT6_USER}:{FRIGATE_BASEMENT6_PASSWORD}@basement6.lan:554/ch0
+        basement6_sub:
+          - rtsp://{FRIGATE_BASEMENT6_USER}:{FRIGATE_BASEMENT6_PASSWORD}@basement6.lan:554/ch1
+        kitchen1:
+          - rtsp://{FRIGATE_KITCHEN1_USER}:{FRIGATE_KITCHEN1_PASSWORD}@kitchen1.lan:554/ch0
+        kitchen1_sub:
+          - rtsp://{FRIGATE_KITCHEN1_USER}:{FRIGATE_KITCHEN1_PASSWORD}@kitchen1.lan:554/ch1
+        kitchen2:
+          - rtsp://{FRIGATE_KITCHEN2_USER}:{FRIGATE_KITCHEN2_PASSWORD}@kitchen2.lan:554/ch0
+        kitchen2_sub:
+          - rtsp://{FRIGATE_KITCHEN2_USER}:{FRIGATE_KITCHEN2_PASSWORD}@kitchen2.lan:554/ch1
+        living2:
+          - rtsp://{FRIGATE_LIVING2_USER}:{FRIGATE_LIVING2_PASSWORD}@living2.lan:554/ch0
+        living2_sub:
+          - rtsp://{FRIGATE_LIVING2_USER}:{FRIGATE_LIVING2_PASSWORD}@living2.lan:554/ch1
+        living3:
+          - rtsp://{FRIGATE_LIVING3_USER}:{FRIGATE_LIVING3_PASSWORD}@living3.lan:554/ch0
+        living3_sub:
+          - rtsp://{FRIGATE_LIVING3_USER}:{FRIGATE_LIVING3_PASSWORD}@living3.lan:554/ch1
+        entryway:
+          - rtsp://{FRIGATE_ENTRYWAY_USER}:{FRIGATE_ENTRYWAY_PASSWORD}@entryway.lan:554/ch0
+        entryway_sub:
+          - rtsp://{FRIGATE_ENTRYWAY_USER}:{FRIGATE_ENTRYWAY_PASSWORD}@entryway.lan:554/ch1
+        laundry:
+          - rtsp://{FRIGATE_LAUNDRY_USER}:{FRIGATE_LAUNDRY_PASSWORD}@laundry.lan:554/ch0
+        laundry_sub:
+          - rtsp://{FRIGATE_LAUNDRY_USER}:{FRIGATE_LAUNDRY_PASSWORD}@laundry.lan:554/ch1
+        3dprintercam:
+          - rtsp://{FRIGATE_3DPRINTERCAM_USER}:{FRIGATE_3DPRINTERCAM_PASSWORD}@3dprintercam.lan:554/ch0
+        3dprintercam_sub:
+          - rtsp://{FRIGATE_3DPRINTERCAM_USER}:{FRIGATE_3DPRINTERCAM_PASSWORD}@3dprintercam.lan:554/ch1
+        window-south:
+          - rtsp://{FRIGATE_WINDOW_SOUTH_USER}:{FRIGATE_WINDOW_SOUTH_PASSWORD}@window-south.lan:554/ch0
+        window-south_sub:
+          - rtsp://{FRIGATE_WINDOW_SOUTH_USER}:{FRIGATE_WINDOW_SOUTH_PASSWORD}@window-south.lan:554/ch1
+        office-couch:
+          - rtsp://{FRIGATE_OFFICE_COUCH_USER}:{FRIGATE_OFFICE_COUCH_PASSWORD}@office-couch.lan:554/ch0
+        office-couch_sub:
+          - rtsp://{FRIGATE_OFFICE_COUCH_USER}:{FRIGATE_OFFICE_COUCH_PASSWORD}@office-couch.lan:554/ch1
+        # http-flv, not RTSP: Frigate documents it as the reliable path for
+        # Reolink at 5MP and under, and this doorbell is 2560x1920.
+        doorbell:
+          - ffmpeg:http://doorbell.lan/flv?port=1935&app=bcs&stream=channel0_main.bcs&user={FRIGATE_DOORBELL_USER}&password={FRIGATE_DOORBELL_PASSWORD}#video=copy#audio=copy#audio=opus
+        doorbell_sub:
+          - ffmpeg:http://doorbell.lan/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user={FRIGATE_DOORBELL_USER}&password={FRIGATE_DOORBELL_PASSWORD}#video=copy#audio=copy#audio=opus
+
+    cameras:
+      basement1:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/basement1_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/basement1
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: basement1
+            Sub: basement1_sub
+      basement2:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/basement2_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/basement2
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: basement2
+            Sub: basement2_sub
+      basement3:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/basement3_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/basement3
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: basement3
+            Sub: basement3_sub
+      basement4:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/basement4_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/basement4
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: basement4
+            Sub: basement4_sub
+      basement5:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/basement5_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/basement5
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: basement5
+            Sub: basement5_sub
+      basement6:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/basement6_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/basement6
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: basement6
+            Sub: basement6_sub
+      kitchen1:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/kitchen1_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/kitchen1
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: kitchen1
+            Sub: kitchen1_sub
+      kitchen2:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/kitchen2_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/kitchen2
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: kitchen2
+            Sub: kitchen2_sub
+      living2:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/living2_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/living2
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: living2
+            Sub: living2_sub
+      living3:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/living3_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/living3
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: living3
+            Sub: living3_sub
+      entryway:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/entryway_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/entryway
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: entryway
+            Sub: entryway_sub
+      laundry:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/laundry_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/laundry
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: laundry
+            Sub: laundry_sub
+      3dprintercam:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/3dprintercam_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/3dprintercam
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: 3dprintercam
+            Sub: 3dprintercam_sub
+      window-south:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/window-south_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/window-south
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: window-south
+            Sub: window-south_sub
+      office-couch:
+        enabled: false # DISCONNECTED in Protect, no DHCP lease
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/office-couch_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/office-couch
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: office-couch
+            Sub: office-couch_sub
+      doorbell:
+        ffmpeg:
+          inputs:
+            - path: rtsp://127.0.0.1:8554/doorbell_sub
+              input_args: preset-rtsp-restream
+              roles: [detect]
+            # - path: rtsp://127.0.0.1:8554/doorbell
+            #   input_args: preset-rtsp-restream
+            #   roles: [record]
+        live:
+          streams:
+            Main: doorbell
+            Sub: doorbell_sub

--- a/kubernetes/apps/nvr/frigate/app/configmap.yaml
+++ b/kubernetes/apps/nvr/frigate/app/configmap.yaml
@@ -31,9 +31,18 @@ data:
     # need a BackendTLSPolicy to trust it. Envoy already terminates TLS.
     tls:
       enabled: false
+    # The role arrives from the HTTPRoute filter on the OIDC-gated route, not
+    # from pocket-id: envoy gateway 1.9.1 can't map a claim into a header. No
+    # user mapping for the same reason -- nothing forwards an identity, so
+    # frigate shows everyone as anonymous.
     proxy:
       header_map:
-        user: x-forwarded-email
+        role: x-forwarded-groups
+      role_map:
+        admin:
+          - frigate-admins
+      # Anything without the header -- i.e. the ungated /api route, which
+      # strips it -- is read-only.
       default_role: viewer
 
     ffmpeg:

--- a/kubernetes/apps/nvr/frigate/app/configmap.yaml
+++ b/kubernetes/apps/nvr/frigate/app/configmap.yaml
@@ -131,12 +131,13 @@ data:
           - rtsp://{FRIGATE_OFFICE_COUCH_USER}:{FRIGATE_OFFICE_COUCH_PASSWORD}@office-couch.lan:554/ch0
         office-couch_sub:
           - rtsp://{FRIGATE_OFFICE_COUCH_USER}:{FRIGATE_OFFICE_COUCH_PASSWORD}@office-couch.lan:554/ch1
-        # http-flv, not RTSP: Frigate documents it as the reliable path for
-        # Reolink at 5MP and under, and this doorbell is 2560x1920.
+        # RTSP, despite frigate documenting http-flv as the reliable path for
+        # Reolink at 5MP and under: the bcs endpoint 4xx's on this doorbell,
+        # while these two probe clean at 2560x1920 and 640x480.
         doorbell:
-          - ffmpeg:http://doorbell.lan/flv?port=1935&app=bcs&stream=channel0_main.bcs&user={FRIGATE_DOORBELL_USER}&password={FRIGATE_DOORBELL_PASSWORD}#video=copy#audio=copy#audio=opus
+          - rtsp://{FRIGATE_DOORBELL_USER}:{FRIGATE_DOORBELL_PASSWORD}@doorbell.lan:554/h264Preview_01_main
         doorbell_sub:
-          - ffmpeg:http://doorbell.lan/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user={FRIGATE_DOORBELL_USER}&password={FRIGATE_DOORBELL_PASSWORD}#video=copy#audio=copy#audio=opus
+          - rtsp://{FRIGATE_DOORBELL_USER}:{FRIGATE_DOORBELL_PASSWORD}@doorbell.lan:554/h264Preview_01_sub
 
     cameras:
       basement1:

--- a/kubernetes/apps/nvr/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/nvr/frigate/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: frigate-secret
+spec:
+  refreshInterval: 1h
+  refreshPolicy: Periodic
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: frigate-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      mergePolicy: Replace
+  # The 1Password fields are named for the env vars config.yml interpolates, so
+  # every key passes straight through to envFrom with no mapping.
+  dataFrom:
+    - extract:
+        key: k8s-nvr-frigate-secret

--- a/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
@@ -74,7 +74,17 @@ spec:
           - name: envoy-internal
             namespace: network
         rules:
-          - backendRefs:
+            # Reaching this route means pocket-id already authenticated the
+            # request, so grant the role frigate maps to admin. `set`, not
+            # `add`, so a client-supplied value is overwritten rather than
+            # appended.
+          - filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  set:
+                    - name: &rolehdr x-forwarded-groups
+                      value: &adminrole frigate-admins
+            backendRefs:
               - identifier: *app
                 port: *port
       api:
@@ -86,7 +96,15 @@ spec:
           - name: envoy-internal
             namespace: network
         rules:
-          - matches:
+            # Load-bearing: frigate trusts this header unconditionally, so
+            # without stripping it anyone who can reach envoy-internal could
+            # send it themselves and get admin on the ungated route.
+          - filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - *rolehdr
+            matches:
               - path: { type: PathPrefix, value: /api }
               - path: { type: PathPrefix, value: /ws }
             backendRefs:

--- a/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
@@ -1,0 +1,126 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app frigate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          resourceClaims:
+            - name: gpu
+              resourceClaimTemplateName: *app
+          securityContext:
+            # Frigate's s6 init and nginx expect uid 0. Moving to a dedicated
+            # uid additionally needs S6_CATCHALL_USER, a world-writable /run and
+            # a writable HOME -- deferred until this is proven.
+            runAsNonRoot: false
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/blakeblackshear/frigate
+              tag: 0.17.2
+            env:
+              TZ: America/Detroit
+            # Every key is already named for the {FRIGATE_*} placeholder it
+            # fills in config.yml, so no per-camera mapping is needed.
+            envFrom:
+              - secretRef:
+                  name: frigate-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: "2"
+                memory: 2Gi
+              limits:
+                memory: 6Gi
+              claims:
+                - name: gpu
+    service:
+      *app :
+        ports:
+          http:
+            # 8971, never 5000: on 5000 roles aren't enforced and every request
+            # is treated as admin.
+            port: &port 8971
+    route:
+      *app :
+        hostnames:
+          - &host "frigate.${DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+      api:
+        # Unprotected by the OIDC SecurityPolicy so Home Assistant and the
+        # mobile app can reach the API without a browser login.
+        hostnames:
+          - *host
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - matches:
+              - path: { type: PathPrefix, value: /api }
+              - path: { type: PathPrefix, value: /ws }
+            backendRefs:
+              - identifier: *app
+                port: *port
+    persistence:
+      config:
+        existingClaim: *app
+        globalMounts:
+          - path: /config
+      config-file:
+        type: configMap
+        name: frigate-config
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
+      # Snapshots land here. Bounded emptyDir until recording moves to NFS,
+      # so a runaway can't fill the node's ephemeral storage.
+      media:
+        type: emptyDir
+        sizeLimit: 2Gi
+        globalMounts:
+          - path: /media/frigate
+      # Recording target. Uncomment together with the record blocks in
+      # configmap.yaml, and drop the emptyDir above.
+      # media:
+      #   type: nfs
+      #   server: storage.lan
+      #   path: /mnt/hot
+      #   globalMounts:
+      #     - path: /media/frigate
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp/cache
+      # ~3.4 MB per camera at 640x360; 512Mi covers all 16 with room over.
+      dshm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 512Mi
+        globalMounts:
+          - path: /dev/shm

--- a/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
@@ -19,10 +19,16 @@ spec:
             - name: gpu
               resourceClaimTemplateName: *app
           securityContext:
-            # Frigate's s6 init and nginx expect uid 0. Moving to a dedicated
-            # uid additionally needs S6_CATCHALL_USER, a world-writable /run and
-            # a writable HOME -- deferred until this is proven.
+            # uid 0 is what the image is built for: s6-applyuidgid calls
+            # setgroups(), so every s6-log crash-loops under any other uid
+            # unless that binary is shimmed. Running root here is deliberate --
+            # the kopiur mover is the thing kept unprivileged, via KOPIUR_UID.
             runAsNonRoot: false
+            # Not for frigate, which is root and ignores it, but for the mover:
+            # it runs as 65534 and can only back up /config if the files frigate
+            # writes carry a group it shares.
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           *app :
             image:

--- a/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/nvr/frigate/app/helmrelease.yaml
@@ -88,10 +88,13 @@ spec:
               - identifier: *app
                 port: *port
       api:
-        # Unprotected by the OIDC SecurityPolicy so Home Assistant and the
-        # mobile app can reach the API without a browser login.
+        # Its own hostname, not a /api path on the main one: routing is
+        # stateless, so a path split would send the UI's own /api calls down
+        # the ungated route and leave a logged-in browser stuck as viewer.
+        # Single-label, because the gateway cert is *.${DOMAIN} and a wildcard
+        # only matches one label.
         hostnames:
-          - *host
+          - "frigate-api.${DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -104,9 +107,6 @@ spec:
                 requestHeaderModifier:
                   remove:
                     - *rolehdr
-            matches:
-              - path: { type: PathPrefix, value: /api }
-              - path: { type: PathPrefix, value: /ws }
             backendRefs:
               - identifier: *app
                 port: *port

--- a/kubernetes/apps/nvr/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/nvr/frigate/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./resourceclaimtemplate.yaml
+  - ./usergroup.yaml

--- a/kubernetes/apps/nvr/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/nvr/frigate/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./resourceclaimtemplate.yaml

--- a/kubernetes/apps/nvr/frigate/app/ocirepository.yaml
+++ b/kubernetes/apps/nvr/frigate/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: frigate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/nvr/frigate/app/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/nvr/frigate/app/resourceclaimtemplate.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: frigate
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            # Shared, not reserving: a reserving claim would lock jellyfin and
+            # llmkube off the single B50.
+            adminAccess: true

--- a/kubernetes/apps/nvr/frigate/app/usergroup.yaml
+++ b/kubernetes/apps/nvr/frigate/app/usergroup.yaml
@@ -1,0 +1,21 @@
+---
+# Without a group naming this client, `allowedUserGroups` is empty and Pocket ID
+# lets any user log in. This is the access boundary.
+#
+# One group, not the usual users/admins pair: envoy gateway 1.9.1 has no
+# claimToHeaders, so it can't map a pocket-id claim into a header frigate's
+# header_map can read. The role instead comes from an HTTPRoute filter on the
+# OIDC-gated route, which can't tell one logged-in user from another -- so
+# everyone who can log in is an admin, and the name says so.
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDUserGroup
+metadata:
+  name: frigate-admins
+spec:
+  friendlyName: Frigate Admins
+  allowedOIDCClients:
+    - name: frigate
+  users:
+    userRefs:
+      - name: david
+        namespace: security

--- a/kubernetes/apps/nvr/frigate/ks.yaml
+++ b/kubernetes/apps/nvr/frigate/ks.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app frigate
+spec:
+  dependsOn:
+    - name: external-secrets-config
+      namespace: external-secrets
+    - name: pocket-id
+      namespace: security
+    - name: kopiur-repository
+      namespace: kopiur-system
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+  components:
+    - ../../../../components/oidc/envoy
+    - ../../../../components/kopiur
+  interval: 1h
+  path: ./kubernetes/apps/nvr/frigate/app
+  postBuild:
+    substitute:
+      APP: *app
+      APP_ICON_URL: "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/frigate.svg"
+      OIDC_APP_NAME: Frigate
+      # config.yml is a read-only mount, but frigate.db and model_cache/ share
+      # the volume and are what actually grow.
+      KOPIUR_CAPACITY: 10Gi
+      KOPIUR_UID: "0"
+      KOPIUR_GID: "0"
+    substituteFrom:
+      - name: cluster-global-config
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: nvr
+  wait: false

--- a/kubernetes/apps/nvr/frigate/ks.yaml
+++ b/kubernetes/apps/nvr/frigate/ks.yaml
@@ -26,8 +26,8 @@ spec:
       # config.yml is a read-only mount, but frigate.db and model_cache/ share
       # the volume and are what actually grow.
       KOPIUR_CAPACITY: 10Gi
-      KOPIUR_UID: "0"
-      KOPIUR_GID: "0"
+      KOPIUR_UID: "65534"
+      KOPIUR_GID: "65534"
     substituteFrom:
       - name: cluster-global-config
         kind: ConfigMap

--- a/kubernetes/apps/nvr/kustomization.yaml
+++ b/kubernetes/apps/nvr/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvr
+components:
+  - ../../components/cluster-global-config
+resources:
+  - ./namespace.yaml
+  - ./frigate/ks.yaml

--- a/kubernetes/apps/nvr/namespace.yaml
+++ b/kubernetes/apps/nvr/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvr
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    # Frigate's s6 init runs as uid 0; the commented-out recording volume is an
+    # inline NFS mount. Baseline PSA rejects both.
+    pod-security.kubernetes.io/enforce: privileged
+    # Required for ResourceClaims that set adminAccess: true.
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/nvr/namespace.yaml
+++ b/kubernetes/apps/nvr/namespace.yaml
@@ -6,8 +6,9 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
-    # Frigate's s6 init runs as uid 0; the commented-out recording volume is an
-    # inline NFS mount. Baseline PSA rejects both.
-    pod-security.kubernetes.io/enforce: privileged
+    # Baseline, not restricted: frigate runs as uid 0, and the commented-out
+    # recording volume is an inline NFS mount -- restricted rejects both.
+    # Baseline itself is fine with root, so privileged isn't needed.
+    pod-security.kubernetes.io/enforce: baseline
     # Required for ResourceClaims that set adminAccess: true.
     resource.kubernetes.io/admin-access: "true"


### PR DESCRIPTION
Adds Frigate as a second consumer of the 16 cameras adopted into UniFi Protect, in a new `nvr` namespace. Object detection runs on the Arc Pro B50; recording stays with Protect.

**Deployed and verified on the branch via `just flux-branch`.** 15 of 16 cameras streaming at 5 fps, OpenVINO detector at ~4 ms inference on the B50. `office-couch` ships `enabled: false` — it's DISCONNECTED in Protect with no DHCP lease.

## Why this shape

**Streams come straight from the cameras, not through Protect.** Every Protect channel has `is_rtsp_enabled: false`, so routing through Protect would have meant enabling RTSP on 32 channels and making the NVR a hard dependency. Pulling direct from `<name>.lan:554` on VLAN 32 avoids both and gives native sub-streams for detect. Cluster-to-camera routing across VLAN 32 → 42 was the main open risk and it works.

**The GPU comes from the same DRA path jellyfin and llmkube use** — a `ResourceClaimTemplate` with `adminAccess: true`, which keeps the single B50 shareable rather than reserved. No node selector; DRA places the pod on talos0 as the only node advertising `gpu.intel.com`.

**Recording is off but pre-wired.** The `record:` retention block, per-camera record inputs, and the `/mnt/hot` NFS mount are all present and commented, so enabling it later is uncommenting rather than designing.

## Three things live testing settled against the docs

**VAAPI, not QSV.** Frigate recommends `preset-intel-qsv-*` for Arc, but on Battlemage libva loads iHD fine and then QSV child-device creation fails with `EEXIST` (`Error setting child device handle: -17`), crash-looping every decoder. `preset-vaapi` drives the same `renderD128` without that layer.

**RTSP, not http-flv, for the Reolink doorbell.** Frigate documents http-flv as the reliable path for Reolink at 5MP and under; the `bcs` endpoint returns 4xx on this device. `/h264Preview_01_main` and `_sub` probe clean at 2560x1920 and 640x480.

**`role_map` nests under `header_map`.** `docs.frigate.video` tracks `dev`, where it sits at the `proxy` level. In 0.17.2 it's a field of `HeaderMappingConfig`, and getting that wrong fails config validation and crash-loops the pod.

## Auth

Envoy Gateway 1.9.1 has no `claimToHeaders`, so it forwards no OIDC claim as a header — meaning Frigate can't derive identity from the proxy. Two consequences:

- **Access** is enforced by Pocket ID. The `frigate-admins` `PocketIDUserGroup` is the boundary; without it `allowedUserGroups` is empty and any Pocket ID user can log in. The `components/oidc` component only creates the client, never a group — 14 of the 17 apps using it add their own.
- **Role** comes from an HTTPRoute filter, split across two hostnames. `frigate.${DOMAIN}` is OIDC-gated and `set`s `x-forwarded-groups`, which `role_map` turns into admin. `frigate-api.${DOMAIN}` is ungated and **removes** the header — load-bearing, since Frigate trusts it unconditionally and anyone reaching `envoy-internal` could otherwise send it themselves.

Splitting by hostname rather than by path matters: routing is stateless, and the Frigate UI is itself an `/api` client. A `PathPrefix: /api` route would win over the main route for the browser's own calls and leave an authenticated session stuck as viewer. The name is `frigate-api`, not `api.frigate`, because the gateway cert is `*.${DOMAIN}` and a wildcard matches exactly one label.

Verified through the gateway: `frigate.${DOMAIN}` gives `"role":"admin"`, `frigate-api.${DOMAIN}` gives `"role":"viewer"`.

This makes the role binary — whoever can log in is admin, and the ungated hostname is viewer. Per-user roles would need `claimToHeaders` or Frigate's native auth, and the latter means logging in twice.

**Home Assistant and the mobile app point at `frigate-api.${DOMAIN}`.**

**Routes target 8971, never 5000.** On 5000 Frigate enforces no roles and treats every request as admin.

## uid 0, with an unprivileged backup mover

Frigate runs as root, which is what its image is built for: `s6-applyuidgid` calls `setgroups()`, so under any other uid every `s6-log` crash-loops unless that binary is shimmed (upstream #18375). Running as 65534 fixes half of it — `log-prepare`'s `chown nobody:nogroup` becomes a no-op — but the `setgroups` call is unconditional, and the shim plus an init container for `/usr/local/nginx` plus three more emptyDirs is a lot of surface for a single-tenant namespace.

kopiur's gate keys on the **mover's** securityContext, not the app's, so `KOPIUR_UID`/`GID` of 65534 keeps the backup mover unprivileged and needs no `privileged-movers` namespace grant — which was the actual objection to uid 0. `fsGroup: 65534` joins the two: Frigate ignores it, but files it writes to `/config` land in a group the mover can read.

The namespace is `baseline` rather than `privileged` — baseline permits root, and only `restricted` would object to the inline NFS mount.

## Prerequisite

`k8s-nvr-frigate-secret` must exist in the `homelab` 1Password vault — 32 fields named for the `{FRIGATE_*}` placeholders `config.yml` interpolates, so the ExternalSecret needs no key mapping. Already created.

Note the ClusterSecretStore caches provider responses for 6h **in the controller**, and `force-sync` does not clear it — rotating a camera password needs `kubectl -n external-secrets rollout restart deploy/external-secrets` to propagate.

## Known limitations

- `config.yml` is a read-only ConfigMap mount, so Frigate's in-UI editor can't save and its config migrations can't run. That's the GitOps tradeoff, but a future major upgrade will need the migration applied in git instead.
- `just test` validates the chart schema, not the Frigate config inside the ConfigMap — config errors surface only at pod start.
- Frigate shows the user as `viewer` in the UI because nothing forwards an identity; cosmetic, and it resolves if Envoy Gateway gains claim mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

